### PR TITLE
Add validation, campaign status automation, frontend tests, and E2E s…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,11 @@ jobs:
         working-directory: ./backend
         env:
           DATABASE_URL: postgresql://postgres:password@localhost:5432/crowdpay_test
-          JWT_SECRET: ${{ secrets.JWT_SECRET }}
-          PLATFORM_SECRET_KEY: ${{ secrets.PLATFORM_SECRET_KEY }}
-          STELLAR_NETWORK: ${{ secrets.STELLAR_NETWORK }}
-          USDC_ISSUER: ${{ secrets.USDC_ISSUER }}
+          JWT_SECRET: testsecret
+          PLATFORM_SECRET_KEY: SCVMQUS5EMTHWBLJTE5XCSCMHB2ZOVKRR4ATVTRPUNRCOGKRENIL3LHR
+          STELLAR_NETWORK: testnet
+          USDC_ISSUER: GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+          ENABLE_CAMPAIGN_STATUS_CRON: 'false'
         run: npm test
 
   frontend-checks:
@@ -75,6 +76,58 @@ jobs:
         working-directory: ./frontend
         run: npx eslint .
 
+      - name: Run unit tests
+        working-directory: ./frontend
+        run: npm test
+
       - name: Run build
         working-directory: ./frontend
         run: npm run build
+
+  e2e:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: crowdpay
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install backend dependencies
+        working-directory: ./backend
+        run: npm ci
+
+      - name: Install frontend dependencies
+        working-directory: ./frontend
+        run: npm ci
+
+      - name: Install Playwright
+        run: npm ci && npx playwright install --with-deps chromium
+
+      - name: Prepare database
+        env:
+          PGPASSWORD: password
+        run: |
+          psql -h localhost -p 5433 -U postgres -d crowdpay -f backend/db/schema.sql
+          psql -h localhost -p 5433 -U postgres -d crowdpay -f backend/db/seed.sql
+
+      - name: Run E2E tests
+        env:
+          CI: true
+          DATABASE_URL: postgresql://postgres:password@localhost:5433/crowdpay
+        run: npm run test:e2e

--- a/README.md
+++ b/README.md
@@ -188,6 +188,22 @@ cd frontend && npm run dev
 Backend runs on `http://localhost:3001`  
 Frontend runs on `http://localhost:5173`
 
+### Testing
+
+```bash
+# Backend unit + route tests
+cd backend && npm test
+
+# Frontend component tests (Vitest + React Testing Library)
+cd frontend && npm test
+
+# End-to-end tests (Playwright — starts backend + frontend dev servers)
+# Requires PostgreSQL with schema + seed applied (see docker-compose on port 5433)
+npm install
+npx playwright install
+npm run test:e2e
+```
+
 ---
 
 ## Core Stellar Concepts Used

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.1",
+        "node-cron": "^3.0.3",
         "nodemailer": "^8.0.6",
         "pg": "^8.11.5",
         "swagger-jsdoc": "^6.2.8",
@@ -3658,10 +3659,22 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nodemailer": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
-      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.9.tgz",
+      "integrity": "sha512-5ofa7BUN8+C+Hckh5V2GjeeOGRQBx0CJQA6KxrvuZfC8iU4/q7sLn8XrtEEhJkjV6HdyIiQs7Bba6bTao8JhkA==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -4794,6 +4807,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validator": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "nodemon src/index.js",
     "start": "node src/index.js",
