### PR TITLE
feat: add reconciliation job for campaign balances (#133)

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -132,6 +132,18 @@ function startCampaignStatusCron() {
   logger.info('Campaign status cron scheduled (hourly)');
 }
 
+function startReconciliationCron() {
+  if (process.env.ENABLE_RECONCILIATION_CRON === 'false') return;
+  const cron = require('node-cron');
+  const { reconcileCampaignBalances } = require('./services/reconciliation');
+  cron.schedule('*/15 * * * *', () => {
+    reconcileCampaignBalances().catch((err) => {
+      logger.error('Reconciliation cron failed', { error: err.message });
+    });
+  });
+  logger.info('Reconciliation cron scheduled (every 15 minutes)');
+}
+
 async function bootstrap() {
   if (process.env.NODE_ENV === 'production') {
     await assertNoLegacyPlaintextUserWalletSecrets();
@@ -142,6 +154,7 @@ async function bootstrap() {
     startLedgerMonitor();
     startWebhookRetryPoller();
     startCampaignStatusCron();
+    startReconciliationCron();
   });
 }
 

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -2,6 +2,7 @@ const router = require('express').Router();
 const db = require('../config/database');
 const logger = require('../config/logger');
 const { requireAuth, requireAdmin } = require('../middleware/auth');
+const { reconcileSingleCampaign } = require('../services/reconciliation');
 
 router.use(requireAuth);
 router.use(requireAdmin);
@@ -449,6 +450,23 @@ router.get('/milestones', async (req, res) => {
     params
   );
   res.json(rows);
+});
+
+/**
+ * POST /api/admin/campaigns/:id/reconcile
+ * Manually force a sync for a specific campaign's raised_amount.
+ */
+router.post('/campaigns/:id/reconcile', async (req, res) => {
+  try {
+    const result = await reconcileSingleCampaign(req.params.id);
+    res.json({ message: 'Reconciliation completed', result });
+  } catch (err) {
+    if (err.message === 'Campaign not found') {
+      return res.status(404).json({ error: 'Campaign not found' });
+    }
+    logger.error('Error during manual reconciliation', { error: err.message, campaignId: req.params.id });
+    res.status(500).json({ error: 'Failed to reconcile campaign' });
+  }
 });
 
 module.exports = router;

--- a/backend/src/services/reconciliation.js
+++ b/backend/src/services/reconciliation.js
@@ -1,0 +1,63 @@
+const db = require('../config/database');
+const { getCampaignBalance } = require('./stellarService');
+const logger = require('../config/logger');
+
+async function reconcileCampaign(campaign) {
+  try {
+    const { rows: pendingRows } = await db.query(
+      `SELECT id FROM withdrawal_requests WHERE campaign_id = $1 AND status = 'pending' LIMIT 1`,
+      [campaign.id]
+    );
+    if (pendingRows.length > 0) {
+      logger.info(`[reconcile] Skipping campaign ${campaign.id} due to pending withdrawal`);
+      return { skipped: true, reason: 'pending_withdrawal' };
+    }
+
+    const onChain = await getCampaignBalance(campaign.wallet_public_key);
+    const liveBalance = parseFloat(onChain[campaign.asset_type] || '0');
+    const dbBalance = parseFloat(campaign.raised_amount);
+
+    if (Math.abs(liveBalance - dbBalance) > 0.0000001) {
+      logger.warn(`[reconcile] Campaign ${campaign.id}: DB=${dbBalance} vs chain=${liveBalance}. Updating.`);
+      await db.query(
+        `UPDATE campaigns SET raised_amount = $1 WHERE id = $2`,
+        [liveBalance, campaign.id]
+      );
+      return { updated: true, dbBalance, liveBalance };
+    }
+    return { updated: false, dbBalance, liveBalance };
+  } catch (err) {
+    logger.error(`[reconcile] Failed for campaign ${campaign.id}:`, { error: err.message });
+    throw err;
+  }
+}
+
+async function reconcileCampaignBalances() {
+  const { rows } = await db.query(
+    `SELECT id, wallet_public_key, asset_type, raised_amount FROM campaigns WHERE status IN ('active', 'funded')`
+  );
+
+  for (const campaign of rows) {
+    try {
+      await reconcileCampaign(campaign);
+    } catch (err) {
+      // Error is already logged inside reconcileCampaign
+    }
+  }
+}
+
+async function reconcileSingleCampaign(campaignId) {
+  const { rows } = await db.query(
+    `SELECT id, wallet_public_key, asset_type, raised_amount FROM campaigns WHERE id = $1`,
+    [campaignId]
+  );
+  if (!rows.length) {
+    throw new Error('Campaign not found');
+  }
+  return await reconcileCampaign(rows[0]);
+}
+
+module.exports = {
+  reconcileCampaignBalances,
+  reconcileSingleCampaign,
+};


### PR DESCRIPTION
## Description
Closes #133  

This PR implements a reconciliation job to keep a campaign's `raised_amount` in the PostgreSQL database synchronized with the live on-chain balance on the Stellar network. This addresses issues where database values could diverge due to stream downtime, manual on-chain payments, or testnet resets.

## Changes Made
- **Reconciliation Service**: Added `backend/src/services/reconciliation.js` containing logic to check DB balances vs on-chain balances. Discrepancies > 1 stroop (0.0000001) are automatically corrected in the DB.
- **Race Condition Prevention**: The reconciliation job skips campaigns that have a pending withdrawal request to prevent conflicts with mid-flight transactions.
- **Cron Job**: Scheduled the reconciliation job in `index.js` via `node-cron` to run every 15 minutes.
- **Manual Trigger Endpoint**: Added a new admin endpoint `POST /api/admin/campaigns/:id/reconcile` to allow operators to manually force a sync for a specific campaign.
- **Logging**: Added detailed logging with `winston` to track any corrections made or errors encountered.

## Acceptance Criteria Met
- [x] Reconciliation job runs every 15 minutes and corrects any discrepancy > 0.0000001 (1 Stellar stroop)
- [x] Each correction is logged with both the DB value and the chain value
- [x] The job handles Horizon errors gracefully (one failed campaign doesn't stop the rest)
- [x] Reconciliation does not run while a pending withdrawal exists for the campaign
- [x] Exposed a manual trigger endpoint (`POST /api/admin/campaigns/:id/reconcile`)
