### PR TITLE
fix: add STELLAR_HORIZON_URL to required env vars and optional-var wa…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           JWT_SECRET: testsecret
           PLATFORM_SECRET_KEY: SCVMQUS5EMTHWBLJTE5XCSCMHB2ZOVKRR4ATVTRPUNRCOGKRENIL3LHR
           STELLAR_NETWORK: testnet
+          STELLAR_HORIZON_URL: https://horizon-testnet.stellar.org
           USDC_ISSUER: GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
           ENABLE_CAMPAIGN_STATUS_CRON: 'false'
         run: npm test
@@ -130,4 +131,8 @@ jobs:
         env:
           CI: true
           DATABASE_URL: postgresql://postgres:password@localhost:5433/crowdpay
+          JWT_SECRET: testsecret
+          PLATFORM_SECRET_KEY: SCVMQUS5EMTHWBLJTE5XCSCMHB2ZOVKRR4ATVTRPUNRCOGKRENIL3LHR
+          STELLAR_NETWORK: testnet
+          STELLAR_HORIZON_URL: https://horizon-testnet.stellar.org
         run: npm run test:e2e

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -35,8 +35,8 @@ PLATFORM_FEE_BPS=150
 # ALERT_WEBHOOK_URL=https://hooks.slack.com/services/...
 
 # Optional: UUID of the user who may approve/reject withdrawals as platform (JWT subject must match).
-# When unset, any logged-in user may call# Platform User for Approvals (Optional)
-PLATFORM_APPROVER_USER_ID=00000000-0000-0000-0000-000000000000
+# When unset, any logged-in user may call the withdrawal approval endpoints (dev mode only).
+# PLATFORM_APPROVER_USER_ID=00000000-0000-0000-0000-000000000000
 
 # Email Configuration
 EMAIL_FROM="CrowdPay" <noreply@crowdpay.local>

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -1,6 +1,12 @@
 const { validateWalletSecretConfig } = require('../services/walletSecrets');
 
-const REQUIRED = ['JWT_SECRET', 'DATABASE_URL', 'PLATFORM_SECRET_KEY', 'STELLAR_NETWORK'];
+const REQUIRED = [
+  'DATABASE_URL',
+  'JWT_SECRET',
+  'PLATFORM_SECRET_KEY',
+  'STELLAR_NETWORK',
+  'STELLAR_HORIZON_URL',
+];
 const STORAGE_VARS = ['STORAGE_BUCKET', 'STORAGE_ENDPOINT'];
 
 function validateEnv() {
@@ -28,6 +34,18 @@ function validateEnv() {
   } catch (err) {
     process.stderr.write(`\n[crowdpay] Cannot start: ${err.message}\n\n`);
     process.exit(1);
+  }
+
+  // Warn about important optional variables
+  if (!process.env.PLATFORM_APPROVER_USER_ID) {
+    process.stderr.write(
+      '[crowdpay] Warning: PLATFORM_APPROVER_USER_ID not set — withdrawal approvals are open to all users (dev mode)\n'
+    );
+  }
+  if (!process.env.JWT_EXPIRES_IN) {
+    process.stderr.write(
+      '[crowdpay] Warning: JWT_EXPIRES_IN not set — access tokens will use the default expiry (15m)\n'
+    );
   }
 }
 


### PR DESCRIPTION
…rnings

Closes #131

Changes:
- Add STELLAR_HORIZON_URL to the REQUIRED list in config/env.js (was present in .env.example and used by config/stellar.js but omitted from startup validation — a missing value caused a silent connection failure rather than a clear error on boot)

- Add startup warnings (stderr, not exit) for optional vars:
  - PLATFORM_APPROVER_USER_ID: warns that withdrawal approvals are open to all users when unset (dev mode)
  - JWT_EXPIRES_IN: warns that the code-level default (15m) is in effect, so operators know tokens are not perpetual

- Fix malformed comment in .env.example where the comment text for PLATFORM_APPROVER_USER_ID was accidentally merged with a section header; also comment-out the placeholder value so copying the file as-is doesn't accidentally set a zeroed-out UUID as the approver

Note: auth.js already sets expiresIn: process.env.JWT_EXPIRES_IN || '15m' so no change is needed there — the default is already safe.