### PR TITLE
feat: improve campaign cover upload UX and fallbacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,9 @@ PLATFORM_SECRET_KEY=your_platform_secret_key_here
 # Asset Issuance
 # Public key of the USDC issuer on the selected Stellar network
 USDC_ISSUER=your_usdc_issuer_public_key_here
+
+# Object Storage (campaign covers)
+STORAGE_BUCKET=
+STORAGE_REGION=
+STORAGE_ACCESS_KEY=
+STORAGE_SECRET_KEY=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -45,3 +45,10 @@ SMTP_HOST=smtp.sendgrid.net
 SMTP_PORT=587
 SMTP_USER=apikey
 SMTP_PASS=your-smt-pass-here
+
+# Object Storage (campaign covers)
+STORAGE_BUCKET=
+STORAGE_REGION=
+STORAGE_ACCESS_KEY=
+STORAGE_SECRET_KEY=
+STORAGE_ENDPOINT=

--- a/backend/src/services/storage.js
+++ b/backend/src/services/storage.js
@@ -14,6 +14,13 @@ function createStorageClient() {
     endpoint,
     region: process.env.STORAGE_REGION || 'auto',
     forcePathStyle: true,
+    credentials:
+      process.env.STORAGE_ACCESS_KEY && process.env.STORAGE_SECRET_KEY
+        ? {
+            accessKeyId: process.env.STORAGE_ACCESS_KEY,
+            secretAccessKey: process.env.STORAGE_SECRET_KEY,
+          }
+        : undefined,
   });
 }
 

--- a/frontend/src/components/CampaignCard.jsx
+++ b/frontend/src/components/CampaignCard.jsx
@@ -13,7 +13,11 @@ export default function CampaignCard({ campaign }) {
           <div style={styles.coverImageWrapper}>
             <img alt={campaign.title} src={campaign.cover_image_url} style={styles.coverImage} />
           </div>
-        ) : null}
+        ) : (
+          <div style={styles.coverPlaceholder} aria-hidden="true">
+            <span style={styles.coverPlaceholderText}>No campaign image</span>
+          </div>
+        )}
         <div style={styles.header}>
           <div style={{ display: 'flex', gap: '0.35rem', alignItems: 'center', flexWrap: 'wrap' }}>
             <span style={styles.asset}>{campaign.asset_type}</span>
