### PR TITLE
Feature/manual withdrawal audit UI

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,3 +18,7 @@ JWT_EXPIRES_IN=7d
 
 # Server
 PORT=3001
+
+# Optional: UUID of the user who may approve/reject withdrawals as platform (JWT subject must match).
+# When unset, any logged-in user may call platform withdrawal APIs (development only).
+# PLATFORM_APPROVER_USER_ID=

--- a/backend/API.md
+++ b/backend/API.md
@@ -99,9 +99,13 @@ Success response (`200`):
 ]
 ```
 
+### `GET /api/withdrawals/capabilities`
+
+Returns whether the authenticated user may perform **platform** signing/rejection (`can_approve_platform`). If `PLATFORM_APPROVER_USER_ID` is set in the backend environment, only that user’s JWT subject matches; otherwise (dev only) any authenticated user may act as platform for API calls.
+
 ### `POST /api/withdrawals/request`
 
-Create a pending withdrawal request (creator only). The backend verifies campaign wallet multisig thresholds/signers before storing the XDR.
+Create a pending withdrawal request (creator only). Verifies multisig on the campaign wallet, ensures the campaign is `active` or `funded`, and rejects if another `pending` withdrawal already exists for the same campaign.
 
 Body:
 
@@ -111,6 +115,14 @@ Body:
 
 Returns `201` with withdrawal request (`creator_signed=false`, `platform_signed=false`, `status=pending`).
 
+Appends an audit row to `withdrawal_approval_events` with action `requested`.
+
+Errors:
+
+- `403` not the campaign creator
+- `409` campaign status not eligible, or duplicate pending withdrawal
+- `422` multisig configuration invalid
+
 ### `POST /api/withdrawals/:id/approve/creator`
 
 Creator approval step. Signs withdrawal XDR using creator custodial key and marks `creator_signed=true`.
@@ -118,7 +130,9 @@ Creator approval step. Signs withdrawal XDR using creator custodial key and mark
 Errors:
 
 - `403` caller is not campaign creator
-- `409` request no longer pending or already creator-approved
+- `409` request no longer pending, campaign status not `active`/`funded`, or already creator-approved
+
+Logs `creator_signed` in `withdrawal_approval_events`.
 
 ### `POST /api/withdrawals/:id/approve/platform`
 
@@ -126,17 +140,32 @@ Platform approval/finalization step. Signs with platform key, validates dual-sig
 
 Errors:
 
-- `409` creator approval missing
+- `403` caller cannot perform platform signature (see `PLATFORM_APPROVER_USER_ID`)
+- `409` creator approval missing, campaign status not eligible, or request not pending
 - `422` insufficient signatures in XDR
+- `502` Stellar rejected the transaction — request is marked `failed` and `submit_failed` is logged
 
 Success:
 
 - marks request as `status=submitted`
 - stores Stellar `tx_hash`
+- logs `platform_signed` in `withdrawal_approval_events`
+
+### `POST /api/withdrawals/:id/cancel`
+
+Creator-only. Cancels a **pending** request **before** creator signature (`creator_signed=false`). Sets `status=denied` and stores optional `reason` in `denial_reason`. Logs `creator_cancelled`.
+
+### `POST /api/withdrawals/:id/reject`
+
+Platform-only (same rules as platform approve). Rejects a **pending** request **after** creator has signed and **before** platform signature. Sets `status=denied`. Body optional: `{ "reason": "..." }`. Logs `platform_rejected`.
 
 ### `GET /api/withdrawals/campaign/:campaignId`
 
-List withdrawal requests and signature statuses for a campaign.
+List withdrawal requests for a campaign (`denial_reason` included when denied). **Authorized for campaign creator or configured platform approver only** (others receive `403`).
+
+### `GET /api/withdrawals/:id/events`
+
+Immutable audit timeline for one withdrawal: `action`, `actor_user_id`, `note`, `metadata`, `created_at`. Same authorization as the campaign list endpoint.
 
 ## Auditability and traceability
 
@@ -148,6 +177,8 @@ List withdrawal requests and signature statuses for a campaign.
   - conversion `path` as JSON
   - immutable Stellar `tx_hash`
 - This enables independent reconciliation against Horizon payment records by `tx_hash`.
+
+- Manual fund releases append rows to `withdrawal_approval_events` (`requested`, `creator_signed`, `platform_signed`, `creator_cancelled`, `platform_rejected`, `submit_failed`) with optional `note` and `metadata` JSON for audit and manual review.
 
 ## Test coverage
 
@@ -162,3 +193,5 @@ List withdrawal requests and signature statuses for a campaign.
 - withdrawal request creation with multisig validation
 - withdrawal creator/platform approval flow
 - withdrawal denial paths (missing creator approval, insufficient signatures)
+- withdrawal campaign status and duplicate-pending guards
+- withdrawal cancel/reject and Stellar submit failure logging

--- a/backend/db/migrations/20260423_withdrawal_approval_audit.sql
+++ b/backend/db/migrations/20260423_withdrawal_approval_audit.sql
@@ -1,0 +1,32 @@
+BEGIN;
+
+ALTER TABLE withdrawal_requests
+  ADD COLUMN IF NOT EXISTS denial_reason TEXT;
+
+ALTER TABLE withdrawal_requests DROP CONSTRAINT IF EXISTS withdrawal_requests_status_check;
+ALTER TABLE withdrawal_requests ADD CONSTRAINT withdrawal_requests_status_check
+  CHECK (status IN ('pending', 'submitted', 'failed', 'denied'));
+
+CREATE TABLE IF NOT EXISTS withdrawal_approval_events (
+  id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  withdrawal_request_id   UUID NOT NULL REFERENCES withdrawal_requests(id) ON DELETE CASCADE,
+  actor_user_id           UUID REFERENCES users(id),
+  action                  TEXT NOT NULL CHECK (action IN (
+                            'requested',
+                            'creator_signed',
+                            'platform_signed',
+                            'creator_cancelled',
+                            'platform_rejected',
+                            'submit_failed'
+                          )),
+  note                    TEXT,
+  metadata                JSONB,
+  created_at              TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS withdrawal_approval_events_wr_idx
+  ON withdrawal_approval_events (withdrawal_request_id);
+CREATE INDEX IF NOT EXISTS withdrawal_approval_events_created_idx
+  ON withdrawal_approval_events (created_at DESC);
+
+COMMIT;

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -54,9 +54,27 @@ CREATE TABLE withdrawal_requests (
   creator_signed      BOOLEAN DEFAULT FALSE,
   platform_signed     BOOLEAN DEFAULT FALSE,
   status              TEXT NOT NULL DEFAULT 'pending'
-                        CHECK (status IN ('pending', 'submitted', 'failed')),
+                        CHECK (status IN ('pending', 'submitted', 'failed', 'denied')),
+  denial_reason       TEXT,
   tx_hash             TEXT,
   created_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE withdrawal_approval_events (
+  id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  withdrawal_request_id   UUID NOT NULL REFERENCES withdrawal_requests(id) ON DELETE CASCADE,
+  actor_user_id           UUID REFERENCES users(id),
+  action                  TEXT NOT NULL CHECK (action IN (
+                            'requested',
+                            'creator_signed',
+                            'platform_signed',
+                            'creator_cancelled',
+                            'platform_rejected',
+                            'submit_failed'
+                          )),
+  note                    TEXT,
+  metadata                JSONB,
+  created_at              TIMESTAMPTZ DEFAULT NOW()
 );
 
 -- Indexes
@@ -64,3 +82,5 @@ CREATE INDEX ON contributions (campaign_id);
 CREATE INDEX ON contributions (tx_hash);
 CREATE INDEX ON campaigns (status);
 CREATE INDEX ON campaigns (creator_id);
+CREATE INDEX ON withdrawal_approval_events (withdrawal_request_id);
+CREATE INDEX ON withdrawal_approval_events (created_at DESC);

--- a/backend/src/routes/withdrawals.js
+++ b/backend/src/routes/withdrawals.js
@@ -10,19 +10,61 @@ const {
   PLATFORM_PUBLIC_KEY,
 } = require('../services/stellarService');
 
+const ALLOWED_CAMPAIGN_STATUS_FOR_REQUEST = ['active', 'funded'];
+
 function hasSigner(signers, publicKey) {
   return signers.some((s) => s.key === publicKey && s.weight >= 1);
 }
 
-// Request a withdrawal (creator only). Stores base transaction XDR.
+/** Dev / open mode: any authenticated user may perform platform signature API calls when unset. */
+function canPerformPlatformSignature(userId) {
+  if (!process.env.PLATFORM_APPROVER_USER_ID) return true;
+  return userId === process.env.PLATFORM_APPROVER_USER_ID;
+}
+
+/** For viewing audit trails: only creator or an explicitly configured platform approver. */
+function isPlatformApproverForAudit(userId) {
+  if (!process.env.PLATFORM_APPROVER_USER_ID) return false;
+  return userId === process.env.PLATFORM_APPROVER_USER_ID;
+}
+
+async function logWithdrawalEvent(client, { withdrawalRequestId, actorUserId, action, note, metadata }) {
+  const runner = client || db;
+  await runner.query(
+    `INSERT INTO withdrawal_approval_events
+       (withdrawal_request_id, actor_user_id, action, note, metadata)
+     VALUES ($1, $2, $3, $4, $5::jsonb)`,
+    [withdrawalRequestId, actorUserId || null, action, note || null, metadata ? JSON.stringify(metadata) : null]
+  );
+}
+
+async function assertWithdrawalAccess(req, campaignId) {
+  const { rows } = await db.query('SELECT creator_id FROM campaigns WHERE id = $1', [campaignId]);
+  if (!rows.length) return { error: 'Campaign not found', status: 404 };
+  const isCreator = rows[0].creator_id === req.user.userId;
+  const isPlatform = isPlatformApproverForAudit(req.user.userId);
+  if (!isCreator && !isPlatform) {
+    return { error: 'Not authorized to view or manage withdrawals for this campaign', status: 403 };
+  }
+  return { creatorId: rows[0].creator_id, isCreator, isPlatform };
+}
+
+router.get('/capabilities', requireAuth, (req, res) => {
+  res.json({ can_approve_platform: canPerformPlatformSignature(req.user.userId) });
+});
+
 router.post('/request', requireAuth, async (req, res) => {
   const { campaign_id, destination_key, amount } = req.body;
   if (!campaign_id || !destination_key || !amount) {
     return res.status(400).json({ error: 'campaign_id, destination_key and amount are required' });
   }
+  if (!Number(amount) || Number(amount) <= 0) {
+    return res.status(400).json({ error: 'amount must be a positive number' });
+  }
 
   const { rows: campaigns } = await db.query(
-    'SELECT id, creator_id, wallet_public_key, asset_type FROM campaigns WHERE id = $1',
+    `SELECT id, creator_id, wallet_public_key, asset_type, status
+     FROM campaigns WHERE id = $1`,
     [campaign_id]
   );
   if (!campaigns.length) return res.status(404).json({ error: 'Campaign not found' });
@@ -30,6 +72,22 @@ router.post('/request', requireAuth, async (req, res) => {
 
   if (campaign.creator_id !== req.user.userId) {
     return res.status(403).json({ error: 'Only campaign creator can request withdrawal' });
+  }
+  if (!ALLOWED_CAMPAIGN_STATUS_FOR_REQUEST.includes(campaign.status)) {
+    return res.status(409).json({
+      error: `Withdrawals cannot be requested while campaign status is "${campaign.status}".`,
+    });
+  }
+
+  const { rows: pending } = await db.query(
+    `SELECT id FROM withdrawal_requests
+     WHERE campaign_id = $1 AND status = 'pending' LIMIT 1`,
+    [campaign_id]
+  );
+  if (pending.length) {
+    return res.status(409).json({
+      error: 'A pending withdrawal already exists for this campaign. Cancel it or wait for completion before opening another.',
+    });
   }
 
   const { rows: creatorRows } = await db.query(
@@ -56,21 +114,37 @@ router.post('/request', requireAuth, async (req, res) => {
     asset: campaign.asset_type,
   });
 
-  const { rows } = await db.query(
-    `INSERT INTO withdrawal_requests
-       (campaign_id, requested_by, amount, destination_key, unsigned_xdr, creator_signed, platform_signed)
-     VALUES ($1, $2, $3, $4, $5, FALSE, FALSE)
-     RETURNING *`,
-    [campaign_id, req.user.userId, amount, destination_key, xdr]
-  );
-
-  res.status(201).json(rows[0]);
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN');
+    const { rows } = await client.query(
+      `INSERT INTO withdrawal_requests
+         (campaign_id, requested_by, amount, destination_key, unsigned_xdr, creator_signed, platform_signed)
+       VALUES ($1, $2, $3, $4, $5, FALSE, FALSE)
+       RETURNING *`,
+      [campaign_id, req.user.userId, amount, destination_key, xdr]
+    );
+    await logWithdrawalEvent(client, {
+      withdrawalRequestId: rows[0].id,
+      actorUserId: req.user.userId,
+      action: 'requested',
+      note: null,
+      metadata: { amount, destination_key, asset_type: campaign.asset_type },
+    });
+    await client.query('COMMIT');
+    res.status(201).json(rows[0]);
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('[withdrawals] request failed:', err.message);
+    res.status(500).json({ error: 'Could not create withdrawal request' });
+  } finally {
+    client.release();
+  }
 });
 
-// Creator approval/signature.
 router.post('/:id/approve/creator', requireAuth, async (req, res) => {
   const { rows: requests } = await db.query(
-    `SELECT wr.*, c.creator_id, c.wallet_public_key AS campaign_wallet_key
+    `SELECT wr.*, c.creator_id, c.status AS campaign_status
      FROM withdrawal_requests wr
      JOIN campaigns c ON c.id = wr.campaign_id
      WHERE wr.id = $1`,
