### PR TITLE
Implement role-based access, dashboards, and campaign updates

### DIFF
--- a/backend/db/migrations/20260425_roles_dashboards_and_campaign_updates.sql
+++ b/backend/db/migrations/20260425_roles_dashboards_and_campaign_updates.sql
@@ -1,0 +1,19 @@
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS role TEXT NOT NULL DEFAULT 'contributor'
+  CHECK (role IN ('contributor', 'creator', 'admin'));
+
+UPDATE users
+SET role = 'admin'
+WHERE is_admin = TRUE;
+
+CREATE TABLE IF NOT EXISTS campaign_updates (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id     UUID NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  author_id       UUID NOT NULL REFERENCES users(id),
+  title           TEXT NOT NULL,
+  body            TEXT NOT NULL,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS campaign_updates_campaign_idx
+  ON campaign_updates (campaign_id, created_at DESC);

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -9,6 +9,8 @@ CREATE TABLE users (
   name                    TEXT NOT NULL,
   wallet_public_key       TEXT UNIQUE NOT NULL,
   wallet_secret_encrypted TEXT NOT NULL,  -- encrypt with KMS in production
+  role                    TEXT NOT NULL DEFAULT 'contributor'
+                          CHECK (role IN ('contributor', 'creator', 'admin')),
   is_admin                BOOLEAN DEFAULT FALSE,
   created_at              TIMESTAMPTZ DEFAULT NOW()
 );
@@ -183,6 +185,17 @@ CREATE TABLE milestones (
 );
 
 CREATE INDEX milestones_campaign_idx ON milestones (campaign_id);
+
+CREATE TABLE campaign_updates (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id     UUID NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  author_id       UUID NOT NULL REFERENCES users(id),
+  title           TEXT NOT NULL,
+  body            TEXT NOT NULL,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX campaign_updates_campaign_idx ON campaign_updates (campaign_id, created_at DESC);
 
 -- Horizon paging cursor per campaign wallet (survives restarts; enables replay + stream resume)
 CREATE TABLE ledger_stream_cursors (

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "express-rate-limit": "^8.4.1",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
+        "nodemailer": "^8.0.6",
         "pg": "^8.11.5",
         "winston": "^3.19.0"
       },

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "express-rate-limit": "^8.4.1",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
+    "nodemailer": "^8.0.6",
     "pg": "^8.11.5",
     "winston": "^3.19.0"
   },

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -41,13 +41,25 @@ async function authenticate(req) {
 }
 
 function requireAdmin(req, res, next) {
-  if (!req.user || !req.user.is_admin) {
+  if (!req.user || req.user.role !== 'admin') {
     return res.status(403).json({ error: 'Requires admin role' });
   }
   next();
 }
 
-module.exports = { requireAuth, requireAdmin };
+function requireRole(...roles) {
+  const allowed = new Set(roles);
+  return (req, res, next) => {
+    if (!req.user || !req.user.role) {
+      return res.status(403).json({ error: 'Requires authenticated user role' });
+    }
+    if (!allowed.has(req.user.role)) {
+      return res.status(403).json({ error: 'Insufficient role for this action' });
+    }
+    next();
+  };
+}
+
 /**
  * API keys carry scope arrays. JWT sessions retain full access.
  * @returns {boolean} false if response was sent (403)
@@ -110,4 +122,11 @@ function requireAuth(req, res, next) {
     });
 }
 
-module.exports = { requireAuth, authenticate, assertApiKeyScopes, hashApiKey };
+module.exports = {
+  requireAuth,
+  authenticate,
+  assertApiKeyScopes,
+  hashApiKey,
+  requireAdmin,
+  requireRole,
+};

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -49,7 +49,7 @@ router.patch('/campaigns/:id/status', async (req, res) => {
 // GET /users
 router.get('/users', async (req, res) => {
   const { rows } = await db.query(`
-    SELECT u.id, u.name, u.email, u.wallet_public_key, u.is_admin, u.created_at,
+    SELECT u.id, u.name, u.email, u.wallet_public_key, u.role, u.created_at,
            (SELECT COUNT(*) FROM campaigns WHERE creator_id = u.id) as campaign_count,
            (SELECT COUNT(*) FROM contributions WHERE sender_public_key = u.wallet_public_key) as contribution_count
     FROM users u

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -1,6 +1,6 @@
 const router = require('express').Router();
 const db = require('../config/database');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireRole } = require('../middleware/auth');
 const {
   createCampaignWallet,
   getCampaignBalance,
@@ -11,11 +11,6 @@ const { watchCampaignWallet } = require('../services/ledgerMonitor');
 const { insertWithdrawalPendingSignatures } = require('../services/stellarTransactionService');
 const { sendEmail } = require('../services/emailService');
 const SUPPORTED_ASSETS = getSupportedAssetCodes();
-
-function canPerformPlatformAction(userId) {
-  if (!process.env.PLATFORM_APPROVER_USER_ID) return true;
-  return userId === process.env.PLATFORM_APPROVER_USER_ID;
-}
 
 async function logWithdrawalEvent(client, { withdrawalRequestId, actorUserId, action, note, metadata }) {
   const runner = client || db;
@@ -31,7 +26,8 @@ async function logWithdrawalEvent(client, { withdrawalRequestId, actorUserId, ac
 router.get('/', async (req, res) => {
   const { rows } = await db.query(
     `SELECT id, title, description, target_amount, raised_amount, asset_type,
-            wallet_public_key, status, creator_id, created_at
+            wallet_public_key, status, creator_id, created_at,
+            (SELECT COUNT(*)::int FROM campaign_updates cu WHERE cu.campaign_id = campaigns.id) AS updates_count
      FROM campaigns WHERE status = 'active' ORDER BY created_at DESC`
   );
   res.json(rows);
@@ -56,11 +52,7 @@ router.get('/:id/balance', async (req, res) => {
 });
 
 // Scheduled endpoint to fail expired campaigns and prevent further contributions
-router.post('/cron/fail-expired', requireAuth, async (req, res) => {
-  if (!canPerformPlatformAction(req.user.userId)) {
-    return res.status(403).json({ error: 'Only platform approver can run campaign expiry checks' });
-  }
-
+router.post('/cron/fail-expired', requireAuth, requireRole('admin'), async (req, res) => {
   const { rows } = await db.query(
     `UPDATE campaigns SET status = 'failed'
        WHERE status = 'active'
@@ -74,11 +66,7 @@ router.post('/cron/fail-expired', requireAuth, async (req, res) => {
 });
 
 // Scheduled endpoint to send 48h deadline reminders
-router.post('/cron/reminders', requireAuth, async (req, res) => {
-  if (!canPerformPlatformAction(req.user.userId)) {
-    return res.status(403).json({ error: 'Only platform approver can run reminders' });
-  }
-
+router.post('/cron/reminders', requireAuth, requireRole('admin'), async (req, res) => {
   // Find campaigns ending in exactly 2 days that are still active
   const { rows } = await db.query(
     `SELECT c.id, c.title, c.deadline, u.email as creator_email
@@ -101,11 +89,7 @@ If your target is reached, you can request a withdrawal. Otherwise, contribution
 });
 
 // Trigger refund withdrawal requests for a failed campaign
-router.post('/:id/trigger-refunds', requireAuth, async (req, res) => {
-  if (!canPerformPlatformAction(req.user.userId)) {
-    return res.status(403).json({ error: 'Only platform approver can trigger campaign refunds' });
-  }
-
+router.post('/:id/trigger-refunds', requireAuth, requireRole('admin'), async (req, res) => {
   const campaignId = req.params.id;
   const { rows: campaigns } = await db.query(
     `SELECT id, wallet_public_key, status FROM campaigns WHERE id = $1`,
@@ -185,7 +169,7 @@ router.post('/:id/trigger-refunds', requireAuth, async (req, res) => {
 });
 
 // Create campaign (authenticated)
-router.post('/', requireAuth, async (req, res) => {
+router.post('/', requireAuth, requireRole('creator', 'admin'), async (req, res) => {
   const { title, description, target_amount, asset_type, deadline } = req.body;
   if (!title || !target_amount || !asset_type) {
     return res.status(400).json({ error: 'title, target_amount and asset_type are required' });
@@ -217,6 +201,42 @@ router.post('/', requireAuth, async (req, res) => {
   // Start monitoring the new wallet immediately
   watchCampaignWallet(rows[0].id, wallet.publicKey);
 
+  res.status(201).json(rows[0]);
+});
+
+router.get('/:id/updates', async (req, res) => {
+  const limit = Math.min(50, Math.max(1, Number(req.query.limit) || 10));
+  const offset = Math.max(0, Number(req.query.offset) || 0);
+  const { rows } = await db.query(
+    `SELECT cu.id, cu.campaign_id, cu.author_id, cu.title, cu.body, cu.created_at, u.name AS author_name
+     FROM campaign_updates cu
+     JOIN users u ON u.id = cu.author_id
+     WHERE cu.campaign_id = $1
+     ORDER BY cu.created_at DESC
+     LIMIT $2 OFFSET $3`,
+    [req.params.id, limit, offset]
+  );
+  res.json(rows);
+});
+
+router.post('/:id/updates', requireAuth, async (req, res) => {
+  const { title, body } = req.body;
+  if (!title || !body) {
+    return res.status(400).json({ error: 'title and body are required' });
+  }
+
+  const { rows: campaignRows } = await db.query('SELECT creator_id FROM campaigns WHERE id = $1', [req.params.id]);
+  if (!campaignRows.length) return res.status(404).json({ error: 'Campaign not found' });
+  if (campaignRows[0].creator_id !== req.user.userId) {
+    return res.status(403).json({ error: 'Only campaign creator can post updates' });
+  }
+
+  const { rows } = await db.query(
+    `INSERT INTO campaign_updates (campaign_id, author_id, title, body)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id, campaign_id, author_id, title, body, created_at`,
+    [req.params.id, req.user.userId, title.trim(), body.trim()]
+  );
   res.status(201).json(rows[0]);
 });
 

--- a/backend/src/routes/campaigns.test.js
+++ b/backend/src/routes/campaigns.test.js
@@ -24,7 +24,10 @@ function buildApp({ queryImpl, buildWithdrawalTransactionImpl, insertWithdrawalP
     },
     '../middleware/auth': {
       requireAuth: (req, _res, next) => {
-        req.user = { userId: 'platform-1' };
+        req.user = { userId: 'platform-1', role: 'admin' };
+        next();
+      },
+      requireRole: () => (req, _res, next) => {
         next();
       },
     },

--- a/backend/src/routes/contributions.js
+++ b/backend/src/routes/contributions.js
@@ -65,9 +65,7 @@ router.get('/finalization/:txHash', requireAuth, async (req, res) => {
   const isInitiator = row.initiated_by_user_id === req.user.userId;
   const isCreator = row.creator_id === req.user.userId;
   const isContributor = userPk && row.sender_public_key && row.sender_public_key === userPk;
-  const isPlatform =
-    process.env.PLATFORM_APPROVER_USER_ID &&
-    req.user.userId === process.env.PLATFORM_APPROVER_USER_ID;
+  const isPlatform = req.user.role === 'admin';
 
   if (!isInitiator && !isCreator && !isContributor && !isPlatform) {
     return res.status(403).json({ error: 'Not authorized to view this transaction' });

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -7,6 +7,7 @@ const db = require('../config/database');
 const logger = require('../config/logger');
 const { ensureCustodialAccountFundedAndTrusted } = require('../services/stellarService');
 const { sendEmail } = require('../services/emailService');
+const { requireAuth } = require('../middleware/auth');
 
 const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -18,9 +19,14 @@ const authLimiter = rateLimit({
 
 // Register — creates user + custodial Stellar keypair
 router.post('/register', authLimiter, async (req, res) => {
-  const { email, password, name } = req.body;
+  const { email, password, name, role } = req.body;
   if (!email || !password || !name) {
     return res.status(400).json({ error: 'email, password and name are required' });
+  }
+  const allowedRoles = new Set(['contributor', 'creator']);
+  const userRole = role || 'contributor';
+  if (!allowedRoles.has(userRole)) {
+    return res.status(400).json({ error: 'role must be contributor or creator' });
   }
 
   const existing = await db.query('SELECT id FROM users WHERE email = $1', [email]);
@@ -32,13 +38,13 @@ router.post('/register', authLimiter, async (req, res) => {
   const keypair = Keypair.random();
 
   const { rows } = await db.query(
-    `INSERT INTO users (email, password_hash, name, wallet_public_key, wallet_secret_encrypted)
-     VALUES ($1, $2, $3, $4, $5) RETURNING id, email, name, wallet_public_key`,
-    [email, passwordHash, name, keypair.publicKey(), keypair.secret()]
+    `INSERT INTO users (email, password_hash, name, wallet_public_key, wallet_secret_encrypted, role)
+     VALUES ($1, $2, $3, $4, $5, $6) RETURNING id, email, name, wallet_public_key, role`,
+    [email, passwordHash, name, keypair.publicKey(), keypair.secret(), userRole]
     // TODO: encrypt secret with KMS before storing in production
   );
 
-  const token = jwt.sign({ userId: rows[0].id, is_admin: false }, process.env.JWT_SECRET, {
+  const token = jwt.sign({ userId: rows[0].id, role: rows[0].role }, process.env.JWT_SECRET, {
     expiresIn: process.env.JWT_EXPIRES_IN,
   });
 
@@ -72,7 +78,7 @@ router.post('/login', authLimiter, async (req, res) => {
     return res.status(401).json({ error: 'Invalid credentials' });
   }
 
-  const token = jwt.sign({ userId: rows[0].id, is_admin: rows[0].is_admin }, process.env.JWT_SECRET, {
+  const token = jwt.sign({ userId: rows[0].id, role: rows[0].role }, process.env.JWT_SECRET, {
     expiresIn: process.env.JWT_EXPIRES_IN,
   });
 
@@ -83,7 +89,7 @@ router.post('/login', authLimiter, async (req, res) => {
       email: rows[0].email,
       name: rows[0].name,
       wallet_public_key: rows[0].wallet_public_key,
-      is_admin: rows[0].is_admin,
+      role: rows[0].role,
     },
   });
 });
@@ -92,6 +98,60 @@ router.post('/login', authLimiter, async (req, res) => {
 router.post('/forgot-password', authLimiter, async (req, res) => {
   // Real implementation would send a reset link
   res.json({ message: 'If that email exists, a password reset link has been sent.' });
+});
+
+router.get('/me/campaigns', requireAuth, async (req, res) => {
+  const { rows } = await db.query(
+    `SELECT c.id, c.title, c.status, c.asset_type, c.target_amount, c.raised_amount,
+            c.deadline, c.created_at,
+            COALESCE(stats.contributor_count, 0) AS contributor_count
+     FROM campaigns c
+     LEFT JOIN LATERAL (
+       SELECT COUNT(DISTINCT sender_public_key)::int AS contributor_count
+       FROM contributions ctr
+       WHERE ctr.campaign_id = c.id
+     ) stats ON TRUE
+     WHERE c.creator_id = $1
+     ORDER BY c.created_at DESC`,
+    [req.user.userId]
+  );
+  res.json(rows);
+});
+
+router.get('/me/stats', requireAuth, async (req, res) => {
+  const { rows } = await db.query(
+    `SELECT
+      COUNT(*)::int AS total_campaigns,
+      COALESCE(SUM(raised_amount), 0)::numeric AS total_raised,
+      COUNT(*) FILTER (WHERE status = 'active')::int AS active_campaigns,
+      COUNT(*) FILTER (WHERE status = 'funded')::int AS funded_campaigns,
+      COUNT(*) FILTER (WHERE status IN ('closed', 'withdrawn', 'failed'))::int AS closed_campaigns
+     FROM campaigns
+     WHERE creator_id = $1`,
+    [req.user.userId]
+  );
+  res.json(rows[0]);
+});
+
+router.get('/me/contributions', requireAuth, async (req, res) => {
+  const { rows: userRows } = await db.query(
+    'SELECT wallet_public_key FROM users WHERE id = $1',
+    [req.user.userId]
+  );
+  if (!userRows.length) return res.status(404).json({ error: 'User not found' });
+
+  const senderPublicKey = userRows[0].wallet_public_key;
+  const { rows } = await db.query(
+    `SELECT ctr.id, ctr.amount, ctr.asset, ctr.tx_hash, ctr.created_at,
+            c.id AS campaign_id, c.title AS campaign_title, c.status AS campaign_status,
+            c.target_amount, c.raised_amount
+     FROM contributions ctr
+     JOIN campaigns c ON c.id = ctr.campaign_id
+     WHERE ctr.sender_public_key = $1
+     ORDER BY ctr.created_at DESC`,
+    [senderPublicKey]
+  );
+  res.json(rows);
 });
 
 module.exports = router;

--- a/backend/src/routes/withdrawals.js
+++ b/backend/src/routes/withdrawals.js
@@ -1,6 +1,6 @@
 const router = require('express').Router();
 const db = require('../config/database');
-const { requireAuth } = require('../middleware/auth');
+const { requireAuth, requireRole } = require('../middleware/auth');
 const logger = require('../config/logger');
 const { sendAlert } = require('../services/alerting');
 const {
@@ -25,18 +25,6 @@ function hasSigner(signers, publicKey) {
   return signers.some((s) => s.key === publicKey && s.weight >= 1);
 }
 
-/** Dev / open mode: any authenticated user may perform platform signature API calls when unset. */
-function canPerformPlatformSignature(userId) {
-  if (!process.env.PLATFORM_APPROVER_USER_ID) return true;
-  return userId === process.env.PLATFORM_APPROVER_USER_ID;
-}
-
-/** For viewing audit trails: only creator or an explicitly configured platform approver. */
-function isPlatformApproverForAudit(userId) {
-  if (!process.env.PLATFORM_APPROVER_USER_ID) return false;
-  return userId === process.env.PLATFORM_APPROVER_USER_ID;
-}
-
 async function logWithdrawalEvent(client, { withdrawalRequestId, actorUserId, action, note, metadata }) {
   const runner = client || db;
   await runner.query(
@@ -51,15 +39,15 @@ async function assertWithdrawalAccess(req, campaignId) {
   const { rows } = await db.query('SELECT creator_id FROM campaigns WHERE id = $1', [campaignId]);
   if (!rows.length) return { error: 'Campaign not found', status: 404 };
   const isCreator = rows[0].creator_id === req.user.userId;
-  const isPlatform = isPlatformApproverForAudit(req.user.userId);
-  if (!isCreator && !isPlatform) {
+  const isAdmin = req.user.role === 'admin';
+  if (!isCreator && !isAdmin) {
     return { error: 'Not authorized to view or manage withdrawals for this campaign', status: 403 };
   }
-  return { creatorId: rows[0].creator_id, isCreator, isPlatform };
+  return { creatorId: rows[0].creator_id, isCreator, isAdmin };
 }
 
 router.get('/capabilities', requireAuth, (req, res) => {
-  res.json({ can_approve_platform: canPerformPlatformSignature(req.user.userId) });
+  res.json({ can_approve_platform: req.user.role === 'admin' });
 });
 
 router.post('/request', requireAuth, async (req, res) => {
@@ -79,7 +67,7 @@ router.post('/request', requireAuth, async (req, res) => {
   if (!campaigns.length) return res.status(404).json({ error: 'Campaign not found' });
   const campaign = campaigns[0];
 
-  if (campaign.creator_id !== req.user.userId) {
+  if (campaign.creator_id !== req.user.userId && req.user.role !== 'admin') {
     return res.status(403).json({ error: 'Only campaign creator can request withdrawal' });
   }
   if (!ALLOWED_CAMPAIGN_STATUS_FOR_REQUEST.includes(campaign.status)) {
@@ -173,7 +161,7 @@ router.post('/:id/approve/creator', requireAuth, async (req, res) => {
   if (!requests.length) return res.status(404).json({ error: 'Withdrawal request not found' });
   const requestRow = requests[0];
 
-  if (requestRow.creator_id !== req.user.userId) {
+  if (requestRow.creator_id !== req.user.userId && req.user.role !== 'admin') {
     return res.status(403).json({ error: 'Only campaign creator can approve creator signature' });
   }
   if (!requestRow.is_refund && !ALLOWED_CAMPAIGN_STATUS_FOR_REQUEST.includes(requestRow.campaign_status)) {
@@ -231,11 +219,7 @@ router.post('/:id/approve/creator', requireAuth, async (req, res) => {
   }
 });
 
-router.post('/:id/approve/platform', requireAuth, async (req, res) => {
-  if (!canPerformPlatformSignature(req.user.userId)) {
-    return res.status(403).json({ error: 'Only designated platform approver can sign as platform' });
-  }
-
+router.post('/:id/approve/platform', requireAuth, requireRole('admin'), async (req, res) => {
   const { rows: requests } = await db.query(
     `SELECT wr.*, c.status AS campaign_status
      FROM withdrawal_requests wr
@@ -392,7 +376,7 @@ router.post('/:id/cancel', requireAuth, async (req, res) => {
   if (!requests.length) return res.status(404).json({ error: 'Withdrawal request not found' });
   const requestRow = requests[0];
 
-  if (requestRow.creator_id !== req.user.userId) {
+  if (requestRow.creator_id !== req.user.userId && req.user.role !== 'admin') {
     return res.status(403).json({ error: 'Only the campaign creator can cancel this request' });
   }
   if (requestRow.status !== 'pending') {
@@ -436,10 +420,7 @@ router.post('/:id/cancel', requireAuth, async (req, res) => {
   }
 });
 
-router.post('/:id/reject', requireAuth, async (req, res) => {
-  if (!canPerformPlatformSignature(req.user.userId)) {
-    return res.status(403).json({ error: 'Only designated platform approver can reject at this stage' });
-  }
+router.post('/:id/reject', requireAuth, requireRole('admin'), async (req, res) => {
   const reason = (req.body && req.body.reason) || 'Rejected by platform';
 
   const { rows: requests } = await db.query(

--- a/backend/src/routes/withdrawals.test.js
+++ b/backend/src/routes/withdrawals.test.js
@@ -4,7 +4,7 @@ const express = require('express');
 const request = require('supertest');
 const proxyquire = require('proxyquire').noCallThru();
 
-function buildApp({ queryImpl, stellarImpl, userId = 'creator-1' }) {
+function buildApp({ queryImpl, stellarImpl, userId = 'creator-1', role = 'creator' }) {
   const stellarStub = {
     buildWithdrawalTransaction: async () => 'xdr-base',
     getAccountMultisigConfig: async () => ({
@@ -29,7 +29,13 @@ function buildApp({ queryImpl, stellarImpl, userId = 'creator-1' }) {
     '../services/stellarService': stellarStub,
     '../middleware/auth': {
       requireAuth: (req, _res, next) => {
-        req.user = { userId };
+        req.user = { userId, role };
+        next();
+      },
+      requireRole: (...roles) => (req, res, next) => {
+        if (!roles.includes(req.user.role)) {
+          return res.status(403).json({ error: 'Insufficient role for this action' });
+        }
         next();
       },
     },
@@ -53,22 +59,16 @@ function campaignRow(overrides = {}) {
   };
 }
 
-test('GET /api/withdrawals/capabilities reflects approver env', async () => {
-  const prev = process.env.PLATFORM_APPROVER_USER_ID;
-  process.env.PLATFORM_APPROVER_USER_ID = 'platform-1';
-  try {
-    const { app, cleanup } = buildApp({
-      queryImpl: async () => ({ rows: [] }),
-      userId: 'platform-1',
-    });
-    const res = await request(app).get('/api/withdrawals/capabilities').set('Authorization', 'Bearer t');
-    cleanup();
-    assert.equal(res.status, 200);
-    assert.equal(res.body.can_approve_platform, true);
-  } finally {
-    if (prev === undefined) delete process.env.PLATFORM_APPROVER_USER_ID;
-    else process.env.PLATFORM_APPROVER_USER_ID = prev;
-  }
+test('GET /api/withdrawals/capabilities reflects admin role', async () => {
+  const { app, cleanup } = buildApp({
+    queryImpl: async () => ({ rows: [] }),
+    userId: 'platform-1',
+    role: 'admin',
+  });
+  const res = await request(app).get('/api/withdrawals/capabilities').set('Authorization', 'Bearer t');
+  cleanup();
+  assert.equal(res.status, 200);
+  assert.equal(res.body.can_approve_platform, true);
 });
 
 test('POST /api/withdrawals/request creates pending request and logs event', async () => {
@@ -113,6 +113,7 @@ test('POST /api/withdrawals/request creates pending request and logs event', asy
 
 test('POST /api/withdrawals/request blocks when campaign not active or funded', async () => {
   const { app, cleanup } = buildApp({
+    role: 'admin',
     queryImpl: async (text) => {
       if (text.includes('FROM campaigns WHERE id')) {
         return { rows: [campaignRow({ status: 'closed' })] };
@@ -183,6 +184,7 @@ test('POST /api/withdrawals/request denies invalid multisig config', async () =>
 
 test('POST /api/withdrawals/:id/approve/platform denies before creator approval', async () => {
   const { app, cleanup } = buildApp({
+    role: 'admin',
     queryImpl: async () => ({
       rows: [{
         id: 'w-1',
@@ -248,6 +250,7 @@ test('POST /api/withdrawals/:id/approve/creator signs withdrawal request', async
 
 test('POST /api/withdrawals/:id/approve/platform denies insufficient signatures', async () => {
   const { app, cleanup } = buildApp({
+    role: 'admin',
     queryImpl: async () => ({
       rows: [{
         id: 'w-1',
@@ -275,6 +278,7 @@ test('POST /api/withdrawals/:id/approve/platform denies insufficient signatures'
 test('POST /api/withdrawals/:id/approve/platform submits with dual signatures', async () => {
   const calls = [];
   const { app, cleanup } = buildApp({
+    role: 'admin',
     queryImpl: async (text) => {
       calls.push(text);
       if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
@@ -369,6 +373,7 @@ test('POST /api/withdrawals/:id/cancel succeeds before creator signs', async () 
 test('POST /api/withdrawals/:id/reject marks denied after creator signed', async () => {
   const { app, cleanup } = buildApp({
     userId: 'platform-user',
+    role: 'admin',
     queryImpl: async (text) => {
       if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
       if (text.includes('SELECT * FROM withdrawal_requests WHERE id')) {
@@ -389,18 +394,10 @@ test('POST /api/withdrawals/:id/reject marks denied after creator signed', async
     },
   });
 
-  const prev = process.env.PLATFORM_APPROVER_USER_ID;
-  process.env.PLATFORM_APPROVER_USER_ID = 'platform-user';
-  let response;
-  try {
-    response = await request(app)
-      .post('/api/withdrawals/w-1/reject')
-      .set('Authorization', 'Bearer t')
-      .send({ reason: 'Compliance hold' });
-  } finally {
-    if (prev === undefined) delete process.env.PLATFORM_APPROVER_USER_ID;
-    else process.env.PLATFORM_APPROVER_USER_ID = prev;
-  }
+  const response = await request(app)
+    .post('/api/withdrawals/w-1/reject')
+    .set('Authorization', 'Bearer t')
+    .send({ reason: 'Compliance hold' });
 
   cleanup();
   assert.equal(response.status, 200);
@@ -409,6 +406,7 @@ test('POST /api/withdrawals/:id/reject marks denied after creator signed', async
 
 test('POST /api/withdrawals/:id/approve/platform logs failure when Stellar rejects', async () => {
   const { app, cleanup } = buildApp({
+    role: 'admin',
     queryImpl: async (text) => {
       if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
       if (text.includes('SELECT wr.*, c.status')) {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,8 @@ import Login from './pages/Login';
 import Register from './pages/Register';
 import AdminDashboard from './pages/AdminDashboard';
 import Developer from './pages/Developer';
+import Dashboard from './pages/Dashboard';
+import MyContributions from './pages/MyContributions';
 import { AuthProvider } from './context/AuthContext';
 
 export default function App() {
@@ -22,6 +24,8 @@ export default function App() {
         <Route path="/register" element={<Register />} />
         <Route path="/admin" element={<AdminDashboard />} />
         <Route path="/developer" element={<Developer />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/my-contributions" element={<MyContributions />} />
       </Routes>
     </AuthProvider>
   );

--- a/frontend/src/components/CampaignCard.jsx
+++ b/frontend/src/components/CampaignCard.jsx
@@ -9,6 +9,9 @@ export default function CampaignCard({ campaign }) {
       <div className="campaign-card" style={styles.card}>
         <div style={styles.header}>
           <span style={styles.asset}>{campaign.asset_type}</span>
+          {typeof campaign.updates_count === 'number' && (
+            <span style={styles.updates}>{campaign.updates_count} updates</span>
+          )}
         </div>
         <h3 style={styles.title}>{campaign.title}</h3>
         <p style={styles.desc}>{campaign.description?.slice(0, 100)}{campaign.description?.length > 100 ? '…' : ''}</p>
@@ -29,8 +32,9 @@ export default function CampaignCard({ campaign }) {
 
 const styles = {
   card: { background: '#fff', border: '1px solid #e5e5e5', borderRadius: '10px', padding: '1.25rem', transition: 'box-shadow 0.15s' },
-  header: { marginBottom: '0.6rem' },
+  header: { marginBottom: '0.6rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' },
   asset: { background: '#ede9fe', color: '#7c3aed', fontSize: '0.75rem', fontWeight: 700, padding: '2px 8px', borderRadius: '99px' },
+  updates: { fontSize: '0.75rem', fontWeight: 700, color: '#0f766e' },
   title: { fontSize: '1.05rem', fontWeight: 700, marginBottom: '0.4rem', color: '#111' },
   desc: { fontSize: '0.875rem', color: '#666', marginBottom: '1rem' },
   bar: { background: '#f0f0f0', borderRadius: '99px', height: '6px', marginBottom: '0.5rem', overflow: 'hidden' },

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -18,8 +18,14 @@ export default function Navbar() {
         <div className="nav-links">
           {user ? (
             <>
-              {user.is_admin && <Link to="/admin" style={styles.link}>Admin</Link>}
-              <Link to="/campaigns/new" style={styles.link}>Start Campaign</Link>
+              {(user.role === 'creator' || user.role === 'admin') && (
+                <Link to="/campaigns/new" style={styles.link}>Start Campaign</Link>
+              )}
+              {(user.role === 'creator' || user.role === 'admin') && (
+                <Link to="/dashboard" style={styles.link}>Dashboard</Link>
+              )}
+              <Link to="/my-contributions" style={styles.link}>My Contributions</Link>
+              {user.role === 'admin' && <Link to="/admin" style={styles.link}>Admin</Link>}
               <Link to="/developer" style={styles.link}>Developer</Link>
               <span style={styles.name}>{user.name}</span>
               <button onClick={handleLogout} className="btn-secondary" style={{ padding: '0.4rem 0.9rem' }}>

--- a/frontend/src/components/WithdrawalsSection.jsx
+++ b/frontend/src/components/WithdrawalsSection.jsx
@@ -27,6 +27,7 @@ export default function WithdrawalsSection({ campaign, user, token, onReleased }
   const [openAudit, setOpenAudit] = useState(null);
 
   const isCreator = user?.id && campaign.creator_id === user.id;
+  const isAdmin = user?.role === 'admin';
   const canView = !forbidden && (isCreator || cap.can_approve_platform);
   const hasPending = rows.some((r) => r.status === 'pending');
   const canOpenRequest =
@@ -290,7 +291,7 @@ export default function WithdrawalsSection({ campaign, user, token, onReleased }
                       onClick={() => runAction(row.id, () => api.approveWithdrawalPlatform(row.id, token))}
                       style={{ fontSize: '0.8rem' }}
                     >
-                      Approve & submit
+                      Admin approve & submit
                     </button>
                   </>
                 )}
@@ -300,10 +301,10 @@ export default function WithdrawalsSection({ campaign, user, token, onReleased }
         </ul>
       )}
 
-      {cap.can_approve_platform && (
+      {cap.can_approve_platform && isAdmin && (
         <p style={{ ...styles.hint, marginTop: '1rem' }}>
-          Platform actions use the server key; your account is only checked for authorization. Set{' '}
-          <code>PLATFORM_APPROVER_USER_ID</code> in production to restrict this UI to ops staff.
+          Admin actions sign using the platform server key after creator approval. Every transition is written to audit
+          history.
         </p>
       )}
     </section>

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -5,14 +5,20 @@ const AuthContext = createContext(null);
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(() => {
     const stored = localStorage.getItem('cp_user');
-    return stored ? JSON.parse(stored) : null;
+    if (!stored) return null;
+    const parsed = JSON.parse(stored);
+    if (!parsed.role) {
+      parsed.role = parsed.is_admin ? 'admin' : 'contributor';
+    }
+    return parsed;
   });
   const [token, setToken] = useState(() => localStorage.getItem('cp_token'));
 
   function login(userData, jwt) {
-    setUser(userData);
+    const normalized = { ...userData, role: userData.role || (userData.is_admin ? 'admin' : 'contributor') };
+    setUser(normalized);
     setToken(jwt);
-    localStorage.setItem('cp_user', JSON.stringify(userData));
+    localStorage.setItem('cp_user', JSON.stringify(normalized));
     localStorage.setItem('cp_token', jwt);
   }
 

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -5,6 +5,27 @@ import { useAuth } from '../context/AuthContext';
 import ContributeModal from '../components/ContributeModal';
 import WithdrawalsSection from '../components/WithdrawalsSection';
 
+function escapeHtml(text) {
+  return text
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function markdownToHtml(markdown) {
+  const escaped = escapeHtml(markdown || '');
+  return escaped
+    .replace(/^### (.*)$/gm, '<h3>$1</h3>')
+    .replace(/^## (.*)$/gm, '<h2>$1</h2>')
+    .replace(/^# (.*)$/gm, '<h1>$1</h1>')
+    .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.*?)\*/g, '<em>$1</em>')
+    .replace(/\[(.*?)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
+    .replace(/\n/g, '<br />');
+}
+
 export default function Campaign() {
   const { id } = useParams();
   const location = useLocation();
@@ -15,6 +36,10 @@ export default function Campaign() {
   const [showModal, setShowModal] = useState(false);
   const [contributed, setContributed] = useState(false);
   const [showCreatedBanner, setShowCreatedBanner] = useState(!!location.state?.created);
+  const [updates, setUpdates] = useState([]);
+  const [updateForm, setUpdateForm] = useState({ title: '', body: '' });
+  const [updateBusy, setUpdateBusy] = useState(false);
+  const [updatesError, setUpdatesError] = useState('');
 
   useEffect(() => {
     setLoadError('');
@@ -23,6 +48,7 @@ export default function Campaign() {
       .then(setCampaign)
       .catch((err) => setLoadError(err.message || 'Could not load campaign.'));
     api.getContributions(id).then(setContributions).catch(() => setContributions([]));
+    api.getCampaignUpdates(id, { limit: 20 }).then(setUpdates).catch(() => setUpdates([]));
   }, [id, contributed]);
 
   useEffect(() => {
@@ -53,6 +79,27 @@ export default function Campaign() {
   }
 
   const pct = Math.min(100, (campaign.raised_amount / campaign.target_amount) * 100).toFixed(1);
+  const canPostUpdate = user?.id && campaign.creator_id === user.id;
+
+  async function submitUpdate(e) {
+    e.preventDefault();
+    setUpdatesError('');
+    setUpdateBusy(true);
+    try {
+      await api.postCampaignUpdate(
+        campaign.id,
+        { title: updateForm.title.trim(), body: updateForm.body.trim() },
+        token
+      );
+      setUpdateForm({ title: '', body: '' });
+      const list = await api.getCampaignUpdates(id, { limit: 20 });
+      setUpdates(list);
+    } catch (err) {
+      setUpdatesError(err.message || 'Could not publish update');
+    } finally {
+      setUpdateBusy(false);
+    }
+  }
 
   return (
     <main className="container" style={{ paddingTop: '2.5rem', paddingBottom: '4rem', maxWidth: '760px' }}>
@@ -139,6 +186,51 @@ export default function Campaign() {
             api.getCampaign(id).then(setCampaign).catch(() => {});
           }}
         />
+      )}
+
+      <h2 style={styles.sectionTitle}>Updates ({updates.length})</h2>
+      {canPostUpdate && (
+        <form onSubmit={submitUpdate} className="campaign-card" style={{ marginBottom: '1rem' }}>
+          <strong style={{ marginBottom: '0.5rem', display: 'block' }}>Post update</strong>
+          <input
+            placeholder="Update title"
+            value={updateForm.title}
+            onChange={(e) => setUpdateForm((s) => ({ ...s, title: e.target.value }))}
+            required
+            style={{ marginBottom: '0.5rem' }}
+          />
+          <textarea
+            placeholder="Write markdown update..."
+            value={updateForm.body}
+            onChange={(e) => setUpdateForm((s) => ({ ...s, body: e.target.value }))}
+            rows={4}
+            required
+          />
+          {updatesError && <p className="alert alert--error" style={{ marginTop: '0.5rem' }}>{updatesError}</p>}
+          <button type="submit" className="btn-primary" disabled={updateBusy} style={{ marginTop: '0.5rem' }}>
+            {updateBusy ? 'Posting...' : 'Post update'}
+          </button>
+        </form>
+      )}
+      {updates.length === 0 ? (
+        <p style={{ color: '#999', marginBottom: '1rem' }}>No updates posted yet.</p>
+      ) : (
+        <div style={{ display: 'grid', gap: '0.75rem', marginBottom: '1.25rem' }}>
+          {updates.map((update) => (
+            <article key={update.id} className="campaign-card">
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.5rem', flexWrap: 'wrap' }}>
+                <strong>{update.title}</strong>
+                <span style={{ color: '#666', fontSize: '0.85rem' }}>
+                  {update.author_name} • {new Date(update.created_at).toLocaleString()}
+                </span>
+              </div>
+              <div
+                style={{ marginTop: '0.5rem', color: '#333', lineHeight: 1.5 }}
+                dangerouslySetInnerHTML={{ __html: markdownToHtml(update.body) }}
+              />
+            </article>
+          ))}
+        </div>
       )}
 
       <h2 style={styles.sectionTitle}>Contributions ({contributions.length})</h2>

--- a/frontend/src/pages/CreateCampaign.jsx
+++ b/frontend/src/pages/CreateCampaign.jsx
@@ -22,7 +22,7 @@ const ASSETS = [
 ];
 
 export default function CreateCampaign() {
-  const { token } = useAuth();
+  const { token, user } = useAuth();
   const navigate = useNavigate();
   const [step, setStep] = useState(1);
   const [form, setForm] = useState({
@@ -100,6 +100,14 @@ export default function CreateCampaign() {
     return (
       <main className="container page-narrow" style={{ paddingTop: '3rem' }}>
         <p className="alert alert--info">Redirecting to sign in…</p>
+      </main>
+    );
+  }
+
+  if (user?.role !== 'creator' && user?.role !== 'admin') {
+    return (
+      <main className="container page-narrow" style={{ paddingTop: '3rem' }}>
+        <p className="alert alert--info">Only creator or admin accounts can start campaigns.</p>
       </main>
     );
   }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { api } from '../services/api';
+
+function progressPct(campaign) {
+  if (!Number(campaign.target_amount)) return 0;
+  return Math.min(100, (Number(campaign.raised_amount) / Number(campaign.target_amount)) * 100);
+}
+
+export default function Dashboard() {
+  const { token, user } = useAuth();
+  const [stats, setStats] = useState(null);
+  const [campaigns, setCampaigns] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!token) return;
+    Promise.all([api.getMyStats(token), api.getMyCampaigns(token)])
+      .then(([s, c]) => {
+        setStats(s);
+        setCampaigns(c);
+      })
+      .catch((err) => setError(err.message || 'Could not load dashboard'))
+      .finally(() => setLoading(false));
+  }, [token]);
+
+  if (!token) return <Navigate to="/login" replace />;
+  if (user?.role !== 'creator' && user?.role !== 'admin') return <Navigate to="/" replace />;
+
+  return (
+    <main className="container" style={{ paddingTop: '2rem', paddingBottom: '3rem' }}>
+      <h1 style={{ fontSize: '1.6rem', fontWeight: 800, marginBottom: '1rem' }}>Creator Dashboard</h1>
+      {error && <p className="alert alert--error">{error}</p>}
+      {loading ? (
+        <p style={{ color: '#666' }}>Loading dashboard...</p>
+      ) : (
+        <>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(180px,1fr))', gap: '0.75rem', marginBottom: '1rem' }}>
+            <div className="campaign-card"><strong>{stats?.total_campaigns || 0}</strong><div>Total campaigns</div></div>
+            <div className="campaign-card"><strong>{Number(stats?.total_raised || 0).toLocaleString()}</strong><div>Total raised</div></div>
+            <div className="campaign-card"><strong>{stats?.active_campaigns || 0}</strong><div>Active campaigns</div></div>
+          </div>
+          <div style={{ marginBottom: '1rem' }}>
+            <Link to="/campaigns/new" style={{ color: '#7c3aed', fontWeight: 600 }}>+ Create new campaign</Link>
+          </div>
+          {campaigns.length === 0 ? (
+            <p className="alert alert--info">No campaigns yet. Create your first campaign to get started.</p>
+          ) : (
+            <div style={{ display: 'grid', gap: '0.75rem' }}>
+              {campaigns.map((campaign) => {
+                const pct = progressPct(campaign).toFixed(1);
+                return (
+                  <div key={campaign.id} className="campaign-card">
+                    <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.5rem', flexWrap: 'wrap' }}>
+                      <strong>{campaign.title}</strong>
+                      <span>{campaign.status}</span>
+                    </div>
+                    <div style={{ marginTop: '0.35rem', fontSize: '0.9rem' }}>
+                      {Number(campaign.raised_amount).toLocaleString()} / {Number(campaign.target_amount).toLocaleString()} {campaign.asset_type}
+                    </div>
+                    <div style={{ background: '#eee', borderRadius: '99px', height: '6px', marginTop: '0.35rem' }}>
+                      <div style={{ background: '#7c3aed', height: '6px', borderRadius: '99px', width: `${pct}%` }} />
+                    </div>
+                    <div style={{ marginTop: '0.35rem', color: '#666', fontSize: '0.85rem' }}>
+                      {campaign.contributor_count} contributors {campaign.deadline ? `• Deadline ${new Date(campaign.deadline).toLocaleDateString()}` : ''}
+                    </div>
+                    <div style={{ marginTop: '0.45rem', display: 'flex', gap: '0.75rem' }}>
+                      <Link to={`/campaigns/${campaign.id}`} style={{ color: '#7c3aed' }}>View</Link>
+                      <Link to={`/campaigns/${campaign.id}`} style={{ color: '#7c3aed' }}>Manage withdrawals</Link>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -80,11 +80,13 @@ export default function Home() {
         </p>
         {user ? (
           <div className="hero-actions">
-            <Link to="/campaigns/new" style={{ width: '100%' }}>
-              <button type="button" className="btn-primary" style={{ fontSize: '1rem', padding: '0.75rem 1.5rem', width: '100%' }}>
-                Start a campaign
-              </button>
-            </Link>
+            {(user.role === 'creator' || user.role === 'admin') && (
+              <Link to="/campaigns/new" style={{ width: '100%' }}>
+                <button type="button" className="btn-primary" style={{ fontSize: '1rem', padding: '0.75rem 1.5rem', width: '100%' }}>
+                  Start a campaign
+                </button>
+              </Link>
+            )}
             <span style={styles.muted}>or browse below and tap a card to contribute.</span>
           </div>
         ) : (
@@ -113,7 +115,7 @@ export default function Home() {
         </p>
       ) : campaigns.length === 0 ? (
         <div className="alert alert--info">
-          {user ? (
+          {user && (user.role === 'creator' || user.role === 'admin') ? (
             <>
               No campaigns yet.{' '}
               <Link to="/campaigns/new" style={{ color: '#1e40af', fontWeight: 700 }}>

--- a/frontend/src/pages/MyContributions.jsx
+++ b/frontend/src/pages/MyContributions.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { api } from '../services/api';
+import { stellarExpertTxUrl } from '../config/stellar';
+
+export default function MyContributions() {
+  const { token } = useAuth();
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!token) return;
+    api.getMyContributions(token)
+      .then(setRows)
+      .catch((err) => setError(err.message || 'Could not load contributions'))
+      .finally(() => setLoading(false));
+  }, [token]);
+
+  if (!token) return <Navigate to="/login" replace />;
+
+  return (
+    <main className="container" style={{ paddingTop: '2rem', paddingBottom: '3rem' }}>
+      <h1 style={{ fontSize: '1.6rem', fontWeight: 800, marginBottom: '1rem' }}>My Contributions</h1>
+      {error && <p className="alert alert--error">{error}</p>}
+      {loading ? (
+        <p style={{ color: '#666' }}>Loading...</p>
+      ) : rows.length === 0 ? (
+        <p className="alert alert--info">You haven't backed any campaigns yet — browse campaigns.</p>
+      ) : (
+        <div style={{ display: 'grid', gap: '0.75rem' }}>
+          {rows.map((row) => (
+            <div key={row.id} className="campaign-card">
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.5rem', flexWrap: 'wrap' }}>
+                <Link to={`/campaigns/${row.campaign_id}`} style={{ color: '#7c3aed', fontWeight: 700 }}>{row.campaign_title}</Link>
+                <span>{row.campaign_status}</span>
+              </div>
+              <div style={{ marginTop: '0.35rem' }}>
+                {Number(row.amount).toLocaleString()} {row.asset} • {new Date(row.created_at).toLocaleString()}
+              </div>
+              <a href={stellarExpertTxUrl(row.tx_hash)} target="_blank" rel="noopener noreferrer" style={{ marginTop: '0.35rem', display: 'inline-block', color: '#7c3aed' }}>
+                View transaction
+              </a>
+            </div>
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -7,7 +7,7 @@ import { markJustRegistered } from '../lib/onboarding';
 export default function Register() {
   const { login } = useAuth();
   const navigate = useNavigate();
-  const [form, setForm] = useState({ name: '', email: '', password: '' });
+  const [form, setForm] = useState({ name: '', email: '', password: '', role: 'contributor' });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -39,6 +39,10 @@ export default function Register() {
         <input placeholder="Full name" value={form.name} onChange={set('name')} required />
         <input type="email" placeholder="Email" value={form.email} onChange={set('email')} required />
         <input type="password" placeholder="Password" value={form.password} onChange={set('password')} required minLength={8} />
+        <select value={form.role} onChange={set('role')} aria-label="Account role">
+          <option value="contributor">Contributor</option>
+          <option value="creator">Creator</option>
+        </select>
         {error && <p style={{ color: '#dc2626', fontSize: '0.875rem' }}>{error}</p>}
         <button type="submit" className="btn-primary" disabled={loading} style={{ padding: '0.8rem' }}>
           {loading ? 'Creating account…' : 'Sign up'}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -47,11 +47,18 @@ async function request(method, path, body, token, options = {}) {
 export const api = {
   register: (body) => request('POST', '/users/register', body),
   login: (body) => request('POST', '/users/login', body),
+  getMyCampaigns: (token) => request('GET', '/users/me/campaigns', null, token),
+  getMyStats: (token) => request('GET', '/users/me/stats', null, token),
+  getMyContributions: (token) => request('GET', '/users/me/contributions', null, token),
 
   getCampaigns: () => request('GET', '/campaigns'),
   getCampaign: (id) => request('GET', `/campaigns/${id}`),
   getCampaignBalance: (id) => request('GET', `/campaigns/${id}/balance`),
   createCampaign: (body, token) => request('POST', '/campaigns', body, token),
+  getCampaignUpdates: (campaignId, options = {}) =>
+    request('GET', `/campaigns/${campaignId}/updates`, null, null, { query: options }),
+  postCampaignUpdate: (campaignId, body, token) =>
+    request('POST', `/campaigns/${campaignId}/updates`, body, token),
 
   getContributions: (campaignId) => request('GET', `/contributions/campaign/${campaignId}`),
   contribute: (body, token) => request('POST', '/contributions', body, token),


### PR DESCRIPTION
## Summary
- Implement issue #31 by introducing role-based authorization (`contributor`, `creator`, `admin`), adding `requireRole(...)`, embedding `role` in JWTs, and replacing fragile `PLATFORM_APPROVER_USER_ID` approval gates with admin-only checks for platform approvals and sensitive operations.
- Implement issue #33 with creator-focused endpoints (`GET /users/me/campaigns`, `GET /users/me/stats`) and a new `/dashboard` page showing campaign summary cards, campaign table/list data, progress, contributor counts, deadlines, and quick navigation.
- Implement issue #34 with `GET /users/me/contributions` and a new `/my-contributions` page showing backed campaigns, amount, asset, date, campaign status, and Stellar explorer transaction links sorted newest-first.
- Implement issue #37 by adding `campaign_updates` storage and APIs (`POST /campaigns/:id/updates`, `GET /campaigns/:id/updates`), creator-only posting, public update feeds on campaign detail pages, markdown rendering, and update counts shown on campaign cards.

## Issue Breakdown
### #31 - Role separation and secure approvals
- Added `role` column support and role checks in backend middleware and route handlers.
- Restricted campaign creation to `creator`/`admin`.
- Restricted platform withdrawal approval/rejection to `admin`.
- Updated frontend to hide/show role-scoped actions in navbar and withdrawal actions.

### #33 - Creator campaign management dashboard
- Added authenticated creator stats and campaign listing endpoints.
- Added `/dashboard` with totals, campaign progress, contributor counts, deadlines, and quick links.
- Added creator empty-state guidance and create-campaign entry points.

### #34 - Contributor contribution history
- Added authenticated contribution history endpoint joined with campaign metadata.
- Added `/my-contributions` view with status, amount/asset, dates, and tx explorer links.
- Added navbar access for logged-in users.

### #37 - Campaign updates and communication
- Added `campaign_updates` table and index via migration.
- Added creator-only update posting endpoint and public paginated listing endpoint.
- Added campaign detail update feed with markdown body rendering and timestamps.
- Added update count badge on campaign cards.

## Validation
- Backend tests: `npm test` (pass)
- Frontend build: `npm run build` (pass)

Closes #31
Closes #33
Closes #34
Closes #37