### PR TITLE
feat: real-time campaign funding progress via SSE (#18)

### DIFF
--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -7,7 +7,7 @@ const {
   getSupportedAssetCodes,
   buildWithdrawalTransaction,
 } = require('../services/stellarService');
-const { watchCampaignWallet } = require('../services/ledgerMonitor');
+const { watchCampaignWallet, addSSEClient, removeSSEClient } = require('../services/ledgerMonitor');
 const { insertWithdrawalPendingSignatures } = require('../services/stellarTransactionService');
 const { sendEmail } = require('../services/emailService');
 const SUPPORTED_ASSETS = getSupportedAssetCodes();
@@ -77,6 +77,36 @@ router.get('/:id', async (req, res) => {
   const { rows } = await db.query('SELECT * FROM campaigns WHERE id = $1', [req.params.id]);
   if (!rows.length) return res.status(404).json({ error: 'Campaign not found' });
   res.json(rows[0]);
+});
+
+// SSE stream for real-time campaign funding updates
+router.get('/:id/stream', async (req, res) => {
+  const campaignId = parseInt(req.params.id, 10);
+  const { rows } = await db.query('SELECT id FROM campaigns WHERE id = $1', [campaignId]);
+  if (!rows.length) return res.status(404).json({ error: 'Campaign not found' });
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+  res.flushHeaders();
+
+  res.write('data: {"type":"connected"}\n\n');
+
+  addSSEClient(campaignId, res);
+
+  const heartbeat = setInterval(() => {
+    try {
+      res.write(': heartbeat\n\n');
+    } catch {
+      clearInterval(heartbeat);
+    }
+  }, 25000);
+
+  req.on('close', () => {
+    clearInterval(heartbeat);
+    removeSSEClient(campaignId, res);
+  });
 });
 
 // Get live on-chain balance for a campaign

--- a/backend/src/services/ledgerMonitor.js
+++ b/backend/src/services/ledgerMonitor.js
@@ -17,6 +17,37 @@ const streamRegistry = new Map();
 /** Consecutive stream failures per wallet (survives registry clears between errors). */
 const reconnectAttempts = new Map();
 
+// Map of campaignId -> Set<res> for SSE clients
+const sseClients = new Map();
+
+function addSSEClient(campaignId, res) {
+  if (!sseClients.has(campaignId)) {
+    sseClients.set(campaignId, new Set());
+  }
+  sseClients.get(campaignId).add(res);
+}
+
+function removeSSEClient(campaignId, res) {
+  const clients = sseClients.get(campaignId);
+  if (clients) {
+    clients.delete(res);
+    if (clients.size === 0) sseClients.delete(campaignId);
+  }
+}
+
+function broadcastCampaignUpdate(campaignId, data) {
+  const clients = sseClients.get(campaignId);
+  if (!clients || clients.size === 0) return;
+  const payload = `data: ${JSON.stringify(data)}\n\n`;
+  for (const res of clients) {
+    try {
+      res.write(payload);
+    } catch {
+      // client likely disconnected; cleanup handled by close event
+    }
+  }
+}
+
 const MAX_RECONNECT_DELAY_MS = 60_000;
 
 function extractPagingToken(record) {
@@ -214,6 +245,11 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
       );
     }
 