@@ -50,6 +54,17 @@ const styles = {
   desc: { fontSize: '0.875rem', color: '#666', marginBottom: '1rem' },
   coverImageWrapper: { overflow: 'hidden', borderRadius: '12px 12px 0 0', marginBottom: '1rem', height: '160px' },
   coverImage: { width: '100%', height: '100%', objectFit: 'cover', display: 'block' },
+  coverPlaceholder: {
+    borderRadius: '12px 12px 0 0',
+    marginBottom: '1rem',
+    height: '160px',
+    background: 'linear-gradient(135deg, #ede9fe 0%, #e0e7ff 100%)',
+    border: '1px solid #ddd6fe',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  coverPlaceholderText: { color: '#6d28d9', fontWeight: 700, fontSize: '0.85rem' },
   bar: { background: '#f0f0f0', borderRadius: '99px', height: '6px', marginBottom: '0.5rem', overflow: 'hidden' },
   fill: { background: '#7c3aed', height: '100%', borderRadius: '99px', transition: 'width 0.3s' },
   meta: { display: 'flex', justifyContent: 'space-between', fontSize: '0.85rem', color: '#444' },

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -333,6 +333,11 @@ export default function Campaign() {
           style={styles.detailCoverImage}
         />
       )}
+      {!campaign.cover_image_url && (
+        <div style={styles.detailCoverPlaceholder} aria-hidden="true">
+          <span style={styles.detailCoverPlaceholderText}>No campaign image yet</span>
+        </div>
+      )}
       <div style={styles.header}>
         <div style={styles.badgeRow}>
           <span style={styles.asset}>{campaign.asset_type}</span>
@@ -759,6 +764,18 @@ const styles = {
   walletLabel: { fontSize: '0.75rem', fontWeight: 600, color: '#888', textTransform: 'uppercase' },
   walletKey: { fontSize: '0.8rem', color: '#555', wordBreak: 'break-all' },
   detailCoverImage: { width: '100%', borderRadius: '14px', marginBottom: '1.5rem', objectFit: 'cover', maxHeight: '360px' },
+  detailCoverPlaceholder: {
+    width: '100%',
+    borderRadius: '14px',
+    marginBottom: '1.5rem',
+    height: '260px',
+    background: 'linear-gradient(135deg, #ede9fe 0%, #e0e7ff 100%)',
+    border: '1px solid #ddd6fe',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  detailCoverPlaceholderText: { color: '#6d28d9', fontWeight: 700 },
   sectionTitle: { fontSize: '1.1rem', fontWeight: 700, marginBottom: '0.75rem' },
   list: { display: 'flex', flexDirection: 'column', gap: '0.5rem' },
   row: { display: 'flex', justifyContent: 'space-between', background: '#fff', border: '1px solid #eee', borderRadius: '6px', padding: '0.6rem 0.85rem' },

--- a/frontend/src/pages/CreateCampaign.jsx
+++ b/frontend/src/pages/CreateCampaign.jsx
@@ -44,6 +44,7 @@ export default function CreateCampaign() {
   });
   const [coverImageFile, setCoverImageFile] = useState(null);
   const [coverImagePreview, setCoverImagePreview] = useState('');
+  const [isDragOverCover, setIsDragOverCover] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [showCreatorTips, setShowCreatorTips] = useState(isCreatorOnboardingVisible);
@@ -71,8 +72,7 @@ export default function CreateCampaign() {
     setForm((f) => ({ ...f, asset_type: value }));
   }
 
-  function handleCoverImageChange(e) {
-    const file = e.target.files?.[0] || null;
+  function setCoverImage(file) {
     if (!file) {
       setCoverImageFile(null);
       setCoverImagePreview('');
@@ -91,6 +91,17 @@ export default function CreateCampaign() {
     const reader = new FileReader();
     reader.onload = () => setCoverImagePreview(reader.result || '');
     reader.readAsDataURL(file);
+  }
+
+  function handleCoverImageChange(e) {
+    setCoverImage(e.target.files?.[0] || null);
+  }
+
+  function handleCoverImageDrop(e) {
+    e.preventDefault();
+    setIsDragOverCover(false);
+    const file = e.dataTransfer?.files?.[0] || null;
+    setCoverImage(file);
   }
 
   function dismissTips() {
@@ -454,12 +465,30 @@ export default function CreateCampaign() {
               <label className="label-strong" htmlFor="cc-cover">
                 Cover image <span style={{ fontWeight: 500, color: '#888' }}>(optional)</span>
               </label>
-              <input
-                id="cc-cover"
-                type="file"
-                accept="image/jpeg,image/png,image/webp"
-                onChange={handleCoverImageChange}
-              />
+              <div
+                onDragOver={(e) => {
+                  e.preventDefault();
+                  setIsDragOverCover(true);
+                }}
+                onDragLeave={() => setIsDragOverCover(false)}
+                onDrop={handleCoverImageDrop}
+                style={{
+                  border: `2px dashed ${isDragOverCover ? '#7c3aed' : '#d4d4d8'}`,
+                  borderRadius: '12px',
+                  padding: '0.9rem',
+                  background: isDragOverCover ? '#f5f3ff' : '#fafafa',
+                }}
+              >
+                <input
+                  id="cc-cover"
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  onChange={handleCoverImageChange}
+                />
+                <p style={{ marginTop: '0.45rem', marginBottom: 0, color: '#666', fontSize: '0.8rem' }}>
+                  Drag and drop a JPEG, PNG, or WEBP image (max 5MB), or browse files.
+                </p>
+              </div>
               {coverImagePreview && (
                 <img
                   src={coverImagePreview}


### PR DESCRIPTION
## Summary
- add drag-and-drop support for campaign cover uploads in `CreateCampaign.jsx`
- keep strict image validation on create flow (JPEG/PNG/WebP, max 5MB) and backend upload path
- render graceful image placeholders on `Campaign.jsx` and `CampaignCard.jsx` when no campaign image exists
- wire storage credential env vars in examples (`STORAGE_BUCKET`, `STORAGE_REGION`, `STORAGE_ACCESS_KEY`, `STORAGE_SECRET_KEY`)

## Why
Campaigns without visual identity are less engaging and harder to scan. This improves first-impression quality while preserving backward compatibility for existing campaigns with no image.

## Test plan
- upload a valid JPEG/PNG/WebP <= 5MB in campaign creation (file picker and drag-and-drop)
- verify invalid type and >5MB files are rejected client-side
- verify backend still enforces file type/size via upload endpoint
- confirm uploaded image appears on campaign detail hero and campaign card thumbnail
- confirm campaigns with no image show placeholders instead of blank sections
- confirm older campaigns without images render unchanged except fallback UI

## Notes
- no migration required for this PR
- no new package install required

Closes #104 