@@ -81,6 +155,11 @@ router.post('/:id/approve/creator', requireAuth, async (req, res) => {
 
   if (requestRow.creator_id !== req.user.userId) {
     return res.status(403).json({ error: 'Only campaign creator can approve creator signature' });
+  }
+  if (!ALLOWED_CAMPAIGN_STATUS_FOR_REQUEST.includes(requestRow.campaign_status)) {
+    return res.status(409).json({
+      error: `Campaign status is "${requestRow.campaign_status}". Creator approval is not allowed.`,
+    });
   }
   if (requestRow.status !== 'pending') {
     return res.status(409).json({ error: 'Withdrawal request is no longer pending' });
@@ -100,30 +179,58 @@ router.post('/:id/approve/creator', requireAuth, async (req, res) => {
     signerSecret: creatorSecret,
   });
 
-  const { rows: updated } = await db.query(
-    `UPDATE withdrawal_requests
-     SET unsigned_xdr = $1, creator_signed = TRUE
-     WHERE id = $2
-     RETURNING *`,
-    [signedXdr, req.params.id]
-  );
-
-  res.json(updated[0]);
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN');
+    const { rows: updated } = await client.query(
+      `UPDATE withdrawal_requests
+       SET unsigned_xdr = $1, creator_signed = TRUE
+       WHERE id = $2 AND status = 'pending' AND creator_signed = FALSE
+       RETURNING *`,
+      [signedXdr, req.params.id]
+    );
+    if (!updated.length) {
+      await client.query('ROLLBACK');
+      return res.status(409).json({ error: 'Withdrawal request changed; refresh and try again.' });
+    }
+    await logWithdrawalEvent(client, {
+      withdrawalRequestId: req.params.id,
+      actorUserId: req.user.userId,
+      action: 'creator_signed',
+      note: null,
+      metadata: {},
+    });
+    await client.query('COMMIT');
+    res.json(updated[0]);
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('[withdrawals] creator approve failed:', err.message);
+    res.status(500).json({ error: 'Could not record creator approval' });
+  } finally {
+    client.release();
+  }
 });
 
-// Platform approval/signature and final submission.
 router.post('/:id/approve/platform', requireAuth, async (req, res) => {
-  if (process.env.PLATFORM_APPROVER_USER_ID && req.user.userId !== process.env.PLATFORM_APPROVER_USER_ID) {
+  if (!canPerformPlatformSignature(req.user.userId)) {
     return res.status(403).json({ error: 'Only designated platform approver can sign as platform' });
   }
 
   const { rows: requests } = await db.query(
-    'SELECT * FROM withdrawal_requests WHERE id = $1',
+    `SELECT wr.*, c.status AS campaign_status
+     FROM withdrawal_requests wr
+     JOIN campaigns c ON c.id = wr.campaign_id
+     WHERE wr.id = $1`,
     [req.params.id]
   );
   if (!requests.length) return res.status(404).json({ error: 'Withdrawal request not found' });
   const requestRow = requests[0];
 
+  if (!ALLOWED_CAMPAIGN_STATUS_FOR_REQUEST.includes(requestRow.campaign_status)) {
+    return res.status(409).json({
+      error: `Campaign status is "${requestRow.campaign_status}". Platform release is blocked.`,
+    });
+  }
   if (requestRow.status !== 'pending') {
     return res.status(409).json({ error: 'Withdrawal request is no longer pending' });
   }
@@ -144,28 +251,211 @@ router.post('/:id/approve/platform', requireAuth, async (req, res) => {
     return res.status(422).json({ error: 'Insufficient signatures: expected creator + platform' });
   }
 
-  const txHash = await submitSignedWithdrawal({ xdr: signedXdr });
+  let txHash;
+  try {
+    txHash = await submitSignedWithdrawal({ xdr: signedXdr });
+  } catch (err) {
+    const client = await db.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `UPDATE withdrawal_requests SET status = 'failed' WHERE id = $1 AND status = 'pending'`,
+        [req.params.id]
+      );
+      await logWithdrawalEvent(client, {
+        withdrawalRequestId: req.params.id,
+        actorUserId: req.user.userId,
+        action: 'submit_failed',
+        note: err.message || 'Stellar submit failed',
+        metadata: { detail: String(err) },
+      });
+      await client.query('COMMIT');
+    } catch (logErr) {
+      await client.query('ROLLBACK');
+      console.error('[withdrawals] failed to log submit error:', logErr.message);
+    } finally {
+      client.release();
+    }
+    return res.status(502).json({
+      error: 'Stellar network rejected the transaction after dual approval. Request marked failed; see audit log.',
+    });
+  }
 
-  const { rows: updated } = await db.query(
-    `UPDATE withdrawal_requests
-     SET unsigned_xdr = $1, platform_signed = TRUE, status = 'submitted', tx_hash = $2
-     WHERE id = $3
-     RETURNING *`,
-    [signedXdr, txHash, req.params.id]
-  );
-
-  res.json(updated[0]);
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN');
+    const { rows: updated } = await client.query(
+      `UPDATE withdrawal_requests
+       SET unsigned_xdr = $1, platform_signed = TRUE, status = 'submitted', tx_hash = $2
+       WHERE id = $3 AND status = 'pending'
+       RETURNING *`,
+      [signedXdr, txHash, req.params.id]
+    );
+    if (!updated.length) {
+      await client.query('ROLLBACK');
+      return res.status(409).json({ error: 'Withdrawal request changed; refresh and try again.' });
+    }
+    await logWithdrawalEvent(client, {
+      withdrawalRequestId: req.params.id,
+      actorUserId: req.user.userId,
+      action: 'platform_signed',
+      note: null,
+      metadata: { tx_hash: txHash },
+    });
+    await client.query('COMMIT');
+    res.json(updated[0]);
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('[withdrawals] platform approve persist failed:', err.message);
+    res.status(500).json({ error: 'Transaction submitted but failed to update records; check Stellar and audit trail.' });
+  } finally {
+    client.release();
+  }
 });
 
-// List withdrawals for campaign.
+router.post('/:id/cancel', requireAuth, async (req, res) => {
+  const reason = (req.body && req.body.reason) || 'Cancelled by creator';
+
+  const { rows: requests } = await db.query(
+    `SELECT wr.*, c.creator_id
+     FROM withdrawal_requests wr
+     JOIN campaigns c ON c.id = wr.campaign_id
+     WHERE wr.id = $1`,
+    [req.params.id]
+  );
+  if (!requests.length) return res.status(404).json({ error: 'Withdrawal request not found' });
+  const requestRow = requests[0];
+
+  if (requestRow.creator_id !== req.user.userId) {
+    return res.status(403).json({ error: 'Only the campaign creator can cancel this request' });
+  }
+  if (requestRow.status !== 'pending') {
+    return res.status(409).json({ error: 'Only pending requests can be cancelled' });
+  }
+  if (requestRow.creator_signed) {
+    return res.status(409).json({
+      error: 'Creator signature is already attached. Use platform reject flow instead of cancel.',
+    });
+  }
+
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN');
+    const { rows: updated } = await client.query(
+      `UPDATE withdrawal_requests
+       SET status = 'denied', denial_reason = $1
+       WHERE id = $2 AND status = 'pending' AND creator_signed = FALSE
+       RETURNING *`,
+      [reason, req.params.id]
+    );
+    if (!updated.length) {
+      await client.query('ROLLBACK');
+      return res.status(409).json({ error: 'Withdrawal request changed; refresh and try again.' });
+    }
+    await logWithdrawalEvent(client, {
+      withdrawalRequestId: req.params.id,
+      actorUserId: req.user.userId,
+      action: 'creator_cancelled',
+      note: reason,
+      metadata: {},
+    });
+    await client.query('COMMIT');
+    res.json(updated[0]);
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('[withdrawals] cancel failed:', err.message);
+    res.status(500).json({ error: 'Could not cancel withdrawal request' });
+  } finally {
+    client.release();
+  }
+});
+
+router.post('/:id/reject', requireAuth, async (req, res) => {
+  if (!canPerformPlatformSignature(req.user.userId)) {
+    return res.status(403).json({ error: 'Only designated platform approver can reject at this stage' });
+  }
+  const reason = (req.body && req.body.reason) || 'Rejected by platform';
+
+  const { rows: requests } = await db.query(
+    'SELECT * FROM withdrawal_requests WHERE id = $1',
+    [req.params.id]
+  );
+  if (!requests.length) return res.status(404).json({ error: 'Withdrawal request not found' });
+  const requestRow = requests[0];
+
+  if (requestRow.status !== 'pending') {
+    return res.status(409).json({ error: 'Only pending requests can be rejected' });
+  }
+  if (!requestRow.creator_signed) {
+    return res.status(409).json({ error: 'Creator must sign before platform can reject this release' });
+  }
+  if (requestRow.platform_signed) {
+    return res.status(409).json({ error: 'Platform has already signed; cannot reject' });
+  }
+
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN');
+    const { rows: updated } = await client.query(
+      `UPDATE withdrawal_requests
+       SET status = 'denied', denial_reason = $1
+       WHERE id = $2 AND status = 'pending' AND creator_signed = TRUE AND platform_signed = FALSE
+       RETURNING *`,
+      [reason, req.params.id]
+    );
+    if (!updated.length) {
+      await client.query('ROLLBACK');
+      return res.status(409).json({ error: 'Withdrawal request changed; refresh and try again.' });
+    }
+    await logWithdrawalEvent(client, {
+      withdrawalRequestId: req.params.id,
+      actorUserId: req.user.userId,
+      action: 'platform_rejected',
+      note: reason,
+      metadata: {},
+    });
+    await client.query('COMMIT');
+    res.json(updated[0]);
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('[withdrawals] reject failed:', err.message);
+    res.status(500).json({ error: 'Could not reject withdrawal request' });
+  } finally {
+    client.release();
+  }
+});
+
 router.get('/campaign/:campaignId', requireAuth, async (req, res) => {
+  const access = await assertWithdrawalAccess(req, req.params.campaignId);
+  if (access.error) return res.status(access.status).json({ error: access.error });
+
   const { rows } = await db.query(
     `SELECT id, campaign_id, requested_by, amount, destination_key, creator_signed,
-            platform_signed, status, tx_hash, created_at
+            platform_signed, status, denial_reason, tx_hash, created_at
      FROM withdrawal_requests
      WHERE campaign_id = $1
      ORDER BY created_at DESC`,
     [req.params.campaignId]
+  );
+  res.json(rows);
+});
+
+router.get('/:id/events', requireAuth, async (req, res) => {
+  const { rows: wr } = await db.query(
+    `SELECT wr.campaign_id FROM withdrawal_requests wr WHERE wr.id = $1`,
+    [req.params.id]
+  );
+  if (!wr.length) return res.status(404).json({ error: 'Withdrawal request not found' });
+
+  const access = await assertWithdrawalAccess(req, wr[0].campaign_id);
+  if (access.error) return res.status(access.status).json({ error: access.error });
+
+  const { rows } = await db.query(
+    `SELECT e.id, e.withdrawal_request_id, e.actor_user_id, e.action, e.note, e.metadata, e.created_at
+     FROM withdrawal_approval_events e
+     WHERE e.withdrawal_request_id = $1
+     ORDER BY e.created_at ASC`,
+    [req.params.id]
   );
   res.json(rows);
 });

