### PR TITLE
feat: 404 page, error boundary, and loading skeletons (#40)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import AdminDashboard from './pages/AdminDashboard';
 import Developer from './pages/Developer';
 import Dashboard from './pages/Dashboard';
 import MyContributions from './pages/MyContributions';
+import NotFound from './pages/NotFound';
 import { AuthProvider } from './context/AuthContext';
 
 export default function App() {
@@ -26,6 +27,7 @@ export default function App() {
         <Route path="/developer" element={<Developer />} />
         <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/my-contributions" element={<MyContributions />} />
+        <Route path="*" element={<NotFound />} />
       </Routes>
     </AuthProvider>
   );

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('[ErrorBoundary] Uncaught error:', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <main style={styles.wrapper}>
+          <div style={styles.box}>
+            <h1 style={styles.heading}>Something went wrong</h1>
+            <p style={styles.sub}>
+              An unexpected error occurred. Your data is safe — try reloading the page.
+            </p>
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={() => window.location.reload()}
+            >
+              Reload page
+            </button>
+          </div>
+        </main>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const styles = {
+  wrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: '60vh',
+    padding: '2rem 1.25rem',
+  },
+  box: { maxWidth: '420px', textAlign: 'center' },
+  heading: { fontSize: '1.4rem', fontWeight: 700, color: '#111', marginBottom: '0.75rem' },
+  sub: { color: '#666', fontSize: '0.95rem', lineHeight: 1.55, marginBottom: '1.5rem' },
+};

--- a/frontend/src/components/skeletons/CampaignCardSkeleton.jsx
+++ b/frontend/src/components/skeletons/CampaignCardSkeleton.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export default function CampaignCardSkeleton() {
+  return (
+    <div className="skeleton--card" aria-hidden="true">
+      <div style={styles.header}>
+        <span className="skeleton" style={styles.badge} />
+      </div>
+      <div className="skeleton" style={styles.title} />
+      <div className="skeleton" style={styles.descLine1} />
+      <div className="skeleton" style={styles.descLine2} />
+      <div className="skeleton" style={styles.bar} />
+      <div style={styles.meta}>
+        <div className="skeleton" style={styles.metaLeft} />
+        <div className="skeleton" style={styles.metaRight} />
+      </div>
+      <div className="skeleton" style={styles.target} />
+    </div>
+  );
+}
+
+const styles = {
+  header: { marginBottom: '0.6rem', display: 'flex', justifyContent: 'space-between' },
+  badge: { width: '40px', height: '20px', borderRadius: '99px' },
+  title: { height: '18px', width: '70%', marginBottom: '0.5rem' },
+  descLine1: { height: '13px', width: '100%', marginBottom: '0.3rem' },
+  descLine2: { height: '13px', width: '60%', marginBottom: '1rem' },
+  bar: { height: '6px', borderRadius: '99px', marginBottom: '0.5rem' },
+  meta: { display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' },
+  metaLeft: { height: '13px', width: '45%' },
+  metaRight: { height: '13px', width: '20%' },
+  target: { height: '12px', width: '35%', marginTop: '0.3rem' },
+};

--- a/frontend/src/components/skeletons/CampaignDetailSkeleton.jsx
+++ b/frontend/src/components/skeletons/CampaignDetailSkeleton.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+export default function CampaignDetailSkeleton() {
+  return (
+    <main className="container" style={{ paddingTop: '2.5rem', paddingBottom: '4rem', maxWidth: '760px' }} aria-hidden="true">
+      {/* Header */}
+      <div style={{ marginBottom: '1.5rem' }}>
+        <div className="skeleton" style={{ width: '48px', height: '20px', borderRadius: '99px', marginBottom: '0.6rem' }} />
+        <div className="skeleton" style={{ height: '32px', width: '65%', marginBottom: '0.6rem' }} />
+        <div className="skeleton" style={{ height: '16px', width: '100%', marginBottom: '0.3rem' }} />
+        <div className="skeleton" style={{ height: '16px', width: '80%' }} />
+      </div>
+
+      {/* Progress card */}
+      <div style={{ background: '#fff', border: '1px solid #e5e5e5', borderRadius: '10px', padding: '1.5rem', marginBottom: '1rem' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '1rem' }}>
+          <div>
+            <div className="skeleton" style={{ height: '28px', width: '120px', marginBottom: '0.4rem' }} />
+            <div className="skeleton" style={{ height: '14px', width: '90px' }} />
+          </div>
+          <div style={{ textAlign: 'right' }}>
+            <div className="skeleton" style={{ height: '28px', width: '60px', marginBottom: '0.4rem' }} />
+            <div className="skeleton" style={{ height: '14px', width: '44px' }} />
+          </div>
+        </div>
+        <div className="skeleton" style={{ height: '8px', borderRadius: '99px', marginBottom: '1.25rem' }} />
+        <div className="skeleton" style={{ height: '44px', borderRadius: '6px' }} />
+      </div>
+
+      {/* Wallet info */}
+      <div style={{ background: '#f8f8f8', borderRadius: '8px', padding: '0.75rem 1rem', marginBottom: '1.75rem' }}>
+        <div className="skeleton" style={{ height: '11px', width: '100px', marginBottom: '0.4rem' }} />
+        <div className="skeleton" style={{ height: '14px', width: '85%' }} />
+      </div>
+
+      {/* Contributions section */}
+      <div className="skeleton" style={{ height: '20px', width: '160px', marginBottom: '0.75rem' }} />
+      <ContributionListSkeleton />
+    </main>
+  );
+}
+
+function ContributionListSkeleton() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      {[80, 65, 72].map((w, i) => (
+        <div
+          key={i}
+          style={{ display: 'flex', justifyContent: 'space-between', background: '#fff', border: '1px solid #eee', borderRadius: '6px', padding: '0.6rem 0.85rem' }}
+        >
+          <div className="skeleton" style={{ height: '14px', width: `${w}%` }} />
+          <div className="skeleton" style={{ height: '14px', width: '50px', flexShrink: 0, marginLeft: '1rem' }} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/skeletons/ContributionListSkeleton.jsx
+++ b/frontend/src/components/skeletons/ContributionListSkeleton.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function ContributionListSkeleton({ rows = 4 }) {
+  const widths = [78, 62, 71, 55, 68];
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }} aria-hidden="true">
+      {Array.from({ length: rows }, (_, i) => (
+        <div
+          key={i}
+          style={{ display: 'flex', justifyContent: 'space-between', background: '#fff', border: '1px solid #eee', borderRadius: '6px', padding: '0.6rem 0.85rem', alignItems: 'center' }}
+        >
+          <div>
+            <div className="skeleton" style={{ height: '13px', width: `${widths[i % widths.length]}px`, marginBottom: '0.25rem' }} />
+            <div className="skeleton" style={{ height: '11px', width: `${widths[(i + 2) % widths.length] - 10}px` }} />
+          </div>
+          <div className="skeleton" style={{ height: '13px', width: '52px', flexShrink: 0, marginLeft: '1rem' }} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -226,3 +226,23 @@ input:focus, textarea:focus, select:focus { border-color: #7c3aed; }
     flex: 0 0 auto;
   }
 }
+
+@keyframes skeleton-shimmer {
+  0%   { background-position: -400px 0; }
+  100% { background-position: 400px 0; }
+}
+
+.skeleton {
+  background: linear-gradient(90deg, #ececec 25%, #f5f5f5 50%, #ececec 75%);
+  background-size: 800px 100%;
+  animation: skeleton-shimmer 1.4s ease-in-out infinite;
+  border-radius: 4px;
+}
+
+.skeleton--card {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 10px;
+  padding: 1.25rem;
+  min-height: 148px;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,12 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import ErrorBoundary from './components/ErrorBoundary';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -4,6 +4,8 @@ import { api } from '../services/api';
 import { useAuth } from '../context/AuthContext';
 import ContributeModal from '../components/ContributeModal';
 import WithdrawalsSection from '../components/WithdrawalsSection';
+import CampaignDetailSkeleton from '../components/skeletons/CampaignDetailSkeleton';
+import ContributionListSkeleton from '../components/skeletons/ContributionListSkeleton';
 
 function escapeHtml(text) {
   return text
@@ -32,7 +34,7 @@ export default function Campaign() {
   const { user, token } = useAuth();
   const [campaign, setCampaign] = useState(null);
   const [loadError, setLoadError] = useState('');
-  const [contributions, setContributions] = useState([]);
+  const [contributions, setContributions] = useState(null);
   const [showModal, setShowModal] = useState(false);
   const [contributed, setContributed] = useState(false);
   const [showCreatedBanner, setShowCreatedBanner] = useState(!!location.state?.created);
@@ -47,7 +49,8 @@ export default function Campaign() {
       .getCampaign(id)
       .then(setCampaign)
       .catch((err) => setLoadError(err.message || 'Could not load campaign.'));
-    api.getContributions(id).then(setContributions).catch(() => setContributions([]));
+    api.getContributions(id).then(setContributions).catch(() => setContributions([]))
+
     api.getCampaignUpdates(id, { limit: 20 }).then(setUpdates).catch(() => setUpdates([]));
   }, [id, contributed]);
 
@@ -71,11 +74,7 @@ export default function Campaign() {
   }
 
   if (!campaign) {
-    return (
-      <main className="container" style={{ paddingTop: '3rem' }}>
-        <p style={{ color: '#666' }}>Loading campaign…</p>
-      </main>
-    );
+    return <CampaignDetailSkeleton />;
   }
 
   const pct = Math.min(100, (campaign.raised_amount / campaign.target_amount) * 100).toFixed(1);
@@ -233,8 +232,12 @@ export default function Campaign() {
         </div>
       )}
 
-      <h2 style={styles.sectionTitle}>Contributions ({contributions.length})</h2>
-      {contributions.length === 0 ? (
+      <h2 style={styles.sectionTitle}>
+        Contributions {contributions !== null ? `(${contributions.length})` : ''}
+      </h2>
+      {contributions === null ? (
+        <ContributionListSkeleton />
+      ) : contributions.length === 0 ? (
         <p style={{ color: '#999' }}>No contributions yet.</p>
       ) : (
         <div style={styles.list}>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { api } from '../services/api';
 import CampaignCard from '../components/CampaignCard';
+import CampaignCardSkeleton from '../components/skeletons/CampaignCardSkeleton';
 import { useAuth } from '../context/AuthContext';
 import OnboardingCallout from '../components/OnboardingCallout';
 import {
@@ -108,7 +109,9 @@ export default function Home() {
       <h2 style={styles.sectionTitle}>Active campaigns</h2>
 
       {loading ? (
-        <p style={{ color: '#666' }}>Loading campaigns…</p>
+        <div style={styles.grid}>
+          {Array.from({ length: 6 }, (_, i) => <CampaignCardSkeleton key={i} />)}
+        </div>
       ) : listError ? (
         <p className="alert alert--error" role="alert">
           {listError}

--- a/frontend/src/pages/NotFound.jsx
+++ b/frontend/src/pages/NotFound.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function NotFound() {
+  return (
+    <main className="container page-narrow" style={{ paddingTop: '4rem', paddingBottom: '4rem', textAlign: 'center' }}>
+      <div style={styles.code}>404</div>
+      <h1 style={styles.heading}>Page not found</h1>
+      <p style={styles.sub}>
+        The page you're looking for doesn't exist or has been moved.
+      </p>
+      <div style={styles.actions}>
+        <Link to="/">
+          <button type="button" className="btn-primary">Back to home</button>
+        </Link>
+        <Link to="/">
+          <button type="button" className="btn-secondary">Browse campaigns</button>
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+const styles = {
+  code: { fontSize: '5rem', fontWeight: 800, color: '#ede9fe', lineHeight: 1, marginBottom: '0.5rem' },
+  heading: { fontSize: '1.5rem', fontWeight: 700, color: '#111', marginBottom: '0.75rem' },
+  sub: { color: '#666', fontSize: '1rem', lineHeight: 1.55, marginBottom: '2rem' },
+  actions: { display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap' },
+};


### PR DESCRIPTION
Closes #40

## Summary

- **404 page** — `NotFound.jsx` added as the catch-all `path="*"` route in `App.jsx`; includes a home link and a browse campaigns link
- **Error boundary** — `ErrorBoundary.jsx` class component wraps the entire app in `main.jsx`; logs errors to console and shows a "Reload page" button on crash
- **Skeleton screens** — three shimmer skeleton components (`CampaignCardSkeleton`, `CampaignDetailSkeleton`, `ContributionListSkeleton`) replace plain text loading states; shimmer animation added to `index.css` via `.skeleton` utility class

## Behaviour changes

| Location | Before | After |
|---|---|---|
| Unknown route | blank screen | 404 page |
| JS crash | blank screen | error boundary with reload |
| Home loading | "Loading campaigns…" text | 6 shimmer card skeletons |
| Campaign detail loading | "Loading campaign…" text | full-page layout skeleton |
| Contributions loading | shown immediately as empty | skeleton rows until resolved |

## Test plan

- [ ] Navigate to `/campaigns/does-not-exist-uuid` and any random path — 404 page renders with working links
- [ ] Temporarily throw in a component render to verify error boundary catches it and shows reload button
- [ ] On a slow connection (DevTools throttle), Home shows skeleton grid before campaigns appear
- [ ] Campaign detail shows skeleton before data arrives; contributions section shows row skeletons independently
- [ ] Skeleton layout visually matches the real content it replaces
