### PR TITLE
feat: toast notifications, mobile nav, confirm password (#153, #148, #145)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,11 +16,13 @@ import Dashboard from './pages/Dashboard';
 import NotFound from './pages/NotFound';
 import { AuthProvider } from './context/AuthContext';
 import { ThemeProvider } from './context/ThemeContext';
+import { ToastProvider } from './context/ToastContext';
 
 export default function App() {
   return (
     <ThemeProvider>
       <AuthProvider>
+        <ToastProvider>
         <Navbar />
         <Routes>
           <Route path="/" element={<Home />} />
@@ -38,6 +40,7 @@ export default function App() {
           <Route path="/my-contributions" element={<Navigate to="/dashboard?tab=contributions" replace />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
+        </ToastProvider>
       </AuthProvider>
     </ThemeProvider>
   );

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useTheme } from '../context/ThemeContext';
 
@@ -7,29 +7,47 @@ export default function Navbar() {
   const { user, logout } = useAuth();
   const { dark, toggleTheme } = useTheme();
   const navigate = useNavigate();
+  const location = useLocation();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
 
   function handleLogout() {
     logout();
     navigate('/');
   }
 
+  function closeMenu() {
+    setMenuOpen(false);
+  }
+
   return (
     <nav style={styles.nav}>
       <div className="container nav-inner-wrap">
         <Link to="/" style={styles.logo}>CrowdPay</Link>
-        <div className="nav-links">
+        <button
+          className="nav-hamburger"
+          onClick={() => setMenuOpen((v) => !v)}
+          aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+          aria-expanded={menuOpen}
+        >
+          {menuOpen ? '✕' : '☰'}
+        </button>
+        <div className={`nav-links${menuOpen ? ' nav-links--open' : ''}`}>
           {user ? (
             <>
               {(user.role === 'creator' || user.role === 'admin') && (
-                <Link to="/campaigns/new" style={styles.link}>Start Campaign</Link>
+                <Link to="/campaigns/new" style={styles.link} onClick={closeMenu}>Start Campaign</Link>
               )}
-              <Link to="/dashboard" style={styles.link}>Dashboard</Link>
-              <Link to="/my-contributions" style={styles.link}>My Contributions</Link>
-              {user.role === 'admin' && <Link to="/admin" style={styles.link}>Admin</Link>}
-              <Link to="/developer" style={styles.link}>Developer</Link>
+              <Link to="/dashboard" style={styles.link} onClick={closeMenu}>Dashboard</Link>
+              <Link to="/my-contributions" style={styles.link} onClick={closeMenu}>My Contributions</Link>
+              {user.role === 'admin' && <Link to="/admin" style={styles.link} onClick={closeMenu}>Admin</Link>}
+              <Link to="/developer" style={styles.link} onClick={closeMenu}>Developer</Link>
               <span style={styles.name}>{user.name}</span>
-              <button 
-                onClick={toggleTheme} 
+              <button
+                onClick={toggleTheme}
                 style={styles.themeToggle}
                 aria-label={dark ? 'Switch to light mode' : 'Switch to dark mode'}
                 title={dark ? 'Light mode' : 'Dark mode'}
@@ -42,16 +60,16 @@ export default function Navbar() {
             </>
           ) : (
             <>
-              <Link to="/login" style={styles.link}>Log in</Link>
-              <button 
-                onClick={toggleTheme} 
+              <Link to="/login" style={styles.link} onClick={closeMenu}>Log in</Link>
+              <button
+                onClick={toggleTheme}
                 style={styles.themeToggle}
                 aria-label={dark ? 'Switch to light mode' : 'Switch to dark mode'}
                 title={dark ? 'Light mode' : 'Dark mode'}
               >
                 {dark ? '☀️' : '🌙'}
               </button>
-              <Link to="/register">
+              <Link to="/register" onClick={closeMenu}>
                 <button className="btn-primary" style={{ padding: '0.4rem 0.9rem' }}>Sign up</button>
               </Link>
             </>

--- a/frontend/src/components/Toast.jsx
+++ b/frontend/src/components/Toast.jsx
@@ -1,0 +1,28 @@
+import React, { useEffect } from 'react';
+
+export function Toast({ message, type = 'success', onDismiss }) {
+  useEffect(() => {
+    const t = setTimeout(onDismiss, 4000);
+    return () => clearTimeout(t);
+  }, [onDismiss]);
+
+  const colors = {
+    success: { bg: '#d1fae5', color: '#065f46', border: '#6ee7b7' },
+    error:   { bg: '#fee2e2', color: '#991b1b', border: '#fca5a5' },
+    info:    { bg: '#dbeafe', color: '#1e40af', border: '#93c5fd' },
+  };
+  const c = colors[type] || colors.info;
+
+  return (
+    <div role="status" aria-live="polite" style={{
+      position: 'fixed', bottom: '1.5rem', right: '1.5rem',
+      background: c.bg, color: c.color, border: `1px solid ${c.border}`,
+      borderRadius: '8px', padding: '0.75rem 1rem',
+      fontSize: '0.875rem', fontWeight: 600,
+      boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+      zIndex: 200, maxWidth: '320px',
+    }}>
+      {message}
+    </div>
+  );
+}

--- a/frontend/src/components/WithdrawalsSection.jsx
+++ b/frontend/src/components/WithdrawalsSection.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { api } from '../services/api';
 import { getNetwork, signTransaction } from '@stellar/freighter-api';
 import { stellarExpertTxUrl } from '../config/stellar';
+import { useToast } from '../context/ToastContext';
 
 const ELIGIBLE = ['active', 'funded'];
 
@@ -18,6 +19,7 @@ function statusLabel(row, isExpired) {
 }
 
 export default function WithdrawalsSection({ campaign, milestones = [], user, token, onReleased }) {
+  const toast = useToast();
   const [forbidden, setForbidden] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -127,13 +129,14 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
     }
   }
 
-  async function runAction(id, fn) {
+  async function runAction(id, fn, successMessage) {
     setBusyId(id);
     setError('');
     try {
       await fn();
       await refresh();
       onReleased?.();
+      if (successMessage) toast?.(successMessage, 'success');
     } catch (err) {
       if (err.status === 410) {
         // XDR has expired — mark this row so the UI can prompt the creator to re-request
@@ -394,7 +397,8 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
                       disabled={busyId === row.id}
                       onClick={() =>
                         runAction(row.id, () =>
-                          api.cancelWithdrawal(row.id, { reason: 'Cancelled by creator' }, token)
+                          api.cancelWithdrawal(row.id, { reason: 'Cancelled by creator' }, token),
+                          'Withdrawal cancelled'
                         )
                       }
                       style={{ fontSize: '0.8rem' }}
@@ -416,7 +420,7 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
                         type="button"
                         className="btn-primary"
                         disabled={busyId === row.id}
-                        onClick={() => runAction(row.id, () => api.approveWithdrawalCreator(row.id, token))}
+                        onClick={() => runAction(row.id, () => api.approveWithdrawalCreator(row.id, token), 'Withdrawal signed')}
                         style={{ fontSize: '0.8rem' }}
                       >
                         Sign as creator
@@ -436,8 +440,10 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
                           'Rejected by platform'
                         );
                         if (reason === null) return;
-                        await runAction(row.id, () =>
-                          api.rejectWithdrawal(row.id, { reason: reason || 'Rejected' }, token)
+                        await runAction(
+                          row.id,
+                          () => api.rejectWithdrawal(row.id, { reason: reason || 'Rejected' }, token),
+                          'Withdrawal rejected'
                         );
                       }}
                       style={{ fontSize: '0.8rem' }}
@@ -448,7 +454,7 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
                       type="button"
                       className="btn-primary"
                       disabled={busyId === row.id}
-                      onClick={() => runAction(row.id, () => api.approveWithdrawalPlatform(row.id, token))}
+                      onClick={() => runAction(row.id, () => api.approveWithdrawalPlatform(row.id, token), 'Withdrawal approved')}
                       style={{ fontSize: '0.8rem' }}
                     >
                       Admin approve & submit

--- a/frontend/src/context/ToastContext.jsx
+++ b/frontend/src/context/ToastContext.jsx
@@ -1,0 +1,17 @@
+import React, { createContext, useCallback, useContext, useState } from 'react';
+import { Toast } from '../components/Toast';
+
+const ToastContext = createContext(null);
+
+export function ToastProvider({ children }) {
+  const [toast, setToast] = useState(null);
+  const show = useCallback((message, type = 'success') => setToast({ message, type }), []);
+  return (
+    <ToastContext.Provider value={show}>
+      {children}
+      {toast && <Toast {...toast} onDismiss={() => setToast(null)} />}
+    </ToastContext.Provider>
+  );
+}
+
+export const useToast = () => useContext(ToastContext);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -280,6 +280,39 @@ input:focus, textarea:focus, select:focus { border-color: var(--color-accent); }
   .nav-links { gap: 1rem; }
 }
 
+.nav-hamburger {
+  display: none;
+  background: transparent;
+  border: none;
+  font-size: 1.4rem;
+  color: var(--color-text-primary);
+  padding: 0.4rem 0.6rem;
+  min-height: auto;
+  cursor: pointer;
+  line-height: 1;
+}
+
+@media (max-width: 640px) {
+  .nav-hamburger { display: block; }
+  .nav-inner-wrap { flex-wrap: nowrap; position: relative; }
+  .nav-links {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: var(--color-bg);
+    border-bottom: 1px solid var(--color-border);
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    padding: 0.5rem 1.25rem 1rem;
+    z-index: 9;
+  }
+  .nav-links--open { display: flex; }
+  .nav-links a, .nav-links span, .nav-links button { width: 100%; text-align: left; padding: 0.6rem 0; }
+}
+
 .campaign-card {
   min-height: 148px;
 }

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -5,10 +5,23 @@ import { useAuth } from '../context/AuthContext';
 import { markJustRegistered } from '../lib/onboarding';
 import { isConnected as isFreighterConnected, getPublicKey, requestAccess } from '@stellar/freighter-api';
 
+function passwordStrength(pw) {
+  if (!pw) return null;
+  let score = 0;
+  if (pw.length >= 8) score++;
+  if (pw.length >= 12) score++;
+  if (/[A-Z]/.test(pw)) score++;
+  if (/[0-9]/.test(pw)) score++;
+  if (/[^A-Za-z0-9]/.test(pw)) score++;
+  if (score <= 1) return { label: 'Weak', color: '#ef4444', width: '33%' };
+  if (score <= 3) return { label: 'Fair', color: '#f59e0b', width: '66%' };
+  return { label: 'Strong', color: '#10b981', width: '100%' };
+}
+
 export default function Register() {
   const { login } = useAuth();
   const navigate = useNavigate();
-  const [form, setForm] = useState({ name: '', email: '', password: '', role: 'contributor' });
+  const [form, setForm] = useState({ name: '', email: '', password: '', confirmPassword: '', role: 'contributor' });
   const [freighterAvailable, setFreighterAvailable] = useState(false);
   const [usingFreighter, setUsingFreighter] = useState(false);
   const [freighterPublicKey, setFreighterPublicKey] = useState('');
@@ -29,6 +42,10 @@ export default function Register() {
     }
     if (form.password.length < 8) {
       setError('Password must be at least 8 characters.');
+      return;
+    }
+    if (form.password !== form.confirmPassword) {
+      setError('Passwords do not match.');
       return;
     }
     setLoading(true);
@@ -89,7 +106,29 @@ export default function Register() {
       <form noValidate onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem' }}>
         <input placeholder="Full name" value={form.name} onChange={set('name')} required />
         <input type="email" placeholder="Email" value={form.email} onChange={set('email')} required />
-        <input type="password" placeholder="Password" value={form.password} onChange={set('password')} required minLength={8} />
+        <input type="password" placeholder="Password" value={form.password} onChange={set('password')} required minLength={8} autoComplete="new-password" />
+        {form.password && (() => {
+          const s = passwordStrength(form.password);
+          return (
+            <div style={{ marginTop: '-0.4rem' }}>
+              <div style={{ height: '4px', borderRadius: '99px', background: '#e5e5e5', overflow: 'hidden' }}>
+                <div style={{ height: '100%', width: s.width, background: s.color, transition: 'width 0.2s, background 0.2s', borderRadius: '99px' }} />
+              </div>
+              <span style={{ fontSize: '0.78rem', color: s.color, fontWeight: 600 }}>{s.label}</span>
+            </div>
+          );
+        })()}
+        <div className="form-stack">
+          <label className="label-strong" htmlFor="reg-confirm">Confirm password</label>
+          <input
+            id="reg-confirm"
+            type="password"
+            value={form.confirmPassword}
+            onChange={set('confirmPassword')}
+            required
+            autoComplete="new-password"
+          />
+        </div>
         <select value={form.role} onChange={set('role')} aria-label="Account role">
           <option value="contributor">Contributor</option>
           <option value="creator">Creator</option>


### PR DESCRIPTION
## Summary

- **#153** — Toast notification system: `Toast` component + `ToastContext`/`useToast` hook, auto-dismisses after 4 s, `role="status"` / `aria-live="polite"` for accessibility. `WithdrawalsSection` fires success toasts for sign, approve, reject, and cancel actions.
- **#148** — Responsive mobile navbar: hamburger button (`☰`/`✕`) with `aria-expanded`, hidden behind `@media (max-width: 640px)`. Menu closes on route change and on any link tap. Desktop layout unchanged.
- **#145** — Register improvements: confirm password field with mismatch validation (no API call on mismatch), inline password strength bar (Weak / Fair / Strong) rendered as the user types.

> **#149** (skeleton loaders) was already fully implemented — `CampaignCardSkeleton` on Home and `CampaignDetailSkeleton` on Campaign page were both in place; no changes needed.

## Test plan

- [ ] Toast: trigger a withdrawal sign/approve/reject/cancel and confirm a toast appears bottom-right and auto-dismisses after ~4 s
- [ ] Toast: confirm only one toast shows at a time (rapid actions replace previous)
- [ ] Navbar: resize browser to ≤ 640 px, confirm hamburger appears and toggles the menu; confirm menu closes on navigation
- [ ] Navbar: verify desktop (> 640 px) layout is unchanged
- [ ] Register: submit with mismatched passwords — error shown, no network request
- [ ] Register: type a password and confirm strength bar updates live (weak → fair → strong)
- [ ] Register: submit with matching passwords — proceeds normally