-    "test": "NODE_ENV=test JWT_SECRET=testsecret node --test src/**/*.test.js",
+    "test": "NODE_ENV=test JWT_SECRET=testsecret USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5 STELLAR_NETWORK=testnet PLATFORM_SECRET_KEY=SCVMQUS5EMTHWBLJTE5XCSCMHB2ZOVKRR4ATVTRPUNRCOGKRENIL3LHR node --test src/**/*.test.js",
     "rotate-wallet-secrets": "node src/scripts/rotateWalletSecrets.js"
   },
   "dependencies": {
@@ -22,6 +22,7 @@
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.1",
+    "node-cron": "^3.0.3",
     "nodemailer": "^8.0.6",
     "pg": "^8.11.5",
     "swagger-jsdoc": "^6.2.8",

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -10,6 +10,7 @@ const { requestIdMiddleware } = require('./middleware/requestId');
 const { requestLogger } = require('./middleware/requestLogger');
 const { normalizeErrorResponse, errorHandler } = require('./middleware/errorHandler');
 const { startLedgerMonitor, getLedgerStreamHealth } = require('./services/ledgerMonitor');
+const { refreshActiveCampaignStatuses } = require('./services/campaignStatusService');
 const { sendAlert } = require('./services/alerting');
 const { assertNoLegacyPlaintextUserWalletSecrets } = require('./services/walletSecrets');
 const swaggerUi = require('swagger-ui-express');
@@ -105,6 +106,17 @@ const { startWebhookRetryPoller } = require('./services/webhookDispatcher');
 
 const PORT = process.env.PORT || 3001;
 
+function startCampaignStatusCron() {
+  if (process.env.ENABLE_CAMPAIGN_STATUS_CRON === 'false') return;
+  const cron = require('node-cron');
+  cron.schedule('0 * * * *', () => {
+    refreshActiveCampaignStatuses().catch((err) => {
+      logger.error('Campaign status cron failed', { error: err.message });
+    });
+  });
+  logger.info('Campaign status cron scheduled (hourly)');
+}
+
 async function bootstrap() {
   if (process.env.NODE_ENV === 'production') {
     await assertNoLegacyPlaintextUserWalletSecrets();
@@ -114,6 +126,7 @@ async function bootstrap() {
     logger.info('CrowdPay backend running', { port: PORT, stellar_network: process.env.STELLAR_NETWORK });
     startLedgerMonitor();
     startWebhookRetryPoller();
+    startCampaignStatusCron();
   });
 }
 

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -5,6 +5,11 @@ const { getSupportedAssetCodes } = require('../services/stellarService');
 const SUPPORTED_ASSETS = getSupportedAssetCodes();
 const VALID_CAMPAIGN_STATUSES = ['active', 'funded', 'closed', 'failed'];
 const VALID_ORDER_BY = ['newest', 'ending_soon', 'most_funded', 'most_backed'];
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isUuid(value) {
+  return typeof value === 'string' && UUID_PATTERN.test(value);
+}
 
 function stripHtml(value = '') {
   return String(value).replace(/<[^>]*>/g, '').trim();
@@ -48,10 +53,14 @@ const createCampaignValidation = [
   body('title')
     .customSanitizer(stripHtml)
     .notEmpty()
-    .withMessage('Title is required'),
+    .withMessage('Title is required')
+    .isLength({ max: 100 })
+    .withMessage('Title must be at most 100 characters'),
   body('description')
     .optional({ nullable: true })
-    .customSanitizer(stripHtml),
+    .customSanitizer(stripHtml)
+    .isLength({ max: 1000 })
+    .withMessage('Description must be at most 1000 characters'),
   body('target_amount')
     .exists()
     .withMessage('Target amount is required')
@@ -130,12 +139,32 @@ const createCampaignUpdateValidation = [
     .withMessage('Body is required'),
 ];
 
+const contributionQuoteValidation = [
+  query('send_asset')
+    .notEmpty()
+    .withMessage('send_asset is required')
+    .isIn(SUPPORTED_ASSETS)
+    .withMessage(`send_asset must be one of: ${SUPPORTED_ASSETS.join(', ')}`),
+  query('dest_asset')
+    .notEmpty()
+    .withMessage('dest_asset is required')
+    .isIn(SUPPORTED_ASSETS)
+    .withMessage(`dest_asset must be one of: ${SUPPORTED_ASSETS.join(', ')}`),
+  query('dest_amount')
+    .notEmpty()
+    .withMessage('dest_amount is required')
+    .isFloat({ gt: 0 })
+    .withMessage('dest_amount must be greater than zero'),
+];
+
 const contributionValidation = [
   body('campaign_id')
     .notEmpty()
     .withMessage('campaign_id is required')
-    .isUUID()
-    .withMessage('campaign_id must be a valid UUID'),
+    .custom((value) => {
+      if (!isUuid(value)) throw new Error('campaign_id must be a valid UUID');
+      return true;
+    }),
   body('amount')
     .exists()
     .withMessage('amount is required')
@@ -157,8 +186,10 @@ const withdrawalValidation = [
   body('campaign_id')
     .notEmpty()
     .withMessage('campaign_id is required')
-    .isUUID()
-    .withMessage('campaign_id must be a valid UUID'),
+    .custom((value) => {
+      if (!isUuid(value)) throw new Error('campaign_id must be a valid UUID');
+      return true;
+    }),
   body('amount')
     .exists()
     .withMessage('amount is required')
@@ -207,20 +238,7 @@ function validateRequest(req, res, next) {
   const result = validationResult(req);
   if (result.isEmpty()) return next();
 
-  const fields = result.array().reduce((acc, error) => {
-    if (!acc[error.param]) {
-      acc[error.param] = error.msg;
-    }
-    return acc;
-  }, {});
-
-  return res.status(422).json({
-    error: {
-      code: 'VALIDATION_ERROR',
-      message: 'Validation failed',
-      fields,
-    },
-  });
+  return res.status(400).json({ errors: result.array() });
 }
 
 module.exports = {
@@ -229,6 +247,7 @@ module.exports = {
   createCampaignValidation,
   createCampaignUpdateValidation,
   contributionValidation,
+  contributionQuoteValidation,
   withdrawalValidation,
   getCampaignsValidation,
   validateRequest,

--- a/backend/src/middleware/validation.test.js
+++ b/backend/src/middleware/validation.test.js
@@ -1,0 +1,73 @@
+process.env.USDC_ISSUER = process.env.USDC_ISSUER || 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+process.env.STELLAR_NETWORK = process.env.STELLAR_NETWORK || 'testnet';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { validationResult } = require('express-validator');
+const {
+  registerValidation,
+  createCampaignValidation,
+  contributionValidation,
+  withdrawalValidation,
+} = require('../middleware/validation');
+
+async function runValidation(validations, body = {}, query = {}) {
+  const req = { body, query };
+  for (const fn of validations) {
+    await fn(req, {}, () => {});
+  }
+  const result = validationResult(req);
+  if (!result.isEmpty()) {
+    return { ok: false, errors: result.array() };
+  }
+  return { ok: true };
+}
+
+test('register validation rejects invalid email and short password', async () => {
+  const result = await runValidation(registerValidation, {
+    email: 'not-an-email',
+    password: 'short',
+    name: '',
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.length >= 2);
+});
+
+test('createCampaign validation rejects title longer than 100 characters', async () => {
+  const result = await runValidation(createCampaignValidation, {
+    title: 'x'.repeat(101),
+    target_amount: '10',
+    asset_type: 'USDC',
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => e.path === 'title'));
+});
+
+test('contribution validation rejects non-UUID campaign_id', async () => {
+  const result = await runValidation(contributionValidation, {
+    campaign_id: 'not-a-uuid',
+    amount: '5',
+    send_asset: 'XLM',
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => e.path === 'campaign_id'));
+});
+
+test('withdrawal validation rejects invalid Stellar destination key', async () => {
+  const result = await runValidation(withdrawalValidation, {
+    campaign_id: '11111111-1111-1111-1111-111111111111',
+    amount: '10',
+    destination_key: 'invalid-key',
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => e.path === 'destination_key'));
+});
+
+test('register validation passes for valid payload', async () => {
+  const result = await runValidation(registerValidation, {
+    email: 'user@example.com',
+    password: 'Password1',
+    name: 'Test User',
+  });
+  assert.equal(result.ok, true);
+});

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -11,6 +11,8 @@ const {
 } = require('../services/stellarService');
 const { encryptSecret } = require('../services/walletService');
 const { watchCampaignWallet, addSSEClient, removeSSEClient } = require('../services/ledgerMonitor');
+const { emitWebhookEventForUser, WEBHOOK_EVENTS } = require('../services/webhookDispatcher');
+const { refreshCampaignStatus, refreshActiveCampaignStatuses } = require('../services/campaignStatusService');
 const { invokeContract, encodeMilestone, nativeToScVal } = require('../services/sorobanService');
 const { insertWithdrawalPendingSignatures } = require('../services/stellarTransactionService');
 const { sendEmail } = require('../services/emailService');
@@ -259,6 +261,7 @@ router.get('/:id', async (req, res) => {
     FROM campaigns
     WHERE id = $1
   `;
+  await refreshCampaignStatus(req.params.id);
   const { rows } = await db.query(query, [req.params.id]);
   if (!rows.length) return res.status(404).json({ error: 'Campaign not found' });
   
@@ -422,16 +425,8 @@ router.get('/:id/balance', async (req, res) => {
 
 // Scheduled endpoint to fail expired campaigns and prevent further contributions
 router.post('/cron/fail-expired', requireAuth, requireRole('admin'), async (req, res) => {
-  const { rows } = await db.query(
-    `UPDATE campaigns SET status = 'failed'
-       WHERE status = 'active'
-         AND deadline IS NOT NULL
-         AND deadline < CURRENT_DATE
-         AND raised_amount < target_amount
-     RETURNING id, title, target_amount, raised_amount, deadline`
-  );
-
-  res.json({ failedCampaigns: rows });
+  const { failed, funded } = await refreshActiveCampaignStatuses();
+  res.json({ failedCampaigns: failed, fundedCampaigns: funded });
 });
 
 // Scheduled endpoint to send 48h deadline reminders
@@ -538,7 +533,7 @@ router.post('/:id/trigger-refunds', requireAuth, requireRole('admin'), async (re
 });
 
 // Create campaign (authenticated)
-router.post('/', requireAuth, requireRole('creator', 'admin'), async (req, res) => {
+router.post('/', requireAuth, requireRole('creator', 'admin'), createCampaignValidation, validateRequest, async (req, res) => {
   /**
    * @openapi
    * /api/campaigns:
@@ -572,14 +567,6 @@ router.post('/', requireAuth, requireRole('creator', 'admin'), async (req, res) 
    *         description: Forbidden
    */
   const { title, description, target_amount, asset_type, deadline, milestones, min_contribution, max_contribution } = req.body;
-  if (!title || !target_amount || !asset_type) {
-    return res.status(400).json({ error: 'title, target_amount and asset_type are required' });
-  }
-  if (!SUPPORTED_ASSETS.includes(asset_type)) {
-    return res.status(400).json({
-      error: `asset_type must be one of: ${SUPPORTED_ASSETS.join(', ')}`,
-    });
-  }
 
   let normalizedMilestones;
   try {

--- a/backend/src/routes/campaigns.test.js
+++ b/backend/src/routes/campaigns.test.js
@@ -4,8 +4,18 @@ const express = require('express');
 const request = require('supertest');
 const proxyquire = require('proxyquire').noCallThru();
 
-function buildApp({ queryImpl, buildWithdrawalTransactionImpl, insertWithdrawalPendingSignaturesImpl, authUser }) {
+function buildApp({
+  queryImpl,
+  buildWithdrawalTransactionImpl,
+  insertWithdrawalPendingSignaturesImpl,
+  authUser,
+  campaignStatusImpl,
+}) {
   const router = proxyquire('./campaigns', {
+    '../services/campaignStatusService': campaignStatusImpl || {
+      refreshCampaignStatus: async () => ({ failed: null, funded: null }),
+      refreshActiveCampaignStatuses: async () => ({ failed: [], funded: [] }),
+    },
     '../config/database': {
       query: queryImpl,
       connect: async () => ({ query: queryImpl, release: async () => {} }),
@@ -39,18 +49,24 @@ function buildApp({ queryImpl, buildWithdrawalTransactionImpl, insertWithdrawalP
   return app;
 }
 
-test('POST /api/campaigns/cron/fail-expired returns failed campaigns', async () => {
+test('POST /api/campaigns/cron/fail-expired returns failed and funded campaigns', async () => {
   const app = buildApp({
-    queryImpl: async (text) => {
-      if (text.includes('UPDATE campaigns SET status =')) {
-        return {
-          rows: [{ id: 'c-1', title: 'Campaign 1', target_amount: '100', raised_amount: '50', deadline: '2026-04-23' }],
-        };
-      }
-      return { rows: [] };
-    },
+    queryImpl: async () => ({ rows: [] }),
     buildWithdrawalTransactionImpl: async () => '',
     insertWithdrawalPendingSignaturesImpl: async () => 'tx-row',
+    campaignStatusImpl: {
+      refreshActiveCampaignStatuses: async () => ({
+        failed: [{
+          id: 'c-1',
+          title: 'Campaign 1',
+          target_amount: '100',
+          raised_amount: '50',
+          deadline: '2026-04-23',
+          status: 'failed',
+        }],
+        funded: [{ id: 'c-2', title: 'Funded', status: 'funded' }],
+      }),
+    },
   });
 
   const response = await request(app)
@@ -59,7 +75,7 @@ test('POST /api/campaigns/cron/fail-expired returns failed campaigns', async () 
 
   assert.equal(response.status, 200);
   assert.equal(response.body.failedCampaigns.length, 1);
-  assert.equal(response.body.failedCampaigns[0].id, 'c-1');
+  assert.equal(response.body.fundedCampaigns.length, 1);
 });
 
 test('POST /api/campaigns blocks unverified creators when KYC gate is enabled', async (t) => {
@@ -73,7 +89,7 @@ test('POST /api/campaigns blocks unverified creators when KYC gate is enabled', 
   const app = buildApp({
     authUser: { userId: 'creator-1', role: 'creator' },
     queryImpl: async (text) => {
-      if (text.includes('SELECT wallet_public_key, kyc_status FROM users')) {
+      if (text.includes('SELECT email, wallet_public_key, kyc_status FROM users')) {
         return { rows: [{ wallet_public_key: 'GCREATOR', kyc_status: 'pending' }] };
       }
       return { rows: [] };
@@ -102,7 +118,7 @@ test('POST /api/campaigns allows creation when KYC gate is disabled', async (t) 
   const app = buildApp({
     authUser: { userId: 'creator-1', role: 'creator' },
     queryImpl: async (text) => {
-      if (text.includes('SELECT wallet_public_key, kyc_status FROM users')) {
+      if (text.includes('SELECT email, wallet_public_key, kyc_status FROM users')) {
         return { rows: [{ wallet_public_key: 'GCREATOR', kyc_status: 'unverified' }] };
       }
       if (text.includes('INSERT INTO campaigns')) {
@@ -130,6 +146,25 @@ test('POST /api/campaigns allows creation when KYC gate is disabled', async (t) 
 
   assert.equal(response.status, 201);
   assert.equal(response.body.id, 'campaign-1');
+});
+
+test('POST /api/campaigns returns 400 with validation errors for invalid payload', async () => {
+  process.env.KYC_REQUIRED_FOR_CAMPAIGNS = 'false';
+  const app = buildApp({
+    authUser: { userId: 'creator-1', role: 'creator' },
+    queryImpl: async () => ({ rows: [] }),
+    buildWithdrawalTransactionImpl: async () => '',
+    insertWithdrawalPendingSignaturesImpl: async () => 'tx-row',
+  });
+
+  const response = await request(app)
+    .post('/api/campaigns')
+    .set('Authorization', 'Bearer token')
+    .send({ title: '', target_amount: -5, asset_type: 'INVALID' });
+
+  assert.equal(response.status, 400);
+  assert.ok(Array.isArray(response.body.errors));
+  assert.ok(response.body.errors.length >= 1);
 });
 
 test('POST /api/campaigns/:id/trigger-refunds creates refund requests for contributions', async () => {

--- a/backend/src/routes/contributions.js
+++ b/backend/src/routes/contributions.js
@@ -7,7 +7,7 @@ const { networkPassphrase, isTestnet } = require('../config/stellar');
 const { requireAuth } = require('../middleware/auth');
 const logger = require('../config/logger');
 const { sendAlert } = require('../services/alerting');
-const { contributionValidation, validateRequest } = require('../middleware/validation');
+const { contributionValidation, contributionQuoteValidation, validateRequest } = require('../middleware/validation');
 const {
   buildUnsignedContributionPayment,
   buildUnsignedContributionPathPayment,
@@ -232,7 +232,7 @@ router.get('/finalization/:txHash', requireAuth, async (req, res) => {
 });
 
 // Quote conversion before a path payment contribution
-router.get('/quote', requireAuth, async (req, res) => {
+router.get('/quote', requireAuth, contributionQuoteValidation, validateRequest, async (req, res) => {
   /**
    * @openapi
    * /api/contributions/quote:
@@ -277,14 +277,6 @@ router.get('/quote', requireAuth, async (req, res) => {
    *         description: No path found
    */
   const { send_asset, dest_asset, dest_amount } = req.query;
-  if (!send_asset || !dest_asset || !dest_amount) {
-    return res.status(400).json({
-      error: 'send_asset, dest_asset and dest_amount are required query params',
-    });
-  }
-  if (!SUPPORTED_ASSETS.includes(send_asset) || !SUPPORTED_ASSETS.includes(dest_asset)) {
-    return res.status(400).json({ error: `Supported assets: ${SUPPORTED_ASSETS.join(', ')}` });
-  }
 
   const paths = await getPathPaymentQuote({
     sendAsset: send_asset,
@@ -557,6 +549,9 @@ router.post('/', contributionPostLimiter, requireAuth, contributionValidation, v
       stellar_transaction_id: result.stellarTransactionId,
       message: 'Transaction submitted',
       conversion_quote: result.conversionQuote,
+      ...(result.platform_fee_amount != null
+        ? { platform_fee_amount: result.platform_fee_amount }
+        : {}),
     });
   } catch (err) {
     if (err.statusCode === 422) {

--- a/backend/src/routes/contributions.test.js
+++ b/backend/src/routes/contributions.test.js
@@ -14,6 +14,7 @@ const {
 } = require('@stellar/stellar-sdk');
 
 const TESTNET_PASSPHRASE = Networks.TESTNET;
+const VALID_G = 'GASXEYHSSVN3WSHD4WSZ4O37HC2AG4JH2EB6UPHM6IXDXDRJRDJD4RZK';
 
 function buildUnsignedPaymentXdr({ senderPublicKey, destinationPublicKey, amount, asset = 'XLM' }) {
   return new TransactionBuilder(new Account(senderPublicKey, '1'), {
@@ -119,9 +120,14 @@ function buildApp({ queryImpl, stellarImpl, stellarTxImpl }) {
       campaignId,
       userId,
       walletPublicKey,
+      walletSecretEncrypted,
       amount,
       sendAsset,
     }) => {
+      await stellarStub.ensureCustodialAccountFundedAndTrusted({
+        publicKey: walletPublicKey,
+        secret: 'SDECRYPTED',
+      });
       const intent = await contributionServiceStub.buildContributionIntent({
         campaign,
         amount,
@@ -148,20 +154,30 @@ function buildApp({ queryImpl, stellarImpl, stellarTxImpl }) {
               memo: 'cp-c-1',
             });
 
-      const txHash = await stellarStub.submitPreparedTransaction(prepared.signedXdr);
+      let txHash;
+      try {
+        txHash = await stellarStub.submitPreparedTransaction(prepared.signedXdr);
+      } catch (err) {
+        err.statusCode = err.statusCode || 502;
+        throw err;
+      }
       const stellarTransactionId = await stellarTxStub.insertContributionSubmitted(null, {
         txHash,
         campaignId,
         userId,
         unsignedXdr: prepared.unsignedXdr,
         signedXdr: prepared.signedXdr,
-        metadata: intent.flowMetadata,
+        metadata: {
+          ...intent.flowMetadata,
+          platform_fee_amount: prepared.feeAmount ?? 0,
+        },
       });
 
       return {
         txHash,
         stellarTransactionId,
         conversionQuote: intent.conversionQuote,
+        platform_fee_amount: prepared.feeAmount ?? 0,
       };
     },
   };
@@ -244,7 +260,7 @@ test('POST /api/contributions uses direct payment for same asset', async () => {
     queryImpl: async (text) => {
       if (text.includes('FROM campaigns')) {
         return {
-          rows: [{ id: 'c-1', status: 'active', asset_type: 'XLM', wallet_public_key: 'GDEST' }],
+          rows: [{ id: '11111111-1111-1111-1111-111111111111', status: 'active', asset_type: 'XLM', wallet_public_key: VALID_G }],
         };
       }
       if (text.includes('FROM users')) {
@@ -273,7 +289,7 @@ test('POST /api/contributions uses direct payment for same asset', async () => {
   const response = await request(app)
     .post('/api/contributions')
     .set('Authorization', 'Bearer token')
-    .send({ campaign_id: 'c-1', amount: '5.0000000', send_asset: 'XLM' });
+    .send({ campaign_id: '11111111-1111-1111-1111-111111111111', amount: '5.0000000', send_asset: 'XLM' });
 
   assert.equal(response.status, 202);
   assert.equal(response.body.tx_hash, 'tx-direct');
@@ -289,7 +305,7 @@ test('POST /api/contributions uses direct payment for same USDC asset', async ()
     queryImpl: async (text) => {
       if (text.includes('FROM campaigns')) {
         return {
-          rows: [{ id: 'c-2', status: 'active', asset_type: 'USDC', wallet_public_key: 'GDEST2' }],
+          rows: [{ id: '22222222-2222-2222-2222-222222222222', status: 'active', asset_type: 'USDC', wallet_public_key: VALID_G }],
         };
       }
       if (text.includes('FROM users')) {
@@ -316,7 +332,7 @@ test('POST /api/contributions uses direct payment for same USDC asset', async ()
   const response = await request(app)
     .post('/api/contributions')
     .set('Authorization', 'Bearer token')
-    .send({ campaign_id: 'c-2', amount: '7.0000000', send_asset: 'USDC' });
+    .send({ campaign_id: '22222222-2222-2222-2222-222222222222', amount: '7.0000000', send_asset: 'USDC' });
 
   assert.equal(response.status, 202);
   assert.equal(response.body.tx_hash, 'tx-direct-usdc');
@@ -329,7 +345,7 @@ test('POST /api/contributions uses path payment for conversion', async () => {
     queryImpl: async (text) => {
       if (text.includes('FROM campaigns')) {
         return {
-          rows: [{ id: 'c-1', status: 'active', asset_type: 'USDC', wallet_public_key: 'GDEST' }],
+          rows: [{ id: '11111111-1111-1111-1111-111111111111', status: 'active', asset_type: 'USDC', wallet_public_key: VALID_G }],
         };
       }
       if (text.includes('FROM users')) {
@@ -363,7 +379,7 @@ test('POST /api/contributions uses path payment for conversion', async () => {
   const response = await request(app)
     .post('/api/contributions')
     .set('Authorization', 'Bearer token')
-    .send({ campaign_id: 'c-1', amount: '4.5000000', send_asset: 'XLM' });
+    .send({ campaign_id: '11111111-1111-1111-1111-111111111111', amount: '4.5000000', send_asset: 'XLM' });
 
   assert.equal(response.status, 202);
   assert.equal(response.body.tx_hash, 'tx-path');
@@ -379,7 +395,7 @@ test('POST /api/contributions supports reverse conversion USDC -> XLM', async ()
     queryImpl: async (text) => {
       if (text.includes('FROM campaigns')) {
         return {
-          rows: [{ id: 'c-3', status: 'active', asset_type: 'XLM', wallet_public_key: 'GDEST3' }],
+          rows: [{ id: '33333333-3333-3333-3333-333333333333', status: 'active', asset_type: 'XLM', wallet_public_key: VALID_G }],
         };
       }
       if (text.includes('FROM users')) {
@@ -414,7 +430,7 @@ test('POST /api/contributions supports reverse conversion USDC -> XLM', async ()
   const response = await request(app)
     .post('/api/contributions')
     .set('Authorization', 'Bearer token')
-    .send({ campaign_id: 'c-3', amount: '10.0000000', send_asset: 'USDC' });
+    .send({ campaign_id: '33333333-3333-3333-3333-333333333333', amount: '10.0000000', send_asset: 'USDC' });
 
   assert.equal(response.status, 202);
   assert.equal(response.body.tx_hash, 'tx-path-reverse');
@@ -429,7 +445,7 @@ test('POST /api/contributions returns 503 when custodial trustline setup fails',
     queryImpl: async (text) => {
       if (text.includes('FROM campaigns')) {
         return {
-          rows: [{ id: 'c-1', status: 'active', asset_type: 'XLM', wallet_public_key: 'GDEST' }],
+          rows: [{ id: '11111111-1111-1111-1111-111111111111', status: 'active', asset_type: 'XLM', wallet_public_key: VALID_G }],
         };
       }
       if (text.includes('FROM users')) {
@@ -449,7 +465,7 @@ test('POST /api/contributions returns 503 when custodial trustline setup fails',
   const response = await request(app)
     .post('/api/contributions')
     .set('Authorization', 'Bearer token')
-    .send({ campaign_id: 'c-1', amount: '5.0000000', send_asset: 'XLM' });
+    .send({ campaign_id: '11111111-1111-1111-1111-111111111111', amount: '5.0000000', send_asset: 'XLM' });
 
   assert.equal(response.status, 503);
   assert.match(response.body.error, /retry/i);
@@ -461,7 +477,7 @@ test('POST /api/contributions returns 502 when Stellar submit fails and skips au
     queryImpl: async (text) => {
       if (text.includes('FROM campaigns')) {
         return {
-          rows: [{ id: 'c-1', status: 'active', asset_type: 'XLM', wallet_public_key: 'GDEST' }],
+          rows: [{ id: '11111111-1111-1111-1111-111111111111', status: 'active', asset_type: 'XLM', wallet_public_key: VALID_G }],
         };
       }
       if (text.includes('FROM users')) {
@@ -487,7 +503,7 @@ test('POST /api/contributions returns 502 when Stellar submit fails and skips au
   const response = await request(app)
     .post('/api/contributions')
     .set('Authorization', 'Bearer token')
-    .send({ campaign_id: 'c-1', amount: '5.0000000', send_asset: 'XLM' });
+    .send({ campaign_id: '11111111-1111-1111-1111-111111111111', amount: '5.0000000', send_asset: 'XLM' });
 
   assert.equal(response.status, 502);
   assert.equal(inserted, false);
@@ -500,7 +516,7 @@ test('POST /api/contributions/prepare returns unsigned XDR and prepare token for
     queryImpl: async (text) => {
       if (text.includes('FROM campaigns')) {
         return {
-          rows: [{ id: 'c-1', status: 'active', asset_type: 'XLM', wallet_public_key: 'GDEST' }],
+          rows: [{ id: '11111111-1111-1111-1111-111111111111', status: 'active', asset_type: 'XLM', wallet_public_key: VALID_G }],
         };
       }
       return { rows: [] };
@@ -522,7 +538,7 @@ test('POST /api/contributions/prepare returns unsigned XDR and prepare token for
     .post('/api/contributions/prepare')
     .set('Authorization', 'Bearer token')
     .send({
-      campaign_id: 'c-1',
+      campaign_id: '11111111-1111-1111-1111-111111111111',
       amount: '5.0000000',
       send_asset: 'XLM',
       sender_public_key: sender.publicKey(),
@@ -552,7 +568,7 @@ test('POST /api/contributions/submit-signed accepts Freighter-signed XDR that ma
       if (text.includes('FROM campaigns')) {
         return {
           rows: [{
-            id: 'c-1',
+            id: '11111111-1111-1111-1111-111111111111',
             status: 'active',
             asset_type: 'XLM',
             wallet_public_key: destination.publicKey(),
@@ -580,7 +596,7 @@ test('POST /api/contributions/submit-signed accepts Freighter-signed XDR that ma
     .post('/api/contributions/prepare')
     .set('Authorization', 'Bearer token')
     .send({
-      campaign_id: 'c-1',
+      campaign_id: '11111111-1111-1111-1111-111111111111',
       amount: '5.0000000',
       send_asset: 'XLM',
       sender_public_key: sender.publicKey(),
@@ -627,7 +643,7 @@ test('POST /api/contributions/submit-signed rejects a signed XDR that does not m
       if (text.includes('FROM campaigns')) {
         return {
           rows: [{
-            id: 'c-1',
+            id: '11111111-1111-1111-1111-111111111111',
             status: 'active',
             asset_type: 'XLM',
             wallet_public_key: destination.publicKey(),
@@ -648,7 +664,7 @@ test('POST /api/contributions/submit-signed rejects a signed XDR that does not m
     .post('/api/contributions/prepare')
     .set('Authorization', 'Bearer token')
     .send({
-      campaign_id: 'c-1',
+      campaign_id: '11111111-1111-1111-1111-111111111111',
       amount: '5.0000000',
       send_asset: 'XLM',
       sender_public_key: sender.publicKey(),
@@ -681,7 +697,7 @@ test('GET /api/contributions/finalization/:txHash returns finalized when indexed
               id: 'st-1',
               status: 'indexed',
               tx_hash: 'txh',
-              campaign_id: 'c-1',
+              campaign_id: '11111111-1111-1111-1111-111111111111',
               contribution_id: 'contrib-1',
               initiated_by_user_id: 'user-1',
               metadata: {},
@@ -719,7 +735,7 @@ test('POST /api/contributions includes platform_fee_amount in response and metad
     queryImpl: async (text) => {
       if (text.includes('FROM campaigns')) {
         return {
-          rows: [{ id: 'c-1', status: 'active', asset_type: 'USDC', wallet_public_key: 'GDEST' }],
+          rows: [{ id: '11111111-1111-1111-1111-111111111111', status: 'active', asset_type: 'USDC', wallet_public_key: VALID_G }],
         };
       }
       if (text.includes('FROM users')) {
@@ -749,7 +765,7 @@ test('POST /api/contributions includes platform_fee_amount in response and metad
   const response = await request(app)
     .post('/api/contributions')
     .set('Authorization', 'Bearer token')
-    .send({ campaign_id: 'c-1', amount: '10.0000000', send_asset: 'USDC' });
+    .send({ campaign_id: '11111111-1111-1111-1111-111111111111', amount: '10.0000000', send_asset: 'USDC' });
 
   assert.equal(response.status, 202);
   assert.equal(response.body.platform_fee_amount, 0.15);

--- a/backend/src/routes/users.test.js
+++ b/backend/src/routes/users.test.js
@@ -58,7 +58,7 @@ test('POST /api/auth/register encrypts wallet secret before insert and schedules
           rows: [
             {
               id: 'user-new',
-              email: 'a@b.c',
+              email: 'user@example.com',
               name: 'N',
               wallet_public_key: 'GUSER',
               role: 'contributor',
@@ -82,7 +82,7 @@ test('POST /api/auth/register encrypts wallet secret before insert and schedules
 
   const res = await request(app)
     .post('/api/auth/register')
-    .send({ email: 'a@b.c', password: 'longpassword1', name: 'N' });
+    .send({ email: 'user@example.com', password: 'Longpassword1', name: 'N' });
 
   assert.equal(res.status, 201);
   assert.equal(res.body.token, 'jwt-token');
@@ -92,4 +92,31 @@ test('POST /api/auth/register encrypts wallet secret before insert and schedules
   await new Promise((resolve) => setImmediate(resolve));
   await new Promise((resolve) => setImmediate(resolve));
   assert.equal(ensureCalled, true);
+});
+
+test('POST /api/auth/register returns 400 with validation errors for invalid input', async () => {
+  const app = buildApp({
+    queryImpl: async () => ({ rows: [] }),
+  });
+
+  const res = await request(app)
+    .post('/api/auth/register')
+    .send({ email: 'not-an-email', password: 'short', name: '' });
+
+  assert.equal(res.status, 400);
+  assert.ok(Array.isArray(res.body.errors));
+  assert.ok(res.body.errors.length >= 1);
+});
+
+test('POST /api/auth/login returns 400 with validation errors for invalid email', async () => {
+  const app = buildApp({
+    queryImpl: async () => ({ rows: [] }),
+  });
+
+  const res = await request(app)
+    .post('/api/auth/login')
+    .send({ email: 'bad-email', password: '' });
+
+  assert.equal(res.status, 400);
+  assert.ok(Array.isArray(res.body.errors));
 });

--- a/backend/src/routes/withdrawals.test.js
+++ b/backend/src/routes/withdrawals.test.js
@@ -51,9 +51,11 @@ function buildApp({ queryImpl, stellarImpl, userId = 'creator-1', role = 'creato
   return { app, cleanup: () => {} };
 }
 
+const VALID_DESTINATION = 'GASXEYHSSVN3WSHD4WSZ4O37HC2AG4JH2EB6UPHM6IXDXDRJRDJD4RZK';
+
 function campaignRow(overrides = {}) {
   return {
-    id: 'camp-1',
+    id: '11111111-1111-1111-1111-111111111111',
     creator_id: 'creator-1',
     wallet_public_key: 'GCAMPAIGN',
     asset_type: 'USDC',
@@ -105,7 +107,7 @@ test('POST /api/withdrawals/request creates pending request and logs event', asy
   const response = await request(app)
     .post('/api/withdrawals/request')
     .set('Authorization', 'Bearer token')
-    .send({ campaign_id: 'camp-1', destination_key: 'GDEST', amount: '10.0000000' });
+    .send({ campaign_id: '11111111-1111-1111-1111-111111111111', destination_key: VALID_DESTINATION, amount: '10.0000000' });
 
   cleanup();
   assert.equal(response.status, 201);
@@ -128,7 +130,7 @@ test('POST /api/withdrawals/request blocks when campaign not active or funded', 
   const response = await request(app)
     .post('/api/withdrawals/request')
     .set('Authorization', 'Bearer token')
-    .send({ campaign_id: 'camp-1', destination_key: 'GDEST', amount: '10.0000000' });
+    .send({ campaign_id: '11111111-1111-1111-1111-111111111111', destination_key: VALID_DESTINATION, amount: '10.0000000' });
 
   cleanup();
   assert.equal(response.status, 409);
@@ -150,7 +152,7 @@ test('POST /api/withdrawals/request blocks duplicate pending', async () => {
   const response = await request(app)
     .post('/api/withdrawals/request')
     .set('Authorization', 'Bearer token')
-    .send({ campaign_id: 'camp-1', destination_key: 'GDEST', amount: '10.0000000' });
+    .send({ campaign_id: '11111111-1111-1111-1111-111111111111', destination_key: VALID_DESTINATION, amount: '10.0000000' });
 
   cleanup();
   assert.equal(response.status, 409);
@@ -179,7 +181,7 @@ test('POST /api/withdrawals/request denies invalid multisig config', async () =>
   const response = await request(app)
     .post('/api/withdrawals/request')
     .set('Authorization', 'Bearer token')
-    .send({ campaign_id: 'camp-1', destination_key: 'GDEST', amount: '10.0000000' });
+    .send({ campaign_id: '11111111-1111-1111-1111-111111111111', destination_key: VALID_DESTINATION, amount: '10.0000000' });
 
   cleanup();
   assert.equal(response.status, 422);
@@ -216,6 +218,9 @@ test('POST /api/withdrawals/:id/approve/creator signs withdrawal request', async
     queryImpl: async (text) => {
       calls.push(text);
       if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
+      if (text.includes('SELECT creator_id FROM campaigns WHERE id')) {
+        return { rows: [{ creator_id: 'creator-1' }] };
+      }
       if (text.includes('FROM withdrawal_requests wr')) {
         return {
           rows: [{
@@ -225,12 +230,13 @@ test('POST /api/withdrawals/:id/approve/creator signs withdrawal request', async
             platform_signed: false,
             unsigned_xdr: 'xdr-base',
             creator_id: 'creator-1',
+            campaign_id: '11111111-1111-1111-1111-111111111111',
             campaign_status: 'active',
           }],
         };
       }
-      if (text.includes('wallet_secret_encrypted FROM users')) {
-        return { rows: [{ wallet_secret_encrypted: 'SCREATOR' }] };
+      if (text.includes('wallet_secret_encrypted') && text.includes('FROM users')) {
+        return { rows: [{ wallet_secret_encrypted: 'SCREATOR', wallet_public_key: 'GCREATOR' }] };
       }
       if (text.includes('UPDATE withdrawal_requests') && text.includes('creator_signed = TRUE')) {
         return { rows: [{ id: 'w-1', creator_signed: true, unsigned_xdr: 'xdr-signed' }] };
@@ -345,6 +351,9 @@ test('POST /api/withdrawals/:id/cancel succeeds before creator signs', async () 
   const { app, cleanup } = buildApp({
     queryImpl: async (text) => {
       if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
+      if (text.includes('SELECT creator_id FROM campaigns WHERE id')) {
+        return { rows: [{ creator_id: 'creator-1' }] };
+      }
       if (text.includes('FROM withdrawal_requests wr')) {
         return {
           rows: [{
@@ -352,6 +361,7 @@ test('POST /api/withdrawals/:id/cancel succeeds before creator signs', async () 
             status: 'pending',
             creator_signed: false,
             creator_id: 'creator-1',
+            campaign_id: '11111111-1111-1111-1111-111111111111',
           }],
         };
       }

--- a/backend/src/services/campaignStatusService.js
+++ b/backend/src/services/campaignStatusService.js
@@ -1,0 +1,72 @@
+const db = require('../config/database');
+const logger = require('../config/logger');
+
+/**
+ * Reconcile status for one campaign (active → funded or failed based on goal/deadline).
+ */
+async function refreshCampaignStatus(campaignId, client) {
+  const runner = client || db;
+  const { rows: failed } = await runner.query(
+    `UPDATE campaigns
+     SET status = 'failed'
+     WHERE id = $1
+       AND status = 'active'
+       AND deadline IS NOT NULL
+       AND deadline < CURRENT_DATE
+       AND raised_amount < target_amount
+     RETURNING id, title, target_amount, raised_amount, deadline, status`,
+    [campaignId]
+  );
+
+  const { rows: funded } = await runner.query(
+    `UPDATE campaigns
+     SET status = 'funded'
+     WHERE id = $1
+       AND status = 'active'
+       AND raised_amount >= target_amount
+     RETURNING id, title, target_amount, raised_amount, deadline, status`,
+    [campaignId]
+  );
+
+  return {
+    failed: failed[0] || null,
+    funded: funded[0] || null,
+  };
+}
+
+/**
+ * Batch refresh for all still-active campaigns (hourly cron).
+ */
+async function refreshActiveCampaignStatuses() {
+  const { rows: funded } = await db.query(
+    `UPDATE campaigns
+     SET status = 'funded'
+     WHERE status = 'active'
+       AND raised_amount >= target_amount
+     RETURNING id, title, target_amount, raised_amount, deadline, status`
+  );
+
+  const { rows: failed } = await db.query(
+    `UPDATE campaigns
+     SET status = 'failed'
+     WHERE status = 'active'
+       AND deadline IS NOT NULL
+       AND deadline < CURRENT_DATE
+       AND raised_amount < target_amount
+     RETURNING id, title, target_amount, raised_amount, deadline, status`
+  );
+
+  if (funded.length || failed.length) {
+    logger.info('Campaign status refresh completed', {
+      funded_count: funded.length,
+      failed_count: failed.length,
+    });
+  }
+
+  return { funded, failed };
+}
+
+module.exports = {
+  refreshCampaignStatus,
+  refreshActiveCampaignStatuses,
+};

--- a/backend/src/services/campaignStatusService.test.js
+++ b/backend/src/services/campaignStatusService.test.js
@@ -1,0 +1,48 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const proxyquire = require('proxyquire').noCallThru();
+
+test('refreshActiveCampaignStatuses marks funded and failed campaigns', async () => {
+  const queries = [];
+  const { refreshActiveCampaignStatuses } = proxyquire('./campaignStatusService', {
+    '../config/database': {
+      query: async (text) => {
+        queries.push(text);
+        if (text.includes("SET status = 'funded'")) {
+          return { rows: [{ id: 'funded-1', status: 'funded' }] };
+        }
+        if (text.includes("SET status = 'failed'")) {
+          return { rows: [{ id: 'failed-1', status: 'failed' }] };
+        }
+        return { rows: [] };
+      },
+    },
+    '../config/logger': { info: () => {}, error: () => {} },
+  });
+
+  const result = await refreshActiveCampaignStatuses();
+  assert.equal(result.funded.length, 1);
+  assert.equal(result.failed.length, 1);
+  assert.ok(queries.some((q) => q.includes("SET status = 'funded'")));
+  assert.ok(queries.some((q) => q.includes("SET status = 'failed'")));
+});
+
+test('refreshCampaignStatus updates a single campaign', async () => {
+  const { refreshCampaignStatus } = proxyquire('./campaignStatusService', {
+    '../config/database': {
+      query: async (text, params) => {
+        assert.equal(params[0], 'camp-uuid');
+        if (text.includes("SET status = 'failed'")) return { rows: [] };
+        if (text.includes("SET status = 'funded'")) {
+          return { rows: [{ id: 'camp-uuid', status: 'funded' }] };
+        }
+        return { rows: [] };
+      },
+    },
+    '../config/logger': { info: () => {}, error: () => {} },
+  });
+
+  const result = await refreshCampaignStatus('camp-uuid');
+  assert.equal(result.funded?.status, 'funded');
+  assert.equal(result.failed, null);
+});

--- a/e2e/flows.spec.js
+++ b/e2e/flows.spec.js
@@ -1,0 +1,130 @@
+import { test, expect } from '@playwright/test';
+
+const CREATOR = { email: 'bola@example.com', password: 'creator123' };
+const CONTRIBUTOR = { email: 'alice@example.com', password: 'password123' };
+
+test.describe('Contributor journey', () => {
+  test('register, browse campaigns, open campaign, and see contributions list', async ({ page }) => {
+    const email = `e2e-contrib-${Date.now()}@example.com`;
+
+    await page.goto('/register');
+    await page.getByPlaceholder('Full name').fill('E2E Contributor');
+    await page.getByPlaceholder('Email').fill(email);
+    await page.getByPlaceholder('Password').fill('Password1');
+    await page.getByRole('button', { name: /sign up/i }).click();
+
+    await expect(page).toHaveURL(/\/($|\?)/);
+    await expect(page.getByText(/campaign/i).first()).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole('link', { name: /solar study hub/i }).first().click();
+    await expect(page).toHaveURL(/\/campaigns\//);
+    await expect(page.getByRole('heading', { level: 1 })).toContainText(/solar/i);
+
+    await page.route('**/api/contributions', async (route) => {
+      if (route.request().method() === 'POST') {
+        return route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({ tx_hash: 'e2e-mock-tx', amount: '5', asset: 'USDC' }),
+        });
+      }
+      return route.continue();
+    });
+
+    await page.route('**/api/contributions?*', async (route) => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'contrib-e2e',
+            amount: '5',
+            asset: 'USDC',
+            sender_public_key: 'GSENDER',
+            display_name: 'E2E Contributor',
+            created_at: new Date().toISOString(),
+          },
+        ]),
+      });
+    });
+
+    await page.getByRole('button', { name: /contribute/i }).click();
+    await page.getByLabel(/amount campaign receives/i).fill('5');
+    await page.getByRole('button', { name: /confirm payment/i }).click();
+
+    await expect(page.getByText(/E2E Contributor|5/)).toBeVisible({ timeout: 15_000 });
+  });
+});
+
+test.describe('Campaign creator journey', () => {
+  test('login, create campaign, and see it on home', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByPlaceholder('Email').fill(CREATOR.email);
+    await page.getByPlaceholder('Password').fill(CREATOR.password);
+    await page.getByRole('button', { name: /log in/i }).click();
+
+    await page.goto('/campaigns/new');
+    const title = `E2E Campaign ${Date.now()}`;
+    await page.getByLabel(/title/i).fill(title);
+    await page.getByLabel(/description/i).fill('End-to-end test campaign description.');
+    await page.getByLabel(/target amount/i).fill('500');
+    await page.getByRole('button', { name: /create campaign|launch/i }).click();
+
+    await expect(page).toHaveURL(/\/campaigns\//, { timeout: 20_000 });
+    await page.goto('/');
+    await expect(page.getByText(title)).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole('link', { name: title }).click();
+    await expect(page.getByRole('heading', { level: 1 })).toContainText(title);
+    await expect(page.getByText(/500/)).toBeVisible();
+  });
+});
+
+test.describe('Withdrawal flow', () => {
+  test('creator sees withdrawal audit trail on funded campaign', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByPlaceholder('Email').fill(CREATOR.email);
+    await page.getByPlaceholder('Password').fill(CREATOR.password);
+    await page.getByRole('button', { name: /log in/i }).click();
+
+    await page.goto('/campaigns/22222222-2222-2222-2222-222222222222');
+    await expect(page.getByText(/community cold storage|funded/i)).toBeVisible({ timeout: 15_000 });
+
+    await page.route('**/api/withdrawals', async (route) => {
+      if (route.request().method() === 'POST') {
+        return route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: 'wr-e2e',
+            status: 'pending',
+            amount: '100',
+            destination_key: 'GBFQZXA6Q4M7BMSNL6Q5M6P47TQIJM47KQKAR5R6XWQ7QX4PX5A7K5TJ',
+          }),
+        });
+      }
+      return route.continue();
+    });
+
+    await page.route('**/api/withdrawals?*', async (route) => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'wr-e2e',
+            status: 'pending',
+            amount: '100',
+            destination_key: 'GBFQZXA6Q4M7BMSNL6Q5M6P47TQIJM47KQKAR5R6XWQ7QX4PX5A7K5TJ',
+            created_at: new Date().toISOString(),
+            approval_events: [{ event_type: 'requested', created_at: new Date().toISOString() }],
+          },
+        ]),
+      });
+    });
+
+    const withdrawalSection = page.getByText(/withdrawal/i).first();
+    await expect(withdrawalSection).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(/audit|pending|request/i).first()).toBeVisible();
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,9 +16,42 @@
         "react-simplemde-editor": "^5.2.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "^4.3.0",
-        "vite": "^5.2.12"
+        "jsdom": "^26.1.0",
+        "vite": "^5.2.12",
+        "vitest": "^3.1.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -254,6 +287,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -300,6 +343,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1131,6 +1289,104 @@
         "node": ">=10"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1176,6 +1432,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/codemirror": {
       "version": "5.60.17",
       "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.17.tgz",
@@ -1184,6 +1451,13 @@
       "dependencies": {
         "@types/tern": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1225,6 +1499,176 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/base64-js": {
@@ -1318,6 +1762,16 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001790",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
@@ -1338,6 +1792,33 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/codemirror": {
       "version": "5.65.21",
@@ -1361,6 +1842,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1378,6 +1894,41 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/easymde": {
       "version": "2.20.0",
@@ -1398,6 +1949,26 @@
       "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1448,6 +2019,44 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1473,6 +2082,60 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -1493,11 +2156,68 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -1537,6 +2257,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1545,6 +2272,27 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/marked": {
@@ -1557,6 +2305,16 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -1592,12 +2350,62 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.10",
@@ -1628,6 +2436,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1652,6 +2486,14 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -1709,6 +2551,20 @@
         "react-dom": ">=16.8.2"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -1754,6 +2610,33 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -1773,6 +2656,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1781,6 +2671,167 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/typo-js": {
@@ -1879,6 +2930,219 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@stellar/freighter-api": "^4.1.0",
@@ -16,7 +18,12 @@
     "react-simplemde-editor": "^5.2.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.3.0",
-    "vite": "^5.2.12"
+    "jsdom": "^26.1.0",
+    "vite": "^5.2.12",
+    "vitest": "^3.1.4"
   }
 }

--- a/frontend/src/components/CampaignCard.jsx
+++ b/frontend/src/components/CampaignCard.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import VerificationBadge from './VerificationBadge';
+import CampaignStatusBadge from './CampaignStatusBadge';
 
 export default function CampaignCard({ campaign }) {
   const pct = Math.min(100, (campaign.raised_amount / campaign.target_amount) * 100).toFixed(1);
@@ -14,7 +15,10 @@ export default function CampaignCard({ campaign }) {
           </div>
         ) : null}
         <div style={styles.header}>
-          <span style={styles.asset}>{campaign.asset_type}</span>
+          <div style={{ display: 'flex', gap: '0.35rem', alignItems: 'center', flexWrap: 'wrap' }}>
+            <span style={styles.asset}>{campaign.asset_type}</span>
+            <CampaignStatusBadge status={campaign.status} />
+          </div>
           <VerificationBadge status={campaign.creator_kyc_status} compact />
         </div>
         {typeof campaign.updates_count === 'number' && (

--- a/frontend/src/components/CampaignCard.test.jsx
+++ b/frontend/src/components/CampaignCard.test.jsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import CampaignCard from './CampaignCard';
+
+const baseCampaign = {
+  id: '11111111-1111-1111-1111-111111111111',
+  title: 'Solar Study Hub',
+  description: 'Evening study lighting for a neighborhood learning hub in Yaba.',
+  target_amount: 1000,
+  raised_amount: 250,
+  asset_type: 'USDC',
+  status: 'active',
+  contributor_count: 12,
+};
+
+function renderCard(campaign = baseCampaign) {
+  return render(
+    <MemoryRouter>
+      <CampaignCard campaign={campaign} />
+    </MemoryRouter>
+  );
+}
+
+describe('CampaignCard', () => {
+  it('renders campaign title and description excerpt', () => {
+    renderCard();
+    expect(screen.getByText('Solar Study Hub')).toBeInTheDocument();
+    expect(screen.getByText(/Evening study lighting/)).toBeInTheDocument();
+  });
+
+  it('shows progress bar width from raised_amount / target_amount', () => {
+    const { container } = renderCard();
+    const fill = container.querySelector('[style*="width"]');
+    const progress = Array.from(container.querySelectorAll('div')).find(
+      (el) => el.getAttribute('style')?.includes('width: 25%')
+    );
+    expect(progress || fill).toBeTruthy();
+    expect(screen.getByText(/25\.0%/)).toBeInTheDocument();
+  });
+
+  it('shows the asset type badge', () => {
+    renderCard();
+    expect(screen.getByText('USDC')).toBeInTheDocument();
+  });
+
+  it('shows goal reached badge when status is funded', () => {
+    renderCard({ ...baseCampaign, status: 'funded' });
+    expect(screen.getByText('Goal reached')).toBeInTheDocument();
+  });
+
+  it('shows campaign ended badge when status is failed', () => {
+    renderCard({ ...baseCampaign, status: 'failed' });
+    expect(screen.getByText('Campaign ended')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/CampaignStatusBadge.jsx
+++ b/frontend/src/components/CampaignStatusBadge.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+const LABELS = {
+  funded: { text: 'Goal reached', bg: '#dcfce7', color: '#166534' },
+  failed: { text: 'Campaign ended', bg: '#fee2e2', color: '#991b1b' },
+  closed: { text: 'Campaign closed', bg: '#f3f4f6', color: '#374151' },
+};
+
+export default function CampaignStatusBadge({ status }) {
+  if (!status || status === 'active') return null;
+  const style = LABELS[status];
+  if (!style) return null;
+
+  return (
+    <span
+      style={{
+        background: style.bg,
+        color: style.color,
+        fontSize: '0.72rem',
+        fontWeight: 700,
+        padding: '2px 8px',
+        borderRadius: '99px',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {style.text}
+    </span>
+  );
+}

--- a/frontend/src/components/ContributeModal.jsx
+++ b/frontend/src/components/ContributeModal.jsx
@@ -392,7 +392,7 @@ export default function ContributeModal({ campaign, onClose, onSuccess }) {
               the amount below in <strong>{campaign.asset_type}</strong>.
             </p>
 
-            <form onSubmit={handleSubmit}>
+            <form noValidate onSubmit={handleSubmit}>
               <fieldset style={{ border: 'none', margin: '0 0 1rem', padding: 0 }}>
                 <legend className="label-strong" style={{ marginBottom: '0.45rem' }}>
                   Payment method

--- a/frontend/src/components/ContributeModal.test.jsx
+++ b/frontend/src/components/ContributeModal.test.jsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ContributeModal from './ContributeModal';
+
+vi.mock('@stellar/freighter-api', () => ({
+  getNetwork: vi.fn(),
+  isConnected: vi.fn().mockResolvedValue({ isConnected: false }),
+  requestAccess: vi.fn(),
+  signTransaction: vi.fn(),
+}));
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', user: { wallet_public_key: 'GUSER' } }),
+}));
+
+const mockContribute = vi.fn();
+const mockQuote = vi.fn();
+const mockOnClose = vi.fn();
+const mockOnSuccess = vi.fn();
+
+vi.mock('../services/api', () => ({
+  api: {
+    getPlatformConfig: vi.fn().mockResolvedValue({ platform_fee_bps: 0 }),
+    getContributions: vi.fn().mockResolvedValue([]),
+    getAnchorInfo: vi.fn().mockResolvedValue({ anchors: [] }),
+    quoteContribution: (...args) => mockQuote(...args),
+    contribute: (...args) => mockContribute(...args),
+  },
+}));
+
+const campaign = {
+  id: '11111111-1111-1111-1111-111111111111',
+  title: 'Test Campaign',
+  asset_type: 'USDC',
+  status: 'active',
+};
+
+describe('ContributeModal', () => {
+  beforeEach(() => {
+    mockContribute.mockReset();
+    mockQuote.mockReset();
+    mockOnClose.mockReset();
+    mockOnSuccess.mockReset();
+    mockQuote.mockResolvedValue({
+      send_asset: 'XLM',
+      dest_asset: 'USDC',
+      dest_amount: '10',
+      max_send_amount: '12',
+      path: ['USDC'],
+    });
+    mockContribute.mockResolvedValue({ tx_hash: 'abc123' });
+  });
+
+  function renderModal(overrides = {}) {
+    return render(
+      <ContributeModal
+        campaign={{ ...campaign, ...overrides }}
+        onClose={mockOnClose}
+        onSuccess={mockOnSuccess}
+      />
+    );
+  }
+
+  it('renders the contribution form when opened', () => {
+    renderModal();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(/support this campaign/i)).toBeInTheDocument();
+  });
+
+  it('validates that amount must be a positive number', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.clear(screen.getByLabelText(/amount campaign receives/i));
+    await user.type(screen.getByLabelText(/amount campaign receives/i), '0');
+    await user.click(screen.getByRole('button', { name: /confirm payment/i }));
+    expect(screen.getByText(/enter an amount greater than zero/i)).toBeInTheDocument();
+    expect(mockContribute).not.toHaveBeenCalled();
+  });
+
+  it('shows conversion preview when a quote is returned', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('radio', { name: /XLM/i }));
+    await user.clear(screen.getByLabelText(/amount campaign receives/i));
+    await user.type(screen.getByLabelText(/amount campaign receives/i), '25');
+    await waitFor(() => {
+      expect(mockQuote).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/up to/i)).toBeInTheDocument();
+    });
+  });
+
+  it('calls submit handler with the correct payload', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.clear(screen.getByLabelText(/amount campaign receives/i));
+    await user.type(screen.getByLabelText(/amount campaign receives/i), '15');
+    await user.click(screen.getByRole('button', { name: /confirm payment/i }));
+    await waitFor(() => {
+      expect(mockContribute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          campaign_id: campaign.id,
+          amount: '15',
+          send_asset: 'USDC',
+        }),
+        'test-token'
+      );
+    });
+  });
+
+  it('closes on cancel', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/Navbar.test.jsx
+++ b/frontend/src/components/Navbar.test.jsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import Navbar from './Navbar';
+
+const mockNavigate = vi.fn();
+const mockLogout = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+import { useAuth } from '../context/AuthContext';
+
+describe('Navbar', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockLogout.mockClear();
+  });
+
+  it('shows login and sign up when unauthenticated', () => {
+    useAuth.mockReturnValue({ user: null, logout: mockLogout });
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link', { name: /log in/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /sign up/i })).toBeInTheDocument();
+  });
+
+  it('shows dashboard and logout when authenticated as creator', () => {
+    useAuth.mockReturnValue({
+      user: { name: 'Bola', role: 'creator' },
+      logout: mockLogout,
+    });
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /logout/i })).toBeInTheDocument();
+    expect(screen.getByText('Bola')).toBeInTheDocument();
+  });
+
+  it('calls logout and navigates home', async () => {
+    useAuth.mockReturnValue({
+      user: { name: 'Alice', role: 'contributor' },
+      logout: mockLogout,
+    });
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    );
+    await user.click(screen.getByRole('button', { name: /logout/i }));
+    expect(mockLogout).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+});

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -9,6 +9,7 @@ import WithdrawalsSection from '../components/WithdrawalsSection';
 import CampaignDetailSkeleton from '../components/skeletons/CampaignDetailSkeleton';
 import ContributionListSkeleton from '../components/skeletons/ContributionListSkeleton';
 import VerificationBadge from '../components/VerificationBadge';
+import CampaignStatusBadge from '../components/CampaignStatusBadge';
 
 function escapeHtml(text) {
   return text
@@ -310,9 +311,14 @@ export default function Campaign() {
           <strong>Cover image upload failed:</strong> {coverUploadError}
         </div>
       )}
+      {campaign.status === 'funded' && (
+        <div className="alert alert--success" style={{ marginBottom: '1.25rem' }} role="status">
+          <strong>Goal reached.</strong> This campaign has met its funding target. Contributions may still be open until the creator closes the campaign.
+        </div>
+      )}
       {campaign.status === 'failed' && (
         <div className="alert alert--error" style={{ marginBottom: '1.25rem' }} role="status">
-          <strong>This campaign did not reach its goal.</strong> Contributions are closed and refunds can be requested.
+          <strong>Campaign ended.</strong> This campaign did not reach its goal. Contributions are closed and refunds can be requested.
         </div>
       )}
       {campaign.creator_kyc_status !== 'verified' && (
@@ -330,6 +336,7 @@ export default function Campaign() {
       <div style={styles.header}>
         <div style={styles.badgeRow}>
           <span style={styles.asset}>{campaign.asset_type}</span>
+          <CampaignStatusBadge status={campaign.status} />
           <VerificationBadge status={campaign.creator_kyc_status} />
         </div>
         <h1 style={styles.title}>{campaign.title}</h1>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -15,6 +15,14 @@ export default function Login() {
 
   async function handleSubmit(e) {
     e.preventDefault();
+    if (!form.email.trim() || !form.password.trim()) {
+      setError('Email and password are required.');
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim())) {
+      setError('Enter a valid email address.');
+      return;
+    }
     setLoading(true);
     setError('');
     try {
@@ -31,7 +39,7 @@ export default function Login() {
   return (
     <main className="container" style={{ paddingTop: '4rem', maxWidth: '400px' }}>
       <h1 style={{ fontSize: '1.6rem', fontWeight: 800, marginBottom: '1.5rem' }}>Log in</h1>
-      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem' }}>
+      <form noValidate onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem' }}>
         <input type="email" placeholder="Email" value={form.email} onChange={set('email')} required />
         <input type="password" placeholder="Password" value={form.password} onChange={set('password')} required />
         {error && <p style={{ color: '#dc2626', fontSize: '0.875rem' }}>{error}</p>}

--- a/frontend/src/pages/Login.test.jsx
+++ b/frontend/src/pages/Login.test.jsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import Login from './Login';
+
+const mockNavigate = vi.fn();
+const mockLogin = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ state: null }),
+  };
+});
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ login: mockLogin }),
+}));
+
+vi.mock('../services/api', () => ({
+  api: {
+    login: vi.fn(),
+  },
+}));
+
+import { api } from '../services/api';
+
+describe('Login', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockLogin.mockClear();
+    api.login.mockReset();
+  });
+
+  it('shows validation error for empty fields', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+    await user.click(screen.getByRole('button', { name: /log in/i }));
+    expect(screen.getByText(/email and password are required/i)).toBeInTheDocument();
+    expect(api.login).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error for invalid email', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+    await user.type(screen.getByPlaceholderText('Email'), 'not-email');
+    await user.type(screen.getByPlaceholderText('Password'), 'Password1');
+    await user.click(screen.getByRole('button', { name: /log in/i }));
+    expect(screen.getByText(/valid email/i)).toBeInTheDocument();
+  });
+
+  it('calls auth service and redirects on success', async () => {
+    api.login.mockResolvedValue({
+      token: 'jwt',
+      user: { id: '1', email: 'a@b.c', name: 'A', role: 'contributor' },
+    });
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+    await user.type(screen.getByPlaceholderText('Email'), 'a@b.c');
+    await user.type(screen.getByPlaceholderText('Password'), 'Password1');
+    await user.click(screen.getByRole('button', { name: /log in/i }));
+    await waitFor(() => {
+      expect(api.login).toHaveBeenCalledWith({ email: 'a@b.c', password: 'Password1' });
+    });
+    expect(mockLogin).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+  });
+});

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -15,6 +15,18 @@ export default function Register() {
 
   async function handleSubmit(e) {
     e.preventDefault();
+    if (!form.name.trim() || !form.email.trim() || !form.password.trim()) {
+      setError('Name, email, and password are required.');
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim())) {
+      setError('Enter a valid email address.');
+      return;
+    }
+    if (form.password.length < 8) {
+      setError('Password must be at least 8 characters.');
+      return;
+    }
     setLoading(true);
     setError('');
     try {
@@ -35,7 +47,7 @@ export default function Register() {
       <p style={{ color: '#666', marginBottom: '1.5rem', fontSize: '0.9rem' }}>
         A Stellar wallet is created for you automatically.
       </p>
-      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem' }}>
+      <form noValidate onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem' }}>
         <input placeholder="Full name" value={form.name} onChange={set('name')} required />
         <input type="email" placeholder="Email" value={form.email} onChange={set('email')} required />
         <input type="password" placeholder="Password" value={form.password} onChange={set('password')} required minLength={8} />

--- a/frontend/src/pages/Register.test.jsx
+++ b/frontend/src/pages/Register.test.jsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import Register from './Register';
+
+const mockNavigate = vi.fn();
+const mockLogin = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ login: mockLogin }),
+}));
+
+vi.mock('../lib/onboarding', () => ({
+  markJustRegistered: vi.fn(),
+}));
+
+vi.mock('../services/api', () => ({
+  api: {
+    register: vi.fn(),
+  },
+}));
+
+import { api } from '../services/api';
+
+describe('Register', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockLogin.mockClear();
+    api.register.mockReset();
+  });
+
+  it('shows validation error for empty fields', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Register />
+      </MemoryRouter>
+    );
+    await user.click(screen.getByRole('button', { name: /sign up/i }));
+    expect(screen.getByText(/name, email, and password are required/i)).toBeInTheDocument();
+  });
+
+  it('shows validation error for invalid email', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Register />
+      </MemoryRouter>
+    );
+    await user.type(screen.getByPlaceholderText('Full name'), 'Test');
+    await user.type(screen.getByPlaceholderText('Email'), 'bad');
+    await user.type(screen.getByPlaceholderText('Password'), 'Password1');
+    await user.click(screen.getByRole('button', { name: /sign up/i }));
+    expect(screen.getByText(/valid email/i)).toBeInTheDocument();
+  });
+
+  it('calls register and redirects contributor to home', async () => {
+    api.register.mockResolvedValue({
+      token: 'jwt',
+      user: { id: '1', email: 'new@example.com', name: 'New', role: 'contributor' },
+    });
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Register />
+      </MemoryRouter>
+    );
+    await user.type(screen.getByPlaceholderText('Full name'), 'New User');
+    await user.type(screen.getByPlaceholderText('Email'), 'new@example.com');
+    await user.type(screen.getByPlaceholderText('Password'), 'Password1');
+    await user.click(screen.getByRole('button', { name: /sign up/i }));
+    await waitFor(() => {
+      expect(api.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'new@example.com',
+          password: 'Password1',
+          name: 'New User',
+        })
+      );
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+});

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,13 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/test/setup.js',
+  },
   build: {
     rollupOptions: {
       input: {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "crowdpay",
+  "private": true,
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const backendEnv = {
+  NODE_ENV: 'development',
+  PORT: '3001',
+  JWT_SECRET: 'testsecret',
+  STELLAR_NETWORK: 'testnet',
+  USDC_ISSUER: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+  PLATFORM_SECRET_KEY: 'SCVMQUS5EMTHWBLJTE5XCSCMHB2ZOVKRR4ATVTRPUNRCOGKRENIL3LHR',
+  KYC_REQUIRED_FOR_CAMPAIGNS: 'false',
+  ENABLE_CAMPAIGN_STATUS_CRON: 'false',
+  DATABASE_URL: process.env.DATABASE_URL || 'postgresql://postgres:password@localhost:5433/crowdpay',
+};
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: [
+    {
+      command: 'npm run dev',
+      cwd: 'backend',
+      url: 'http://localhost:3001/health',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: backendEnv,
+    },
+    {
+      command: 'npm run dev',
+      cwd: 'frontend',
+      url: 'http://localhost:5173',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

This PR delivers four related quality and lifecycle improvements in one cohesive pass:

- **#84 — express-validator**: Centralized request validation with consistent `400` responses (`{ errors: [...] }`) for auth, campaigns, contributions (including quote params), and withdrawals. Route and middleware tests cover invalid payloads.
- **#88 — Campaign status automation**: `campaignStatusService` transitions active campaigns to `funded` or `failed` based on goal and deadline; hourly cron in the backend (skippable via `ENABLE_CAMPAIGN_STATUS_CRON=false`), on-read refresh for `GET /api/campaigns/:id`, and UI badges/banners on cards and campaign detail.
- **#98 — Frontend component tests**: Vitest + React Testing Library for `CampaignCard`, `ContributeModal`, `Login`, `Register`, and `Navbar` (19 tests, mocked API/auth). CI runs `npm test` in the frontend job.
- **#87 — Playwright E2E**: Root `npm run test:e2e`, `playwright.config.js` targeting `http://localhost:5173`, flows for contributor, creator, and withdrawal journeys; CI e2e job with Postgres schema + seed.

Closes #84
Closes #87
Closes #88
Closes #98

## Test plan

- [ ] `cd backend && npm test` — all route/middleware/service tests pass
- [ ] `cd frontend && npm test` — 19 Vitest component tests pass
- [ ] `npm install && npx playwright install && npm run test:e2e` — with Postgres on port 5433 and `backend/db/schema.sql` + `seed.sql` applied
- [ ] Create campaign with invalid body → `400` + `errors` array
- [ ] Open funded/failed campaign → status badge and closed contribute CTA where expected
- [ ] Verify CI: backend-checks, frontend-checks (lint + unit tests + build), e2e job