--- a/backend/src/routes/withdrawals.test.js
+++ b/backend/src/routes/withdrawals.test.js
@@ -19,7 +19,13 @@ function buildApp({ queryImpl, stellarImpl, userId = 'creator-1' }) {
   };
 
   const router = proxyquire('./withdrawals', {
-    '../config/database': { query: queryImpl },
+    '../config/database': {
+      connect: async () => ({
+        query: queryImpl,
+        release: () => {},
+      }),
+      query: queryImpl,
+    },
     '../services/stellarService': stellarStub,
     '../middleware/auth': {
       requireAuth: (req, _res, next) => {
@@ -33,32 +39,58 @@ function buildApp({ queryImpl, stellarImpl, userId = 'creator-1' }) {
   app.use(express.json());
   app.use('/api/withdrawals', router);
 
+  return { app, cleanup: () => {} };
+}
+
+function campaignRow(overrides = {}) {
   return {
-    app,
-    cleanup: () => {},
+    id: 'camp-1',
+    creator_id: 'creator-1',
+    wallet_public_key: 'GCAMPAIGN',
+    asset_type: 'USDC',
+    status: 'active',
+    ...overrides,
   };
 }
 
-test('POST /api/withdrawals/request creates pending request for creator', async () => {
-  const dbCalls = [];
+test('GET /api/withdrawals/capabilities reflects approver env', async () => {
+  const prev = process.env.PLATFORM_APPROVER_USER_ID;
+  process.env.PLATFORM_APPROVER_USER_ID = 'platform-1';
+  try {
+    const { app, cleanup } = buildApp({
+      queryImpl: async () => ({ rows: [] }),
+      userId: 'platform-1',
+    });
+    const res = await request(app).get('/api/withdrawals/capabilities').set('Authorization', 'Bearer t');
+    cleanup();
+    assert.equal(res.status, 200);
+    assert.equal(res.body.can_approve_platform, true);
+  } finally {
+    if (prev === undefined) delete process.env.PLATFORM_APPROVER_USER_ID;
+    else process.env.PLATFORM_APPROVER_USER_ID = prev;
+  }
+});
+
+test('POST /api/withdrawals/request creates pending request and logs event', async () => {
+  const calls = [];
   const { app, cleanup } = buildApp({
     queryImpl: async (text, params) => {
-      dbCalls.push({ text, params });
-      if (text.includes('FROM campaigns')) {
-        return {
-          rows: [{
-            id: 'camp-1',
-            creator_id: 'creator-1',
-            wallet_public_key: 'GCAMPAIGN',
-            asset_type: 'USDC',
-          }],
-        };
+      calls.push(text);
+      if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
+      if (text.includes('FROM campaigns WHERE id')) {
+        return { rows: [campaignRow()] };
       }
-      if (text.includes('SELECT wallet_public_key FROM users')) {
+      if (text.includes("FROM withdrawal_requests") && text.includes("status = 'pending'")) {
+        return { rows: [] };
+      }
+      if (text.includes('wallet_public_key FROM users')) {
         return { rows: [{ wallet_public_key: 'GCREATOR' }] };
       }
       if (text.includes('INSERT INTO withdrawal_requests')) {
         return { rows: [{ id: 'w-1', status: 'pending', creator_signed: false, platform_signed: false }] };
+      }
+      if (text.includes('INSERT INTO withdrawal_approval_events')) {
+        return { rows: [] };
       }
       return { rows: [] };
     },
@@ -72,23 +104,58 @@ test('POST /api/withdrawals/request creates pending request for creator', async 
   cleanup();
   assert.equal(response.status, 201);
   assert.equal(response.body.status, 'pending');
-  assert.ok(dbCalls.some((c) => c.text.includes('INSERT INTO withdrawal_requests')));
+  assert.ok(calls.some((c) => c.includes('INSERT INTO withdrawal_approval_events')));
+});
+
+test('POST /api/withdrawals/request blocks when campaign not active or funded', async () => {
+  const { app, cleanup } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns WHERE id')) {
+        return { rows: [campaignRow({ status: 'closed' })] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/request')
+    .set('Authorization', 'Bearer token')
+    .send({ campaign_id: 'camp-1', destination_key: 'GDEST', amount: '10.0000000' });
+
+  cleanup();
+  assert.equal(response.status, 409);
+});
+
+test('POST /api/withdrawals/request blocks duplicate pending', async () => {
+  const { app, cleanup } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns WHERE id')) {
+        return { rows: [campaignRow()] };
+      }
+      if (text.includes("status = 'pending'")) {
+        return { rows: [{ id: 'existing' }] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/request')
+    .set('Authorization', 'Bearer token')
+    .send({ campaign_id: 'camp-1', destination_key: 'GDEST', amount: '10.0000000' });
+
+  cleanup();
+  assert.equal(response.status, 409);
 });
 
 test('POST /api/withdrawals/request denies invalid multisig config', async () => {
   const { app, cleanup } = buildApp({
     queryImpl: async (text) => {
-      if (text.includes('FROM campaigns')) {
-        return {
-          rows: [{
-            id: 'camp-1',
-            creator_id: 'creator-1',
-            wallet_public_key: 'GCAMPAIGN',
-            asset_type: 'USDC',
-          }],
-        };
+      if (text.includes('FROM campaigns WHERE id')) {
+        return { rows: [campaignRow()] };
       }
-      if (text.includes('SELECT wallet_public_key FROM users')) {
+      if (text.includes("status = 'pending'")) return { rows: [] };
+      if (text.includes('wallet_public_key FROM users')) {
         return { rows: [{ wallet_public_key: 'GCREATOR' }] };
       }
       return { rows: [] };
@@ -119,6 +186,7 @@ test('POST /api/withdrawals/:id/approve/platform denies before creator approval'
         creator_signed: false,
         platform_signed: false,
         unsigned_xdr: 'xdr-base',
+        campaign_status: 'active',
       }],
     }),
   });
@@ -134,8 +202,11 @@ test('POST /api/withdrawals/:id/approve/platform denies before creator approval'
 });
 
 test('POST /api/withdrawals/:id/approve/creator signs withdrawal request', async () => {
+  const calls = [];
   const { app, cleanup } = buildApp({
     queryImpl: async (text) => {
+      calls.push(text);
+      if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
       if (text.includes('FROM withdrawal_requests wr')) {
         return {
           rows: [{
@@ -145,16 +216,17 @@ test('POST /api/withdrawals/:id/approve/creator signs withdrawal request', async
             platform_signed: false,
             unsigned_xdr: 'xdr-base',
             creator_id: 'creator-1',
-            campaign_wallet_key: 'GCAMPAIGN',
+            campaign_status: 'active',
           }],
         };
       }
-      if (text.includes('SELECT wallet_secret_encrypted FROM users')) {
+      if (text.includes('wallet_secret_encrypted FROM users')) {
         return { rows: [{ wallet_secret_encrypted: 'SCREATOR' }] };
       }
-      if (text.includes('UPDATE withdrawal_requests')) {
+      if (text.includes('UPDATE withdrawal_requests') && text.includes('creator_signed = TRUE')) {
         return { rows: [{ id: 'w-1', creator_signed: true, unsigned_xdr: 'xdr-signed' }] };
       }
+      if (text.includes('INSERT INTO withdrawal_approval_events')) return { rows: [] };
       return { rows: [] };
     },
   });
@@ -167,6 +239,7 @@ test('POST /api/withdrawals/:id/approve/creator signs withdrawal request', async
   cleanup();
   assert.equal(response.status, 200);
   assert.equal(response.body.creator_signed, true);
+  assert.ok(calls.some((c) => c.includes('creator_signed')));
 });
 
 test('POST /api/withdrawals/:id/approve/platform denies insufficient signatures', async () => {
@@ -178,6 +251,7 @@ test('POST /api/withdrawals/:id/approve/platform denies insufficient signatures'
         creator_signed: true,
         platform_signed: false,
         unsigned_xdr: 'xdr-base',
+        campaign_status: 'active',
       }],
     }),
     stellarImpl: {
@@ -199,7 +273,8 @@ test('POST /api/withdrawals/:id/approve/platform submits with dual signatures', 
   const { app, cleanup } = buildApp({
     queryImpl: async (text) => {
       calls.push(text);
-      if (text.includes('SELECT * FROM withdrawal_requests')) {
+      if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
+      if (text.includes('SELECT wr.*, c.status')) {
         return {
           rows: [{
             id: 'w-1',
@@ -207,12 +282,14 @@ test('POST /api/withdrawals/:id/approve/platform submits with dual signatures', 
             creator_signed: true,
             platform_signed: false,
             unsigned_xdr: 'xdr-creator-signed',
+            campaign_status: 'active',
           }],
         };
       }
-      if (text.includes('UPDATE withdrawal_requests')) {
+      if (text.includes('UPDATE withdrawal_requests') && text.includes("status = 'submitted'")) {
         return { rows: [{ id: 'w-1', status: 'submitted', tx_hash: 'tx-hash' }] };
       }
+      if (text.includes('INSERT INTO withdrawal_approval_events')) return { rows: [] };
       return { rows: [] };
     },
   });
@@ -226,4 +303,134 @@ test('POST /api/withdrawals/:id/approve/platform submits with dual signatures', 
   assert.equal(response.status, 200);
   assert.equal(response.body.status, 'submitted');
   assert.ok(calls.some((c) => c.includes("status = 'submitted'")));
+});
+
+test('POST /api/withdrawals/:id/cancel denies after creator signed', async () => {
+  const { app, cleanup } = buildApp({
+    queryImpl: async () => ({
+      rows: [{
+        id: 'w-1',
+        status: 'pending',
+        creator_signed: true,
+        creator_id: 'creator-1',
+      }],
+    }),
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/w-1/cancel')
+    .set('Authorization', 'Bearer token')
+    .send({ reason: 'Never mind' });
+
+  cleanup();
+  assert.equal(response.status, 409);
+});
+
+test('POST /api/withdrawals/:id/cancel succeeds before creator signs', async () => {
+  const { app, cleanup } = buildApp({
+    queryImpl: async (text) => {
+      if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
+      if (text.includes('FROM withdrawal_requests wr')) {
+        return {
+          rows: [{
+            id: 'w-1',
+            status: 'pending',
+            creator_signed: false,
+            creator_id: 'creator-1',
+          }],
+        };
+      }
+      if (text.includes("SET status = 'denied'")) {
+        return { rows: [{ id: 'w-1', status: 'denied', denial_reason: 'x' }] };
+      }
+      if (text.includes('INSERT INTO withdrawal_approval_events')) return { rows: [] };
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/w-1/cancel')
+    .set('Authorization', 'Bearer token')
+    .send({ reason: 'Wrong destination' });
+
+  cleanup();
+  assert.equal(response.status, 200);
+  assert.equal(response.body.status, 'denied');
+});
+
+test('POST /api/withdrawals/:id/reject marks denied after creator signed', async () => {
+  const { app, cleanup } = buildApp({
+    userId: 'platform-user',
+    queryImpl: async (text) => {
+      if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
+      if (text.includes('SELECT * FROM withdrawal_requests WHERE id')) {
+        return {
+          rows: [{
+            id: 'w-1',
+            status: 'pending',
+            creator_signed: true,
+            platform_signed: false,
+          }],
+        };
+      }
+      if (text.includes("SET status = 'denied'")) {
+        return { rows: [{ id: 'w-1', status: 'denied' }] };
+      }
+      if (text.includes('INSERT INTO withdrawal_approval_events')) return { rows: [] };
+      return { rows: [] };
+    },
+  });
+
+  const prev = process.env.PLATFORM_APPROVER_USER_ID;
+  process.env.PLATFORM_APPROVER_USER_ID = 'platform-user';
+  let response;
+  try {
+    response = await request(app)
+      .post('/api/withdrawals/w-1/reject')
+      .set('Authorization', 'Bearer t')
+      .send({ reason: 'Compliance hold' });
+  } finally {
+    if (prev === undefined) delete process.env.PLATFORM_APPROVER_USER_ID;
+    else process.env.PLATFORM_APPROVER_USER_ID = prev;
+  }
+
+  cleanup();
+  assert.equal(response.status, 200);
+  assert.equal(response.body.status, 'denied');
+});
+
+test('POST /api/withdrawals/:id/approve/platform logs failure when Stellar rejects', async () => {
+  const { app, cleanup } = buildApp({
+    queryImpl: async (text) => {
+      if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
+      if (text.includes('SELECT wr.*, c.status')) {
+        return {
+          rows: [{
+            id: 'w-1',
+            status: 'pending',
+            creator_signed: true,
+            platform_signed: false,
+            unsigned_xdr: 'xdr',
+            campaign_status: 'active',
+          }],
+        };
+      }
+      if (text.includes("SET status = 'failed'")) return { rows: [] };
+      if (text.includes('INSERT INTO withdrawal_approval_events')) return { rows: [] };
+      return { rows: [] };
+    },
+    stellarImpl: {
+      submitSignedWithdrawal: async () => {
+        throw new Error('op_underfunded');
+      },
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/w-1/approve/platform')
+    .set('Authorization', 'Bearer token')
+    .send({});
+
+  cleanup();
+  assert.equal(response.status, 502);
 });

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Stellar network label for explorer links (testnet | public)
+VITE_STELLAR_NETWORK=testnet

--- a/frontend/src/components/CampaignCard.jsx
+++ b/frontend/src/components/CampaignCard.jsx
@@ -5,8 +5,8 @@ export default function CampaignCard({ campaign }) {
   const pct = Math.min(100, (campaign.raised_amount / campaign.target_amount) * 100).toFixed(1);
 
   return (
-    <Link to={`/campaigns/${campaign.id}`} style={{ display: 'block' }}>
-      <div style={styles.card}>
+    <Link to={`/campaigns/${campaign.id}`} style={{ display: 'block' }} className="campaign-card-link">
+      <div className="campaign-card" style={styles.card}>
         <div style={styles.header}>
           <span style={styles.asset}>{campaign.asset_type}</span>
         </div>

--- a/frontend/src/components/ContributeModal.jsx
+++ b/frontend/src/components/ContributeModal.jsx
@@ -1,81 +1,295 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { api } from '../services/api';
+import { stellarExpertTxUrl } from '../config/stellar';
+
+const SEND_OPTIONS = [
+  { value: 'XLM', label: 'XLM', hint: 'Native Stellar' },
+  { value: 'USDC', label: 'USDC', hint: 'Stable dollar' },
+];
+
+function friendlyQuoteError(err) {
+  if (err.status === 404) {
+    return 'No conversion path is available for this pair right now. Try the campaign’s asset or a different amount.';
+  }
+  return err.message || 'Could not load a quote.';
+}
+
+function friendlyContributeError(err) {
+  if (err.status === 422) {
+    return err.message || 'Conversion failed. Try another amount or asset.';
+  }
+  if (err.status === 404) {
+    return 'Campaign not found or no longer active.';
+  }
+  if (err.status === 400) {
+    return err.message || 'Check your amount and asset selection.';
+  }
+  return err.message || 'Payment could not be submitted. Try again.';
+}
 
 export default function ContributeModal({ campaign, onClose, onSuccess }) {
   const { token } = useAuth();
   const [amount, setAmount] = useState('');
   const [sendAsset, setSendAsset] = useState(campaign.asset_type);
   const [loading, setLoading] = useState(false);
+  const [quoteLoading, setQuoteLoading] = useState(false);
   const [error, setError] = useState('');
+  const [quoteError, setQuoteError] = useState('');
+  const [quote, setQuote] = useState(null);
+  const [phase, setPhase] = useState('form');
+  const [result, setResult] = useState(null);
+
+  const isPathPayment = sendAsset !== campaign.asset_type;
+  const destAmount = amount.trim();
+
+  const fetchQuote = useCallback(async () => {
+    if (!isPathPayment || !destAmount || Number(destAmount) <= 0) {
+      setQuote(null);
+      setQuoteError('');
+      return;
+    }
+    setQuoteLoading(true);
+    setQuoteError('');
+    try {
+      const q = await api.quoteContribution(
+        {
+          send_asset: sendAsset,
+          dest_asset: campaign.asset_type,
+          dest_amount: destAmount,
+        },
+        token
+      );
+      setQuote(q);
+    } catch (err) {
+      setQuote(null);
+      setQuoteError(friendlyQuoteError(err));
+    } finally {
+      setQuoteLoading(false);
+    }
+  }, [isPathPayment, destAmount, sendAsset, campaign.asset_type, token]);
+
+  useEffect(() => {
+    if (!isPathPayment) {
+      setQuote(null);
+      setQuoteError('');
+      return;
+    }
+    const t = setTimeout(() => {
+      fetchQuote();
+    }, 450);
+    return () => clearTimeout(t);
+  }, [fetchQuote, isPathPayment]);
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
 
   async function handleSubmit(e) {
     e.preventDefault();
-    if (!amount || parseFloat(amount) <= 0) return;
+    if (!destAmount || Number(destAmount) <= 0) {
+      setError('Enter an amount greater than zero.');
+      return;
+    }
     setLoading(true);
     setError('');
     try {
-      await api.contribute({ campaign_id: campaign.id, amount, send_asset: sendAsset }, token);
+      const data = await api.contribute(
+        { campaign_id: campaign.id, amount: destAmount, send_asset: sendAsset },
+        token
+      );
+      setResult(data);
+      setPhase('success');
       onSuccess();
     } catch (err) {
-      setError(err.message);
+      setError(friendlyContributeError(err));
     } finally {
       setLoading(false);
     }
   }
 
-  const isPathPayment = sendAsset !== campaign.asset_type;
+  function handleClose() {
+    onClose();
+  }
 
   return (
-    <div style={styles.overlay} onClick={onClose}>
-      <div style={styles.modal} onClick={(e) => e.stopPropagation()}>
-        <h2 style={styles.title}>Contribute to {campaign.title}</h2>
+    <div className="modal-overlay" style={styles.overlay} onClick={handleClose} role="presentation">
+      <div
+        className="modal-shell"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="contribute-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {phase === 'form' ? (
+          <>
+            <h2 id="contribute-title" style={styles.title}>
+              Support this campaign
+            </h2>
+            <p style={styles.subtitle}>
+              Goal currency: <strong>{campaign.asset_type}</strong>. You choose what you send; the campaign receives
+              the amount below in <strong>{campaign.asset_type}</strong>.
+            </p>
 
-        {isPathPayment && (
-          <div style={styles.notice}>
-            Path payment active — you send {sendAsset}, campaign receives {campaign.asset_type} automatically via Stellar DEX.
-          </div>
-        )}
+            <form onSubmit={handleSubmit}>
+              <fieldset style={{ border: 'none', margin: '0 0 1rem', padding: 0 }}>
+                <legend className="label-strong" style={{ marginBottom: '0.45rem' }}>
+                  Pay with
+                </legend>
+                <div className="asset-picker" role="radiogroup" aria-label="Asset to send">
+                  {SEND_OPTIONS.map((opt) => (
+                    <label
+                      key={opt.value}
+                      className={`asset-picker__option${sendAsset === opt.value ? ' asset-picker__option--selected' : ''}`}
+                    >
+                      <input
+                        type="radio"
+                        name="send_asset"
+                        value={opt.value}
+                        checked={sendAsset === opt.value}
+                        onChange={() => setSendAsset(opt.value)}
+                      />
+                      <div className="asset-picker__code">{opt.label}</div>
+                      <div className="asset-picker__hint">{opt.hint}</div>
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
 
-        <form onSubmit={handleSubmit} style={styles.form}>
-          <label style={styles.label}>Send asset</label>
-          <select value={sendAsset} onChange={(e) => setSendAsset(e.target.value)} style={{ marginBottom: '1rem' }}>
-            <option value="XLM">XLM</option>
-            <option value="USDC">USDC</option>
-          </select>
+              <div className="form-stack" style={{ marginBottom: '0.25rem' }}>
+                <label className="label-strong" htmlFor="contrib-amount">
+                  Amount campaign receives ({campaign.asset_type})
+                </label>
+                <input
+                  id="contrib-amount"
+                  type="number"
+                  inputMode="decimal"
+                  min="0.0000001"
+                  step="any"
+                  placeholder="0.00"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  aria-describedby="contrib-amount-help"
+                />
+                <span id="contrib-amount-help" style={styles.help}>
+                  This is the credited amount toward the campaign goal, in {campaign.asset_type}.
+                </span>
+              </div>
 
-          <label style={styles.label}>Amount ({sendAsset})</label>
-          <input
-            type="number"
-            min="0.0000001"
-            step="any"
-            placeholder="0.00"
-            value={amount}
-            onChange={(e) => setAmount(e.target.value)}
-            style={{ marginBottom: '1rem' }}
-          />
+              {isPathPayment && (
+                <div className="alert alert--info" style={{ marginTop: '0.85rem' }} role="status">
+                  <strong>Cross-asset payment.</strong> Stellar will convert from {sendAsset} to {campaign.asset_type}{' '}
+                  when you confirm. Estimated fees are tiny; conversion uses the network DEX.
+                </div>
+              )}
 
-          {error && <p style={styles.error}>{error}</p>}
+              {isPathPayment && destAmount && Number(destAmount) > 0 && (
+                <div style={{ marginTop: '0.85rem', minHeight: '3.5rem' }}>
+                  {quoteLoading && <p style={{ fontSize: '0.85rem', color: '#666' }}>Fetching live quote…</p>}
+                  {!quoteLoading && quote && (
+                    <div className="alert alert--success" role="status">
+                      <div style={{ fontWeight: 700, marginBottom: '0.25rem' }}>Estimated from your wallet</div>
+                      <div style={{ fontSize: '0.875rem', lineHeight: 1.45 }}>
+                        Up to <strong>{quote.max_send_amount}</strong> {sendAsset} (includes a small slippage buffer).
+                        {Array.isArray(quote.path) && quote.path.length > 0 && (
+                          <>
+                            {' '}
+                            Route: {sendAsset} → {quote.path.join(' → ')} → {campaign.asset_type}
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                  {!quoteLoading && quoteError && (
+                    <p className="alert alert--error" role="alert">
+                      {quoteError}
+                    </p>
+                  )}
+                </div>
+              )}
 
-          <div style={styles.actions}>
-            <button type="button" className="btn-secondary" onClick={onClose}>Cancel</button>
-            <button type="submit" className="btn-primary" disabled={loading}>
-              {loading ? 'Submitting…' : 'Contribute'}
+              {error && (
+                <p className="alert alert--error" style={{ marginTop: '0.85rem' }} role="alert">
+                  {error}
+                </p>
+              )}
+
+              <div style={styles.actions}>
+                <button type="button" className="btn-secondary" onClick={handleClose}>
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="btn-primary"
+                  disabled={loading || (isPathPayment && (quoteLoading || !!quoteError || !quote))}
+                >
+                  {loading ? 'Submitting…' : 'Confirm payment'}
+                </button>
+              </div>
+            </form>
+          </>
+        ) : (
+          <div>
+            <h2 id="contribute-title" style={styles.title}>
+              Payment submitted
+            </h2>
+            <p className="alert alert--success" style={{ marginBottom: '1rem' }} role="status">
+              Your contribution is on its way. It usually confirms in a few seconds on Stellar.
+            </p>
+            {result?.tx_hash && (
+              <p style={{ fontSize: '0.875rem', marginBottom: '0.75rem', wordBreak: 'break-all' }}>
+                <strong>Transaction</strong>{' '}
+                <a
+                  href={stellarExpertTxUrl(result.tx_hash)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ color: '#7c3aed', fontWeight: 600 }}
+                >
+                  View on Stellar Expert
+                </a>
+              </p>
+            )}
+            {result?.conversion_quote && (
+              <div className="alert alert--info" style={{ marginBottom: '1rem', fontSize: '0.85rem' }}>
+                <strong>Conversion summary:</strong> up to {result.conversion_quote.max_send_amount}{' '}
+                {result.conversion_quote.send_asset} authorized for{' '}
+                {result.conversion_quote.campaign_amount} {result.conversion_quote.campaign_asset} received.
+              </div>
+            )}
+            <button type="button" className="btn-primary" style={{ width: '100%' }} onClick={handleClose}>
+              Done
             </button>
           </div>
-        </form>
+        )}
       </div>
     </div>
   );
 }
 
 const styles = {
-  overlay: { position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.45)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100 },
-  modal: { background: '#fff', borderRadius: '12px', padding: '2rem', width: '100%', maxWidth: '420px' },
-  title: { fontSize: '1.2rem', fontWeight: 700, marginBottom: '1rem' },
-  form: { display: 'flex', flexDirection: 'column' },
-  label: { fontSize: '0.85rem', fontWeight: 600, color: '#444', marginBottom: '0.3rem' },
-  notice: { background: '#ede9fe', color: '#5b21b6', borderRadius: '6px', padding: '0.65rem 0.85rem', fontSize: '0.82rem', marginBottom: '1rem' },
-  actions: { display: 'flex', gap: '0.75rem', justifyContent: 'flex-end', marginTop: '0.5rem' },
-  error: { color: '#dc2626', fontSize: '0.85rem', marginBottom: '0.75rem' },
+  overlay: {
+    position: 'fixed',
+    inset: 0,
+    background: 'rgba(15, 23, 42, 0.55)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 100,
+    padding: '0.75rem',
+  },
+  title: { fontSize: '1.2rem', fontWeight: 800, marginBottom: '0.5rem', color: '#111' },
+  subtitle: { color: '#555', fontSize: '0.875rem', lineHeight: 1.55, marginBottom: '1.1rem' },
+  help: { fontSize: '0.78rem', color: '#777', marginTop: '0.2rem' },
+  actions: {
+    display: 'flex',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: '0.65rem',
+    justifyContent: 'stretch',
+    marginTop: '1.1rem',
+  },
 };

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -13,9 +13,9 @@ export default function Navbar() {
 
   return (
     <nav style={styles.nav}>
-      <div className="container" style={styles.inner}>
+      <div className="container nav-inner-wrap">
         <Link to="/" style={styles.logo}>CrowdPay</Link>
-        <div style={styles.links}>
+        <div className="nav-links">
           {user ? (
             <>
               <Link to="/campaigns/new" style={styles.link}>Start Campaign</Link>
@@ -40,9 +40,7 @@ export default function Navbar() {
 
 const styles = {
   nav: { background: '#fff', borderBottom: '1px solid #e5e5e5', position: 'sticky', top: 0, zIndex: 10 },
-  inner: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', height: '56px' },
-  logo: { fontWeight: 800, fontSize: '1.2rem', color: '#7c3aed' },
-  links: { display: 'flex', alignItems: 'center', gap: '1.2rem' },
-  link: { color: '#444', fontWeight: 500 },
-  name: { color: '#555', fontSize: '0.9rem' },
+  logo: { fontWeight: 800, fontSize: '1.15rem', color: '#7c3aed' },
+  link: { color: '#444', fontWeight: 500, fontSize: '0.9rem' },
+  name: { color: '#555', fontSize: '0.85rem', maxWidth: '140px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
 };

--- a/frontend/src/components/OnboardingCallout.jsx
+++ b/frontend/src/components/OnboardingCallout.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export default function OnboardingCallout({ title, children, onDismiss, className = '' }) {
+  return (
+    <aside className={`onboarding-callout ${className}`.trim()} role="note">
+      <div className="onboarding-callout__inner">
+        <div className="onboarding-callout__content">
+          {title && <h2 className="onboarding-callout__title">{title}</h2>}
+          <div className="onboarding-callout__body">{children}</div>
+        </div>
+        {onDismiss && (
+          <button type="button" className="onboarding-callout__dismiss" onClick={onDismiss}>
+            Got it
+          </button>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/components/WithdrawalsSection.jsx
+++ b/frontend/src/components/WithdrawalsSection.jsx
@@ -1,0 +1,349 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { api } from '../services/api';
+import { stellarExpertTxUrl } from '../config/stellar';
+
+const ELIGIBLE = ['active', 'funded'];
+
+function statusLabel(row) {
+  if (row.status === 'pending') {
+    if (!row.creator_signed) return 'Awaiting creator signature';
+    if (!row.platform_signed) return 'Awaiting platform release';
+  }
+  if (row.status === 'submitted') return 'Released on-chain';
+  if (row.status === 'denied') return 'Denied / cancelled';
+  if (row.status === 'failed') return 'Failed (see audit)';
+  return row.status;
+}
+
+export default function WithdrawalsSection({ campaign, user, token, onReleased }) {
+  const [forbidden, setForbidden] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [cap, setCap] = useState({ can_approve_platform: false });
+  const [rows, setRows] = useState([]);
+  const [form, setForm] = useState({ destination_key: '', amount: '' });
+  const [busyId, setBusyId] = useState(null);
+  const [eventsById, setEventsById] = useState({});
+  const [openAudit, setOpenAudit] = useState(null);
+
+  const isCreator = user?.id && campaign.creator_id === user.id;
+  const canView = !forbidden && (isCreator || cap.can_approve_platform);
+  const hasPending = rows.some((r) => r.status === 'pending');
+  const canOpenRequest =
+    isCreator && ELIGIBLE.includes(campaign.status) && !hasPending;
+
+  const refresh = useCallback(async () => {
+    if (!token) return;
+    setError('');
+    try {
+      const caps = await api.getWithdrawalCapabilities(token);
+      setCap(caps);
+      const list = await api.listWithdrawals(campaign.id, token);
+      setRows(list);
+      setForbidden(false);
+    } catch (e) {
+      if (e.status === 403) {
+        setForbidden(true);
+        setRows([]);
+      } else {
+        setError(e.message || 'Could not load withdrawals.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [campaign.id, token]);
+
+  useEffect(() => {
+    if (!token) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    refresh();
+  }, [token, refresh]);
+
+  async function loadEvents(id) {
+    if (openAudit === id) {
+      setOpenAudit(null);
+      return;
+    }
+    if (eventsById[id]) {
+      setOpenAudit(id);
+      return;
+    }
+    try {
+      const ev = await api.getWithdrawalEvents(id, token);
+      setEventsById((m) => ({ ...m, [id]: ev }));
+      setOpenAudit(id);
+    } catch (e) {
+      setError(e.message || 'Could not load audit trail.');
+    }
+  }
+
+  async function handleRequest(e) {
+    e.preventDefault();
+    setBusyId('new');
+    setError('');
+    try {
+      await api.requestWithdrawal(
+        {
+          campaign_id: campaign.id,
+          destination_key: form.destination_key.trim(),
+          amount: form.amount.trim(),
+        },
+        token
+      );
+      setForm({ destination_key: '', amount: '' });
+      await refresh();
+      onReleased?.();
+    } catch (err) {
+      setError(err.message || 'Request failed.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function runAction(id, fn) {
+    setBusyId(id);
+    setError('');
+    try {
+      await fn();
+      await refresh();
+      onReleased?.();
+    } catch (err) {
+      setError(err.message || 'Action failed.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  if (!token || forbidden) return null;
+  if (loading) {
+    return (
+      <section style={styles.section} aria-label="Fund release">
+        <h2 style={styles.h2}>Manual fund release</h2>
+        <p style={{ color: '#888', fontSize: '0.9rem' }}>Loading…</p>
+      </section>
+    );
+  }
+  if (!canView) return null;
+
+  return (
+    <section style={styles.section} aria-label="Fund release">
+      <h2 style={styles.h2}>Manual fund release</h2>
+      <p style={styles.intro}>
+        Funds leave the campaign wallet only after <strong>you</strong> (creator) and <strong>CrowdPay</strong>{' '}
+        (platform) both approve the same transaction. Every step is logged for review.
+      </p>
+
+      {!ELIGIBLE.includes(campaign.status) && (
+        <p className="alert alert--info" role="status">
+          New withdrawal requests are disabled while campaign status is <strong>{campaign.status}</strong>.
+        </p>
+      )}
+
+      {error && (
+        <p className="alert alert--error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {canOpenRequest && (
+        <form onSubmit={handleRequest} style={styles.card}>
+          <h3 style={styles.h3}>Request a release</h3>
+          <p style={styles.hint}>Destination must be a valid Stellar public key. Amount is in {campaign.asset_type}.</p>
+          <label className="label-strong" htmlFor="wd-dest">
+            Destination address
+          </label>
+          <input
+            id="wd-dest"
+            value={form.destination_key}
+            onChange={(e) => setForm((f) => ({ ...f, destination_key: e.target.value }))}
+            placeholder="G…"
+            required
+            style={{ marginBottom: '0.75rem' }}
+            autoComplete="off"
+          />
+          <label className="label-strong" htmlFor="wd-amt">
+            Amount ({campaign.asset_type})
+          </label>
+          <input
+            id="wd-amt"
+            type="number"
+            inputMode="decimal"
+            min="0.0000001"
+            step="any"
+            value={form.amount}
+            onChange={(e) => setForm((f) => ({ ...f, amount: e.target.value }))}
+            required
+            style={{ marginBottom: '0.75rem' }}
+          />
+          <button type="submit" className="btn-primary" disabled={busyId === 'new'} style={{ width: '100%' }}>
+            {busyId === 'new' ? 'Submitting…' : 'Submit request'}
+          </button>
+        </form>
+      )}
+
+      {isCreator && hasPending && (
+        <p className="alert alert--info" style={{ marginTop: '1rem' }} role="status">
+          You have a pending release. Complete signatures, cancel before you sign, or wait for platform decision.
+        </p>
+      )}
+
+      <h3 style={{ ...styles.h3, marginTop: '1.5rem' }}>Requests & audit</h3>
+      {rows.length === 0 ? (
+        <p style={{ color: '#888', fontSize: '0.9rem' }}>No withdrawal activity yet.</p>
+      ) : (
+        <ul style={styles.list}>
+          {rows.map((row) => (
+            <li key={row.id} style={styles.row}>
+              <div style={{ minWidth: 0, flex: 1 }}>
+                <div style={styles.rowTitle}>
+                  {Number(row.amount).toLocaleString()} {campaign.asset_type} →{' '}
+                  <code style={styles.code}>{row.destination_key.slice(0, 6)}…{row.destination_key.slice(-4)}</code>
+                </div>
+                <div style={styles.meta}>{statusLabel(row)}</div>
+                {row.denial_reason && (
+                  <div className="alert alert--error" style={{ marginTop: '0.5rem', fontSize: '0.8rem' }}>
+                    {row.denial_reason}
+                  </div>
+                )}
+                {row.tx_hash && (
+                  <a
+                    href={stellarExpertTxUrl(row.tx_hash)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ fontSize: '0.82rem', color: '#7c3aed', fontWeight: 600 }}
+                  >
+                    View transaction
+                  </a>
+                )}
+                {openAudit === row.id && eventsById[row.id] && (
+                  <ol style={styles.audit}>
+                    {eventsById[row.id].map((ev) => (
+                      <li key={ev.id}>
+                        <strong>{ev.action}</strong>
+                        {ev.note ? ` — ${ev.note}` : ''}
+                        <span style={{ color: '#888' }}>
+                          {' '}
+                          ({new Date(ev.created_at).toLocaleString()})
+                        </span>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </div>
+              <div style={styles.actions}>
+                <button type="button" className="btn-secondary" onClick={() => loadEvents(row.id)} style={{ fontSize: '0.8rem' }}>
+                  {openAudit === row.id ? 'Hide audit' : 'Audit trail'}
+                </button>
+                {row.status === 'pending' && !row.creator_signed && isCreator && (
+                  <>
+                    <button
+                      type="button"
+                      className="btn-secondary"
+                      disabled={busyId === row.id}
+                      onClick={() =>
+                        runAction(row.id, () =>
+                          api.cancelWithdrawal(row.id, { reason: 'Cancelled by creator' }, token)
+                        )
+                      }
+                      style={{ fontSize: '0.8rem' }}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      className="btn-primary"
+                      disabled={busyId === row.id}
+                      onClick={() => runAction(row.id, () => api.approveWithdrawalCreator(row.id, token))}
+                      style={{ fontSize: '0.8rem' }}
+                    >
+                      Sign as creator
+                    </button>
+                  </>
+                )}
+                {row.status === 'pending' && row.creator_signed && !row.platform_signed && cap.can_approve_platform && (
+                  <>
+                    <button
+                      type="button"
+                      className="btn-secondary"
+                      disabled={busyId === row.id}
+                      onClick={async () => {
+                        const reason = window.prompt(
+                          'Rejection reason (visible in audit log):',
+                          'Rejected by platform'
+                        );
+                        if (reason === null) return;
+                        await runAction(row.id, () =>
+                          api.rejectWithdrawal(row.id, { reason: reason || 'Rejected' }, token)
+                        );
+                      }}
+                      style={{ fontSize: '0.8rem' }}
+                    >
+                      Reject
+                    </button>
+                    <button
+                      type="button"
+                      className="btn-primary"
+                      disabled={busyId === row.id}
+                      onClick={() => runAction(row.id, () => api.approveWithdrawalPlatform(row.id, token))}
+                      style={{ fontSize: '0.8rem' }}
+                    >
+                      Approve & submit
+                    </button>
+                  </>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {cap.can_approve_platform && (
+        <p style={{ ...styles.hint, marginTop: '1rem' }}>
+          Platform actions use the server key; your account is only checked for authorization. Set{' '}
+          <code>PLATFORM_APPROVER_USER_ID</code> in production to restrict this UI to ops staff.
+        </p>
+      )}
+    </section>
+  );
+}
+
+const styles = {
+  section: { marginTop: '2rem', paddingTop: '1.5rem', borderTop: '1px solid #e5e5e5' },
+  h2: { fontSize: '1.15rem', fontWeight: 800, marginBottom: '0.5rem' },
+  h3: { fontSize: '1rem', fontWeight: 700, marginBottom: '0.5rem' },
+  intro: { color: '#555', fontSize: '0.9rem', lineHeight: 1.55, marginBottom: '1rem' },
+  hint: { color: '#666', fontSize: '0.82rem', lineHeight: 1.45, marginBottom: '0.65rem' },
+  card: {
+    background: '#fff',
+    border: '1px solid #e5e5e5',
+    borderRadius: '10px',
+    padding: '1.1rem',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.25rem',
+  },
+  list: { listStyle: 'none', display: 'flex', flexDirection: 'column', gap: '0.75rem', margin: 0, padding: 0 },
+  row: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.65rem',
+    background: '#fff',
+    border: '1px solid #eee',
+    borderRadius: '10px',
+    padding: '0.85rem 1rem',
+  },
+  rowTitle: { fontSize: '0.9rem', fontWeight: 600, color: '#111' },
+  meta: { fontSize: '0.8rem', color: '#666' },
+  code: { fontSize: '0.78rem' },
+  actions: { display: 'flex', flexWrap: 'wrap', gap: '0.45rem', alignItems: 'center' },
+  audit: {
+    marginTop: '0.5rem',
+    paddingLeft: '1.1rem',
+    fontSize: '0.78rem',
+    color: '#444',
+    lineHeight: 1.5,
+  },
+};

--- a/frontend/src/config/stellar.js
+++ b/frontend/src/config/stellar.js
@@ -1,0 +1,6 @@
+const network = import.meta.env.VITE_STELLAR_NETWORK || 'testnet';
+
+export function stellarExpertTxUrl(hash) {
+  if (!hash) return '#';
+  return `https://stellar.expert/explorer/${network}/tx/${hash}`;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -32,6 +32,197 @@ input, textarea, select {
 }
 input:focus, textarea:focus, select:focus { border-color: #7c3aed; }
 
-.container { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem; }
-.btn-primary { background: #7c3aed; color: #fff; }
-.btn-secondary { background: #fff; color: #7c3aed; border: 1px solid #7c3aed; }
+.container { max-width: 1100px; margin: 0 auto; padding: 0 1.25rem; }
+@media (min-width: 768px) {
+  .container { padding: 0 1.5rem; }
+}
+
+.btn-primary { background: #7c3aed; color: #fff; min-height: 44px; }
+.btn-secondary { background: #fff; color: #7c3aed; border: 1px solid #7c3aed; min-height: 44px; }
+
+.page-narrow { max-width: 560px; margin: 0 auto; }
+.page-mid { max-width: 640px; margin: 0 auto; }
+
+.onboarding-callout {
+  background: linear-gradient(135deg, #f5f3ff 0%, #ede9fe 100%);
+  border: 1px solid #ddd6fe;
+  border-radius: 12px;
+  padding: 1rem 1.1rem;
+  margin-bottom: 1.5rem;
+}
+.onboarding-callout__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+@media (min-width: 640px) {
+  .onboarding-callout__inner {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+}
+.onboarding-callout__title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #5b21b6;
+  margin-bottom: 0.35rem;
+}
+.onboarding-callout__body {
+  font-size: 0.875rem;
+  color: #4c1d95;
+  line-height: 1.55;
+}
+.onboarding-callout__body ul {
+  margin: 0.35rem 0 0 1.1rem;
+  padding: 0;
+}
+.onboarding-callout__dismiss {
+  flex-shrink: 0;
+  align-self: flex-start;
+  background: #7c3aed;
+  color: #fff;
+  padding: 0.55rem 1rem;
+  font-size: 0.875rem;
+  border-radius: 8px;
+}
+
+.asset-picker {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+@media (min-width: 480px) {
+  .asset-picker { grid-template-columns: 1fr 1fr; }
+}
+
+.asset-picker__option {
+  position: relative;
+  display: block;
+  cursor: pointer;
+  border-radius: 12px;
+  border: 2px solid #e5e5e5;
+  background: #fff;
+  padding: 1rem 1rem 0.85rem;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  min-height: 88px;
+}
+.asset-picker__option:hover { border-color: #c4b5fd; }
+.asset-picker__option--selected {
+  border-color: #7c3aed;
+  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.12);
+}
+.asset-picker__option input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.asset-picker__code {
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: #111;
+  margin-bottom: 0.25rem;
+}
+.asset-picker__hint {
+  font-size: 0.8rem;
+  color: #666;
+  line-height: 1.4;
+}
+
+.form-stack { display: flex; flex-direction: column; gap: 0.25rem; }
+.form-stack + .form-stack { margin-top: 1rem; }
+
+.label-strong {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.alert {
+  border-radius: 10px;
+  padding: 0.75rem 0.9rem;
+  font-size: 0.875rem;
+  line-height: 1.45;
+}
+.alert--error {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+}
+.alert--info {
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  color: #1e40af;
+}
+.alert--success {
+  background: #ecfdf5;
+  border: 1px solid #a7f3d0;
+  color: #065f46;
+}
+
+.modal-shell {
+  width: 100%;
+  max-width: min(440px, calc(100vw - 1.5rem));
+  max-height: min(90vh, 640px);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.25rem 1.25rem 1.5rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+}
+@media (min-width: 480px) {
+  .modal-shell { padding: 1.5rem 1.75rem; }
+}
+
+.nav-inner-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  min-height: 56px;
+  padding: 0.35rem 0;
+}
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+@media (min-width: 480px) {
+  .nav-links { gap: 1rem; }
+}
+
+.campaign-card {
+  min-height: 148px;
+}
+.campaign-card:hover {
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+}
+
+.hero-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.75rem;
+  max-width: 360px;
+  margin: 0 auto;
+  width: 100%;
+}
+@media (min-width: 520px) {
+  .hero-actions--row-sm {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    max-width: none;
+  }
+  .hero-actions--row-sm > * {
+    flex: 0 0 auto;
+  }
+}

--- a/frontend/src/lib/onboarding.js
+++ b/frontend/src/lib/onboarding.js
@@ -1,0 +1,28 @@
+const CREATOR_KEY = 'cp_onboarding_creator_dismissed';
+const CONTRIBUTOR_KEY = 'cp_onboarding_contributor_dismissed';
+
+export function isCreatorOnboardingVisible() {
+  return localStorage.getItem(CREATOR_KEY) !== '1';
+}
+
+export function dismissCreatorOnboarding() {
+  localStorage.setItem(CREATOR_KEY, '1');
+}
+
+export function isContributorOnboardingVisible() {
+  return localStorage.getItem(CONTRIBUTOR_KEY) !== '1';
+}
+
+export function dismissContributorOnboarding() {
+  localStorage.setItem(CONTRIBUTOR_KEY, '1');
+}
+
+export function markJustRegistered() {
+  sessionStorage.setItem('cp_just_registered', '1');
+}
+
+export function consumeJustRegistered() {
+  if (sessionStorage.getItem('cp_just_registered') !== '1') return false;
+  sessionStorage.removeItem('cp_just_registered');
+  return true;
+}

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -1,28 +1,81 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { Link, useParams, useLocation } from 'react-router-dom';
 import { api } from '../services/api';
 import { useAuth } from '../context/AuthContext';
 import ContributeModal from '../components/ContributeModal';
 
 export default function Campaign() {
   const { id } = useParams();
-  const { user, token } = useAuth();
+  const location = useLocation();
+  const { user } = useAuth();
   const [campaign, setCampaign] = useState(null);
+  const [loadError, setLoadError] = useState('');
   const [contributions, setContributions] = useState([]);
   const [showModal, setShowModal] = useState(false);
   const [contributed, setContributed] = useState(false);
+  const [showCreatedBanner, setShowCreatedBanner] = useState(!!location.state?.created);
 
   useEffect(() => {
-    api.getCampaign(id).then(setCampaign).catch(console.error);
-    api.getContributions(id).then(setContributions).catch(console.error);
+    setLoadError('');
+    api
+      .getCampaign(id)
+      .then(setCampaign)
+      .catch((err) => setLoadError(err.message || 'Could not load campaign.'));
+    api.getContributions(id).then(setContributions).catch(() => setContributions([]));
   }, [id, contributed]);
 
-  if (!campaign) return <p style={{ padding: '3rem', color: '#999' }}>Loading…</p>;
+  useEffect(() => {
+    if (location.state?.created) {
+      window.history.replaceState({}, document.title);
+    }
+  }, [location.state]);
+
+  if (loadError && !campaign) {
+    return (
+      <main className="container page-narrow" style={{ paddingTop: '2.5rem' }}>
+        <p className="alert alert--error" role="alert">
+          {loadError}
+        </p>
+        <Link to="/" style={{ color: '#7c3aed', fontWeight: 600 }}>
+          ← Back home
+        </Link>
+      </main>
+    );
+  }
+
+  if (!campaign) {
+    return (
+      <main className="container" style={{ paddingTop: '3rem' }}>
+        <p style={{ color: '#666' }}>Loading campaign…</p>
+      </main>
+    );
+  }
 
   const pct = Math.min(100, (campaign.raised_amount / campaign.target_amount) * 100).toFixed(1);
 
   return (
     <main className="container" style={{ paddingTop: '2.5rem', paddingBottom: '4rem', maxWidth: '760px' }}>
+      {showCreatedBanner && (
+        <div className="alert alert--success" style={{ marginBottom: '1.25rem' }} role="status">
+          <strong>Campaign is live.</strong> Share the link — contributors can fund in XLM or USDC when conversion paths
+          are available.
+          <button
+            type="button"
+            onClick={() => setShowCreatedBanner(false)}
+            style={{
+              marginLeft: '0.5rem',
+              background: 'transparent',
+              color: '#065f46',
+              textDecoration: 'underline',
+              fontWeight: 600,
+              padding: 0,
+              minHeight: 'auto',
+            }}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
       <div style={styles.header}>
         <span style={styles.asset}>{campaign.asset_type}</span>
         <h1 style={styles.title}>{campaign.title}</h1>
@@ -43,11 +96,20 @@ export default function Campaign() {
         <div style={styles.bar}><div style={{ ...styles.fill, width: `${pct}%` }} /></div>
 
         {user ? (
-          <button className="btn-primary" style={styles.cta} onClick={() => setShowModal(true)}>
+          <button type="button" className="btn-primary" style={styles.cta} onClick={() => setShowModal(true)}>
             Contribute
           </button>
         ) : (
-          <p style={{ color: '#777', fontSize: '0.9rem' }}>Log in to contribute.</p>
+          <p style={{ color: '#555', fontSize: '0.9rem', lineHeight: 1.5 }}>
+            <Link to="/login" state={{ from: `/campaigns/${id}` }} style={{ color: '#7c3aed', fontWeight: 600 }}>
+              Log in
+            </Link>{' '}
+            or{' '}
+            <Link to="/register" style={{ color: '#7c3aed', fontWeight: 600 }}>
+              create an account
+            </Link>{' '}
+            to contribute. You will get a custodial Stellar wallet automatically.
+          </p>
         )}
       </div>
 
@@ -63,8 +125,19 @@ export default function Campaign() {
         <div style={styles.list}>
           {contributions.map((c) => (
             <div key={c.id} style={styles.row}>
-              <span style={styles.sender}>{c.sender_public_key.slice(0, 8)}…{c.sender_public_key.slice(-4)}</span>
-              <span style={styles.amount}>{Number(c.amount).toLocaleString()} {c.asset}</span>
+              <div style={{ minWidth: 0 }}>
+                <div style={styles.sender}>
+                  {c.sender_public_key.slice(0, 8)}…{c.sender_public_key.slice(-4)}
+                </div>
+                {c.payment_type === 'path_payment_strict_receive' && c.source_asset && c.source_amount != null && (
+                  <div style={styles.convHint}>
+                    via {Number(c.source_amount).toLocaleString()} {c.source_asset}
+                  </div>
+                )}
+              </div>
+              <span style={styles.amount}>
+                +{Number(c.amount).toLocaleString()} {c.asset}
+              </span>
             </div>
           ))}
         </div>
@@ -74,7 +147,7 @@ export default function Campaign() {
         <ContributeModal
           campaign={campaign}
           onClose={() => setShowModal(false)}
-          onSuccess={() => { setShowModal(false); setContributed((v) => !v); }}
+          onSuccess={() => setContributed((v) => !v)}
         />
       )}
     </main>
@@ -100,5 +173,6 @@ const styles = {
   list: { display: 'flex', flexDirection: 'column', gap: '0.5rem' },
   row: { display: 'flex', justifyContent: 'space-between', background: '#fff', border: '1px solid #eee', borderRadius: '6px', padding: '0.6rem 0.85rem' },
   sender: { fontSize: '0.85rem', color: '#555', fontFamily: 'monospace' },
-  amount: { fontSize: '0.85rem', fontWeight: 600 },
+  amount: { fontSize: '0.85rem', fontWeight: 600, flexShrink: 0 },
+  convHint: { fontSize: '0.72rem', color: '#888', marginTop: '0.15rem' },
 };

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -3,11 +3,12 @@ import { Link, useParams, useLocation } from 'react-router-dom';
 import { api } from '../services/api';
 import { useAuth } from '../context/AuthContext';
 import ContributeModal from '../components/ContributeModal';
+import WithdrawalsSection from '../components/WithdrawalsSection';
 
 export default function Campaign() {
   const { id } = useParams();
   const location = useLocation();
-  const { user } = useAuth();
+  const { user, token } = useAuth();
   const [campaign, setCampaign] = useState(null);
   const [loadError, setLoadError] = useState('');
   const [contributions, setContributions] = useState([]);
@@ -117,6 +118,17 @@ export default function Campaign() {
         <span style={styles.walletLabel}>Campaign wallet</span>
         <code style={styles.walletKey}>{campaign.wallet_public_key}</code>
       </div>
+
+      {token && (
+        <WithdrawalsSection
+          campaign={campaign}
+          user={user}
+          token={token}
+          onReleased={() => {
+            api.getCampaign(id).then(setCampaign).catch(() => {});
+          }}
+        />
+      )}
 
       <h2 style={styles.sectionTitle}>Contributions ({contributions.length})</h2>
       {contributions.length === 0 ? (

--- a/frontend/src/pages/CreateCampaign.jsx
+++ b/frontend/src/pages/CreateCampaign.jsx
@@ -1,76 +1,295 @@
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { api } from '../services/api';
 import { useAuth } from '../context/AuthContext';
+import OnboardingCallout from '../components/OnboardingCallout';
+import {
+  isCreatorOnboardingVisible,
+  dismissCreatorOnboarding,
+} from '../lib/onboarding';
+
+const ASSETS = [
+  {
+    value: 'USDC',
+    label: 'USDC',
+    hint: 'Stable dollar value on Stellar. Best when backers think in USD.',
+  },
+  {
+    value: 'XLM',
+    label: 'XLM',
+    hint: 'Native Stellar asset. Simple for contributors who already hold XLM.',
+  },
+];
 
 export default function CreateCampaign() {
   const { token } = useAuth();
   const navigate = useNavigate();
-  const [form, setForm] = useState({ title: '', description: '', target_amount: '', asset_type: 'USDC', deadline: '' });
+  const [step, setStep] = useState(1);
+  const [form, setForm] = useState({
+    title: '',
+    description: '',
+    target_amount: '',
+    asset_type: 'USDC',
+    deadline: '',
+  });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [showCreatorTips, setShowCreatorTips] = useState(isCreatorOnboardingVisible);
 
-  function set(field) {
+  useEffect(() => {
+    if (!token) {
+      navigate('/login', { replace: true, state: { from: '/campaigns/new' } });
+    }
+  }, [token, navigate]);
+
+  function setField(field) {
     return (e) => setForm((f) => ({ ...f, [field]: e.target.value }));
+  }
+
+  function selectAsset(value) {
+    setForm((f) => ({ ...f, asset_type: value }));
+  }
+
+  function dismissTips() {
+    dismissCreatorOnboarding();
+    setShowCreatorTips(false);
+  }
+
+  function validateStep1() {
+    if (!form.title.trim()) {
+      setError('Please enter a campaign title.');
+      return false;
+    }
+    if (!form.target_amount || Number(form.target_amount) <= 0) {
+      setError('Enter a fundraising goal greater than zero.');
+      return false;
+    }
+    setError('');
+    return true;
   }
 
   async function handleSubmit(e) {
     e.preventDefault();
+    if (!validateStep1()) return;
     setLoading(true);
     setError('');
     try {
-      const campaign = await api.createCampaign(form, token);
-      navigate(`/campaigns/${campaign.id}`);
+      const campaign = await api.createCampaign(
+        {
+          title: form.title.trim(),
+          description: form.description.trim() || undefined,
+          target_amount: form.target_amount,
+          asset_type: form.asset_type,
+          deadline: form.deadline || undefined,
+        },
+        token
+      );
+      navigate(`/campaigns/${campaign.id}`, { state: { created: true } });
     } catch (err) {
-      setError(err.message);
+      if (err.status === 401) {
+        setError('Your session expired. Please log in again.');
+        navigate('/login', { state: { from: '/campaigns/new' } });
+      } else {
+        setError(err.message || 'Could not create campaign. Try again.');
+      }
       setLoading(false);
     }
   }
 
+  if (!token) {
+    return (
+      <main className="container page-narrow" style={{ paddingTop: '3rem' }}>
+        <p className="alert alert--info">Redirecting to sign in…</p>
+      </main>
+    );
+  }
+
   return (
-    <main className="container" style={{ paddingTop: '2.5rem', maxWidth: '560px' }}>
-      <h1 style={styles.title}>Start a campaign</h1>
-      <p style={styles.sub}>A Stellar wallet will be created for your campaign automatically.</p>
+    <main className="container page-mid" style={{ paddingTop: '1.75rem', paddingBottom: '3rem' }}>
+      <nav aria-label="Progress" style={{ marginBottom: '1.25rem' }}>
+        <ol
+          style={{
+            listStyle: 'none',
+            display: 'flex',
+            gap: '0.5rem',
+            flexWrap: 'wrap',
+            fontSize: '0.8rem',
+            fontWeight: 600,
+            color: '#666',
+          }}
+        >
+          <li>
+            <span style={{ color: step === 1 ? '#7c3aed' : '#999' }}>1. Goal & asset</span>
+          </li>
+          <li aria-hidden="true">→</li>
+          <li>
+            <span style={{ color: step === 2 ? '#7c3aed' : '#999' }}>2. Details & launch</span>
+          </li>
+        </ol>
+      </nav>
 
-      <form onSubmit={handleSubmit} style={styles.form}>
-        <label style={styles.label}>Title</label>
-        <input value={form.title} onChange={set('title')} placeholder="Campaign title" required style={{ marginBottom: '1rem' }} />
+      <h1 style={{ fontSize: 'clamp(1.5rem, 4vw, 1.85rem)', fontWeight: 800, marginBottom: '0.35rem' }}>
+        Start a campaign
+      </h1>
+      <p style={{ color: '#555', marginBottom: '1.25rem', fontSize: '0.95rem', lineHeight: 1.55 }}>
+        We create a dedicated Stellar wallet for your campaign. You choose whether the goal is tracked in{' '}
+        <strong>USDC</strong> or <strong>XLM</strong> — contributors can still pay from either asset when paths exist.
+      </p>
 
-        <label style={styles.label}>Description</label>
-        <textarea value={form.description} onChange={set('description')} rows={4} placeholder="What are you raising funds for?" style={{ marginBottom: '1rem', resize: 'vertical' }} />
+      {showCreatorTips && (
+        <OnboardingCallout title="First time creating a campaign?" onDismiss={dismissTips}>
+          <ul>
+            <li>Pick the asset that matches how you think about your goal (USD-like vs XLM).</li>
+            <li>Withdrawals need both you and CrowdPay to sign — funds stay in escrow until then.</li>
+            <li>You can edit the story in the description; the title should be clear for backers.</li>
+          </ul>
+        </OnboardingCallout>
+      )}
 
-        <div style={styles.row}>
-          <div style={{ flex: 1 }}>
-            <label style={styles.label}>Target amount</label>
-            <input type="number" min="1" step="any" value={form.target_amount} onChange={set('target_amount')} placeholder="0.00" required style={{ marginBottom: '1rem' }} />
-          </div>
-          <div style={{ width: '130px' }}>
-            <label style={styles.label}>Asset</label>
-            <select value={form.asset_type} onChange={set('asset_type')} style={{ marginBottom: '1rem' }}>
-              <option value="USDC">USDC</option>
-              <option value="XLM">XLM</option>
-            </select>
-          </div>
-        </div>
+      <form onSubmit={handleSubmit}>
+        {step === 1 && (
+          <>
+            <div className="form-stack">
+              <label className="label-strong" htmlFor="cc-title">
+                Campaign title
+              </label>
+              <input
+                id="cc-title"
+                value={form.title}
+                onChange={setField('title')}
+                placeholder="e.g. Community garden rebuild"
+                required
+                autoComplete="off"
+              />
+            </div>
 
-        <label style={styles.label}>Deadline (optional)</label>
-        <input type="date" value={form.deadline} onChange={set('deadline')} style={{ marginBottom: '1.5rem' }} />
+            <div className="form-stack" style={{ marginTop: '1rem' }}>
+              <label className="label-strong" htmlFor="cc-target">
+                Fundraising goal
+              </label>
+              <input
+                id="cc-target"
+                type="number"
+                inputMode="decimal"
+                min="0.0000001"
+                step="any"
+                value={form.target_amount}
+                onChange={setField('target_amount')}
+                placeholder="0.00"
+                required
+              />
+            </div>
 
-        {error && <p style={styles.error}>{error}</p>}
+            <fieldset style={{ border: 'none', margin: '1.25rem 0 0', padding: 0 }}>
+              <legend className="label-strong" style={{ marginBottom: '0.5rem' }}>
+                Settlement asset
+              </legend>
+              <p style={{ fontSize: '0.8rem', color: '#666', marginBottom: '0.65rem' }}>
+                Progress and payouts use this asset. Contributors may use a different asset if Stellar can convert it.
+              </p>
+              <div className="asset-picker" role="radiogroup" aria-label="Settlement asset">
+                {ASSETS.map((a) => (
+                  <label
+                    key={a.value}
+                    className={`asset-picker__option${form.asset_type === a.value ? ' asset-picker__option--selected' : ''}`}
+                  >
+                    <input
+                      type="radio"
+                      name="asset_type"
+                      value={a.value}
+                      checked={form.asset_type === a.value}
+                      onChange={() => selectAsset(a.value)}
+                    />
+                    <div className="asset-picker__code">{a.label}</div>
+                    <div className="asset-picker__hint">{a.hint}</div>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
 
-        <button type="submit" className="btn-primary" disabled={loading} style={{ padding: '0.85rem', fontSize: '1rem' }}>
-          {loading ? 'Creating wallet…' : 'Launch campaign'}
-        </button>
+            {error && (
+              <p className="alert alert--error" style={{ marginTop: '1rem' }} role="alert">
+                {error}
+              </p>
+            )}
+
+            <button
+              type="button"
+              className="btn-primary"
+              style={{ width: '100%', marginTop: '1.25rem' }}
+              onClick={() => {
+                if (validateStep1()) setStep(2);
+              }}
+            >
+              Continue to details
+            </button>
+          </>
+        )}
+
+        {step === 2 && (
+          <>
+            <div className="form-stack">
+              <label className="label-strong" htmlFor="cc-desc">
+                Description <span style={{ fontWeight: 500, color: '#888' }}>(optional)</span>
+              </label>
+              <textarea
+                id="cc-desc"
+                value={form.description}
+                onChange={setField('description')}
+                rows={5}
+                placeholder="Tell backers what the funds will be used for and any milestones."
+                style={{ resize: 'vertical', minHeight: '120px' }}
+              />
+            </div>
+
+            <div className="form-stack" style={{ marginTop: '1rem' }}>
+              <label className="label-strong" htmlFor="cc-deadline">
+                Deadline <span style={{ fontWeight: 500, color: '#888' }}>(optional)</span>
+              </label>
+              <input id="cc-deadline" type="date" value={form.deadline} onChange={setField('deadline')} />
+            </div>
+
+            <div
+              className="alert alert--info"
+              style={{ marginTop: '1.25rem' }}
+              role="status"
+            >
+              <strong>Summary:</strong> Goal of {form.target_amount || '—'} {form.asset_type} — “{form.title || 'Untitled'}”.
+              A multisig campaign wallet will be created when you launch.
+            </div>
+
+            {error && (
+              <p className="alert alert--error" style={{ marginTop: '1rem' }} role="alert">
+                {error}
+              </p>
+            )}
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.65rem', marginTop: '1.25rem' }}>
+              <button type="submit" className="btn-primary" disabled={loading} style={{ width: '100%' }}>
+                {loading ? 'Creating wallet…' : 'Launch campaign'}
+              </button>
+              <button
+                type="button"
+                className="btn-secondary"
+                style={{ width: '100%' }}
+                disabled={loading}
+                onClick={() => {
+                  setError('');
+                  setStep(1);
+                }}
+              >
+                Back
+              </button>
+            </div>
+          </>
+        )}
       </form>
+
+      <p style={{ marginTop: '1.5rem', fontSize: '0.85rem', color: '#777' }}>
+        <Link to="/" style={{ color: '#7c3aed', fontWeight: 600 }}>
+          ← Back to campaigns
+        </Link>
+      </p>
     </main>
   );
 }
-
-const styles = {
-  title: { fontSize: '1.75rem', fontWeight: 800, marginBottom: '0.4rem' },
-  sub: { color: '#666', marginBottom: '1.75rem', fontSize: '0.95rem' },
-  form: { display: 'flex', flexDirection: 'column' },
-  label: { fontSize: '0.85rem', fontWeight: 600, color: '#444', marginBottom: '0.3rem' },
-  row: { display: 'flex', gap: '1rem' },
-  error: { color: '#dc2626', fontSize: '0.875rem', marginBottom: '1rem' },
-};

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -3,50 +3,133 @@ import { Link } from 'react-router-dom';
 import { api } from '../services/api';
 import CampaignCard from '../components/CampaignCard';
 import { useAuth } from '../context/AuthContext';
+import OnboardingCallout from '../components/OnboardingCallout';
+import {
+  isContributorOnboardingVisible,
+  dismissContributorOnboarding,
+  consumeJustRegistered,
+} from '../lib/onboarding';
 
 export default function Home() {
   const [campaigns, setCampaigns] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [listError, setListError] = useState('');
   const { user } = useAuth();
+  const [showContributorTips, setShowContributorTips] = useState(isContributorOnboardingVisible);
+  const [welcomeNewUser, setWelcomeNewUser] = useState(false);
 
   useEffect(() => {
-    api.getCampaigns()
+    if (consumeJustRegistered()) {
+      setWelcomeNewUser(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    setListError('');
+    api
+      .getCampaigns()
       .then(setCampaigns)
-      .catch(console.error)
+      .catch((err) => setListError(err.message || 'Could not load campaigns.'))
       .finally(() => setLoading(false));
   }, []);
 
+  function dismissContributorTips() {
+    dismissContributorOnboarding();
+    setShowContributorTips(false);
+  }
+
   return (
-    <main className="container" style={{ paddingTop: '2.5rem', paddingBottom: '4rem' }}>
+    <main className="container" style={{ paddingTop: '1.5rem', paddingBottom: '4rem' }}>
+      {welcomeNewUser && (
+        <div className="alert alert--success" style={{ marginBottom: '1rem' }} role="status">
+          <strong>Welcome to CrowdPay.</strong> Your account includes a custodial Stellar wallet. Explore active
+          campaigns and fund one in seconds.
+          <button
+            type="button"
+            onClick={() => setWelcomeNewUser(false)}
+            style={{
+              marginLeft: '0.5rem',
+              background: 'transparent',
+              color: '#065f46',
+              fontWeight: 600,
+              textDecoration: 'underline',
+              padding: 0,
+              minHeight: 'auto',
+            }}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {user && showContributorTips && (
+        <OnboardingCallout title="How contributing works" onDismiss={dismissContributorTips}>
+          <ul>
+            <li>Each campaign settles in either USDC or XLM — that is what moves the progress bar.</li>
+            <li>You can pay with XLM or USDC; if they differ, Stellar converts automatically when a path exists.</li>
+            <li>Watch for live quotes in the contribute window before you confirm.</li>
+          </ul>
+        </OnboardingCallout>
+      )}
+
       <div style={styles.hero}>
         <h1 style={styles.h1}>Fund anything, from anywhere.</h1>
         <p style={styles.sub}>
-          CrowdPay settles contributions on Stellar — instant, cross-border, and in any currency.
+          CrowdPay runs on Stellar: fast settlement, optional cross-asset conversion, and a clear path from pledge to
+          on-chain receipt.
         </p>
         {user ? (
-          <Link to="/campaigns/new">
-            <button className="btn-primary" style={{ fontSize: '1rem', padding: '0.75rem 1.75rem' }}>
-              Start a campaign
-            </button>
-          </Link>
+          <div className="hero-actions">
+            <Link to="/campaigns/new" style={{ width: '100%' }}>
+              <button type="button" className="btn-primary" style={{ fontSize: '1rem', padding: '0.75rem 1.5rem', width: '100%' }}>
+                Start a campaign
+              </button>
+            </Link>
+            <span style={styles.muted}>or browse below and tap a card to contribute.</span>
+          </div>
         ) : (
-          <Link to="/register">
-            <button className="btn-primary" style={{ fontSize: '1rem', padding: '0.75rem 1.75rem' }}>
-              Get started
-            </button>
-          </Link>
+          <div className="hero-actions hero-actions--row-sm">
+            <Link to="/register" style={{ flex: '1 1 140px', minWidth: '140px' }}>
+              <button type="button" className="btn-primary" style={{ fontSize: '1rem', padding: '0.75rem 1.5rem', width: '100%' }}>
+                Create account
+              </button>
+            </Link>
+            <Link to="/login" style={{ flex: '1 1 140px', minWidth: '140px' }}>
+              <button type="button" className="btn-secondary" style={{ fontSize: '1rem', padding: '0.75rem 1.5rem', width: '100%' }}>
+                Log in
+              </button>
+            </Link>
+          </div>
         )}
       </div>
 
       <h2 style={styles.sectionTitle}>Active campaigns</h2>
 
       {loading ? (
-        <p style={{ color: '#999' }}>Loading…</p>
+        <p style={{ color: '#666' }}>Loading campaigns…</p>
+      ) : listError ? (
+        <p className="alert alert--error" role="alert">
+          {listError}
+        </p>
       ) : campaigns.length === 0 ? (
-        <p style={{ color: '#999' }}>No campaigns yet. Be the first.</p>
+        <div className="alert alert--info">
+          {user ? (
+            <>
+              No campaigns yet.{' '}
+              <Link to="/campaigns/new" style={{ color: '#1e40af', fontWeight: 700 }}>
+                Launch the first one
+              </Link>
+              .
+            </>
+          ) : (
+            <>No public campaigns yet. Sign up to get notified when you create or back the first project.</>
+          )}
+        </div>
       ) : (
         <div style={styles.grid}>
-          {campaigns.map((c) => <CampaignCard key={c.id} campaign={c} />)}
+          {campaigns.map((c) => (
+            <CampaignCard key={c.id} campaign={c} />
+          ))}
         </div>
       )}
     </main>
@@ -54,9 +137,17 @@ export default function Home() {
 }
 
 const styles = {
-  hero: { textAlign: 'center', padding: '3rem 0 3.5rem' },
-  h1: { fontSize: 'clamp(2rem, 5vw, 3rem)', fontWeight: 800, marginBottom: '1rem', color: '#111' },
-  sub: { fontSize: '1.1rem', color: '#555', marginBottom: '1.75rem', maxWidth: '500px', margin: '0 auto 1.75rem' },
-  sectionTitle: { fontSize: '1.25rem', fontWeight: 700, marginBottom: '1.25rem', color: '#111' },
-  grid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))', gap: '1.25rem' },
+  hero: { textAlign: 'center', padding: '2rem 0 2.5rem' },
+  h1: { fontSize: 'clamp(1.85rem, 5vw, 2.85rem)', fontWeight: 800, marginBottom: '1rem', color: '#111' },
+  sub: {
+    fontSize: 'clamp(0.95rem, 2.5vw, 1.1rem)',
+    color: '#555',
+    marginBottom: '1.5rem',
+    maxWidth: '560px',
+    margin: '0 auto 1.5rem',
+    lineHeight: 1.55,
+  },
+  muted: { fontSize: '0.85rem', color: '#777', maxWidth: '320px', lineHeight: 1.4, textAlign: 'center' },
+  sectionTitle: { fontSize: '1.2rem', fontWeight: 700, marginBottom: '1.1rem', color: '#111' },
+  grid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(min(100%, 300px), 1fr))', gap: '1.25rem' },
 };

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { api } from '../services/api';
 import { useAuth } from '../context/AuthContext';
 
 export default function Login() {
   const { login } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const [form, setForm] = useState({ email: '', password: '' });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -19,9 +20,10 @@ export default function Login() {
     try {
       const { token, user } = await api.login(form);
       login(user, token);
-      navigate('/');
+      navigate(location.state?.from || '/', { replace: true });
     } catch (err) {
       setError(err.message);
+    } finally {
       setLoading(false);
     }
   }

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { api } from '../services/api';
 import { useAuth } from '../context/AuthContext';
+import { markJustRegistered } from '../lib/onboarding';
 
 export default function Register() {
   const { login } = useAuth();
@@ -19,9 +20,11 @@ export default function Register() {
     try {
       const { token, user } = await api.register(form);
       login(user, token);
+      markJustRegistered();
       navigate('/');
     } catch (err) {
       setError(err.message);
+    } finally {
       setLoading(false);
     }
   }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -59,4 +59,16 @@ export const api = {
     request('GET', '/contributions/quote', null, token, {
       query: { send_asset, dest_asset, dest_amount },
     }),
+
+  getWithdrawalCapabilities: (token) => request('GET', '/withdrawals/capabilities', null, token),
+  listWithdrawals: (campaignId, token) =>
+    request('GET', `/withdrawals/campaign/${campaignId}`, null, token),
+  requestWithdrawal: (body, token) => request('POST', '/withdrawals/request', body, token),
+  approveWithdrawalCreator: (id, token) =>
+    request('POST', `/withdrawals/${id}/approve/creator`, {}, token),
+  approveWithdrawalPlatform: (id, token) =>
+    request('POST', `/withdrawals/${id}/approve/platform`, {}, token),
+  cancelWithdrawal: (id, body, token) => request('POST', `/withdrawals/${id}/cancel`, body || {}, token),
+  rejectWithdrawal: (id, body, token) => request('POST', `/withdrawals/${id}/reject`, body || {}, token),
+  getWithdrawalEvents: (id, token) => request('GET', `/withdrawals/${id}/events`, null, token),
 };

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -7,29 +7,56 @@ function authHeaders(token) {
   };
 }
 
-async function request(method, path, body, token) {
-  const res = await fetch(`${BASE}${path}`, {
+async function request(method, path, body, token, options = {}) {
+  const { query } = options;
+  let url = `${BASE}${path}`;
+  if (query && Object.keys(query).length) {
+    const params = new URLSearchParams();
+    Object.entries(query).forEach(([k, v]) => {
+      if (v !== undefined && v !== null && v !== '') params.set(k, String(v));
+    });
+    url += `?${params.toString()}`;
+  }
+
+  const res = await fetch(url, {
     method,
     headers: authHeaders(token),
     body: body ? JSON.stringify(body) : undefined,
   });
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.error || 'Request failed');
+
+  const text = await res.text();
+  let data = {};
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch {
+      throw new Error('Unexpected server response. Please try again.');
+    }
+  }
+
+  if (!res.ok) {
+    const msg = data.error || `Request failed (${res.status})`;
+    const err = new Error(msg);
+    err.status = res.status;
+    throw err;
+  }
+
   return data;
 }
 
 export const api = {
-  // Auth
   register: (body) => request('POST', '/users/register', body),
   login: (body) => request('POST', '/users/login', body),
 
-  // Campaigns
   getCampaigns: () => request('GET', '/campaigns'),
   getCampaign: (id) => request('GET', `/campaigns/${id}`),
   getCampaignBalance: (id) => request('GET', `/campaigns/${id}/balance`),
   createCampaign: (body, token) => request('POST', '/campaigns', body, token),
 
-  // Contributions
   getContributions: (campaignId) => request('GET', `/contributions/campaign/${campaignId}`),
   contribute: (body, token) => request('POST', '/contributions', body, token),
+  quoteContribution: ({ send_asset, dest_asset, dest_amount }, token) =>
+    request('GET', '/contributions/quote', null, token, {
+      query: { send_asset, dest_asset, dest_amount },
+    }),
 };


### PR DESCRIPTION
closes #4

## Summary
This change delivers MVP **manual campaign fund release** with **creator + platform** approval, a **durable audit trail** for every step, and a **campaign-page UI** so the process is transparent and operable without ad-hoc tools.

## Backend
- Add `withdrawal_approval_events` for immutable audit rows (`requested`, `creator_signed`, `platform_signed`, `creator_cancelled`, `platform_rejected`, `submit_failed`) with optional `note` and `metadata` JSON.
- Extend `withdrawal_requests` with `denied` status and `denial_reason`.
- Harden withdrawal flow:
  - Only **one pending** withdrawal per campaign.
  - New requests only when campaign status is **`active` or `funded`**.
  - Creator signature blocked if campaign is no longer eligible.
  - Platform submit failures mark request **`failed`** and log **`submit_failed`** (no silent failure).
- **Cancel** (creator, before creator signs) and **reject** (platform, after creator signs, before platform signs) with logged reasons.
- **Authorization**: list + audit endpoints restricted to **campaign creator** or a **configured platform approver** (`PLATFORM_APPROVER_USER_ID`). Platform approve/reject still respects the same env gate for production; dev behavior documented in `API.md`.
- SQL migration: `backend/db/migrations/20260423_withdrawal_approval_audit.sql` (apply on existing DBs).

## Frontend
- New `WithdrawalsSection` on the campaign page: request form, status, cancel / sign / reject / approve actions, expandable **audit trail**, Stellar explorer link when `tx_hash` exists.
- API client methods for capabilities, withdrawals, events, cancel, reject.

## Docs
- `backend/API.md` updated for new/changed endpoints and audit model.
- `backend/.env.example` documents `PLATFORM_APPROVER_USER_ID`.

## Test plan
- [x] `npm --prefix backend test` (includes withdrawal + audit path coverage)
- [ ] Apply migration on a staging DB and smoke-test: request → creator sign → platform approve → on-chain tx
- [ ] Smoke-test cancel (pre–creator sign) and reject (post–creator sign) + audit log visibility for creator vs platform user
- [ ] Set `PLATFORM_APPROVER_USER_ID` in a prod-like env and confirm non-approvers cannot list events or approve/reject