+    const { rows: updatedCampaign } = await client.query(
+      'SELECT raised_amount FROM campaigns WHERE id = $1',
+      [campaignId]
+    );
+
     await client.query('COMMIT');
     postCommitHooks = {
       creatorId,
@@ -234,6 +270,24 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
     console.log(
       `[monitor] Contribution indexed: ${destinationAmount} ${destinationAsset} -> campaign ${campaignId}`
     );
+
+    broadcastCampaignUpdate(campaignId, {
+      type: 'contribution',
+      contribution: {
+        id: inserted[0].id,
+        campaign_id: campaignId,
+        sender_public_key: payment.from,
+        amount: destinationAmount,
+        asset: destinationAsset,
+        payment_type: paymentType,
+        source_amount: sourceAmount,
+        source_asset: sourceAsset,
+        conversion_rate: conversionRate,
+        path,
+        tx_hash: txHash,
+      },
+      raised_amount: updatedCampaign[0]?.raised_amount,
+    });
   } catch (err) {
     try {
       await client.query('ROLLBACK');
@@ -437,4 +491,6 @@ module.exports = {
   watchCampaignWallet,
   handlePayment,
   getLedgerStreamHealth,
+  addSSEClient,
+  removeSSEClient,
 };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -246,3 +246,8 @@ input:focus, textarea:focus, select:focus { border-color: #7c3aed; }
   padding: 1.25rem;
   min-height: 148px;
 }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(0.85); }
+}

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -44,6 +44,7 @@ export default function Campaign() {
   const [updateForm, setUpdateForm] = useState({ title: '', body: '' });
   const [updateBusy, setUpdateBusy] = useState(false);
   const [updatesError, setUpdatesError] = useState('');
+  const [isLive, setIsLive] = useState(false);
 
   useEffect(() => {
     setLoadError('');
@@ -55,6 +56,39 @@ export default function Campaign() {
     api.getMilestones(id).then(setMilestones).catch(() => setMilestones([]));
     api.getCampaignUpdates(id, { limit: 20 }).then(setUpdates).catch(() => setUpdates([]));
   }, [id, contributed]);
+
+  useEffect(() => {
+    if (!window.EventSource) return;
+
+    const es = new EventSource(`/api/campaigns/${id}/stream`);
+
+    es.onopen = () => setIsLive(true);
+
+    es.onmessage = (e) => {
+      let msg;
+      try { msg = JSON.parse(e.data); } catch { return; }
+
+      if (msg.type === 'contribution') {
+        setCampaign((prev) =>
+          prev ? { ...prev, raised_amount: msg.raised_amount } : prev
+        );
+        setContributions((prev) => {
+          const exists = prev.some((c) => c.tx_hash === msg.contribution.tx_hash);
+          return exists ? prev : [msg.contribution, ...prev];
+        });
+      }
+    };
+
+    es.onerror = () => {
+      setIsLive(false);
+      es.close();
+    };
+
+    return () => {
+      es.close();
+      setIsLive(false);
+    };
+  }, [id]);
 
   useEffect(() => {
     if (location.state?.created) {
@@ -240,6 +274,12 @@ export default function Campaign() {
 
       <h2 style={styles.sectionTitle}>
         Contributions {contributions !== null ? `(${contributions.length})` : ''}
+        {isLive && (
+          <span style={styles.liveIndicator} title="Live updates active">
+            <span style={styles.liveDot} />
+            Live
+          </span>
+        )}
       </h2>
       {contributions === null ? (
         <ContributionListSkeleton />
@@ -309,4 +349,6 @@ const styles = {
   amount: { fontSize: '0.85rem', fontWeight: 600, flexShrink: 0 },
   convHint: { fontSize: '0.72rem', color: '#888', marginTop: '0.15rem' },
   refundTag: { marginTop: '0.45rem', fontSize: '0.75rem', color: '#7c3aed', fontWeight: 700 },
+  liveIndicator: { display: 'inline-flex', alignItems: 'center', gap: '4px', marginLeft: '0.5rem', fontSize: '0.72rem', fontWeight: 600, color: '#16a34a', verticalAlign: 'middle' },
+  liveDot: { display: 'inline-block', width: '7px', height: '7px', borderRadius: '50%', background: '#16a34a', animation: 'pulse 1.5s ease-in-out infinite' },
 };

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,7 +6,17 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/api': 'http://localhost:3001',
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+        configure: (proxy) => {
+          proxy.on('proxyReq', (proxyReq, req) => {
+            if (req.url?.includes('/stream')) {
+              proxyReq.setHeader('Accept', 'text/event-stream');
+            }
+          });
+        },
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

Closes #18 — implements real-time campaign funding progress via Server-Sent Events.

### Backend (`backend/src/`)

- **`services/ledgerMonitor.js`** — maintains a `Map<campaignId, Set<res>>` of connected SSE clients. After each payment is successfully indexed, it broadcasts a `contribution` event carrying the new contribution row and the updated `raised_amount` to all clients watching that campaign. Adds `addSSEClient` / `removeSSEClient` helpers.
- **`routes/campaigns.js`** — new `GET /campaigns/:id/stream` endpoint that:
  - Sets `Content-Type: text/event-stream` headers and flushes immediately
  - Sends an initial `{"type":"connected"}` event so the client knows the stream is up
  - Sends a `: heartbeat` comment every 25 s to keep the connection alive through proxies
  - Removes the client from the map cleanly on `req.close`

### Frontend (`frontend/src/`)

- **`pages/Campaign.jsx`** — adds a second `useEffect` scoped to `id` that opens an `EventSource` to `/api/campaigns/:id/stream`. On each `contribution` message it:
  - Updates `campaign.raised_amount` (progress bar re-renders reactively)
  - Prepends the new contribution to the list (deduplicated by `tx_hash`)
  - Falls back gracefully if `window.EventSource` is unavailable (existing fetch-on-mount behaviour unchanged)
  - Closes the `EventSource` on unmount
- Tracks a `isLive` boolean; when `true`, shows an animated green **Live** badge next to the contribution count.
- **`index.css`** — adds the `@keyframes pulse` animation for the live dot.
- **`vite.config.js`** — configures the `/api` proxy to forward `Accept: text/event-stream` on stream requests so Vite's dev server doesn't buffer SSE frames.

## Test plan

- [ ] Open a campaign page → check network tab shows `stream` request with `text/event-stream` response type and `200` status
- [ ] Submit a contribution → verify progress bar updates and new row appears in the list within ~5 s without refreshing
- [ ] Open the same campaign in two tabs simultaneously → both tabs should update
- [ ] Navigate away from the campaign page → confirm the SSE connection closes (no lingering request in network tab)
- [ ] Disable JavaScript's `EventSource` (or test in a context without it) → page loads and shows data via the existing fetch-on-mount path