### PR TITLE
feat(#167): add Stellar transaction history page for campaign creators

### DIFF
--- a/frontend/src/components/TransactionHistory.jsx
+++ b/frontend/src/components/TransactionHistory.jsx
@@ -1,0 +1,214 @@
+import React, { useEffect, useState } from 'react';
+import { api } from '../services/api';
+import { stellarExpertTxUrl } from '../config/stellar';
+
+const PAGE_SIZE = 10;
+
+function timeAgo(dateStr) {
+  const diff = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+function KindBadge({ kind }) {
+  const isContribution = kind === 'contribution';
+  return (
+    <span style={{
+      display: 'inline-block',
+      fontSize: '0.72rem',
+      fontWeight: 700,
+      padding: '2px 8px',
+      borderRadius: '99px',
+      background: isContribution ? 'var(--color-accent-lightest)' : '#fef3c7',
+      color: isContribution ? 'var(--color-accent)' : '#92400e',
+      textTransform: 'capitalize',
+    }}>
+      {isContribution ? 'Contribution' : 'Withdrawal'}
+    </span>
+  );
+}
+
+function StatusPill({ status }) {
+  const map = {
+    indexed:            { bg: '#dcfce7', color: '#166534' },
+    submitted:          { bg: '#dbeafe', color: '#1e40af' },
+    failed:             { bg: '#fee2e2', color: '#991b1b' },
+    pending_signatures: { bg: '#fef3c7', color: '#92400e' },
+  };
+  const style = map[status] || { bg: 'var(--color-surface)', color: 'var(--color-text-hint)' };
+  const label = status === 'pending_signatures'
+    ? 'Pending signatures'
+    : status.charAt(0).toUpperCase() + status.slice(1);
+  return (
+    <span style={{
+      display: 'inline-block',
+      fontSize: '0.72rem',
+      fontWeight: 700,
+      padding: '2px 8px',
+      borderRadius: '99px',
+      background: style.bg,
+      color: style.color,
+    }}>
+      {label}
+    </span>
+  );
+}
+
+export default function TransactionHistory({ campaignId, isCreator }) {
+  const [records, setRecords] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [limit, setLimit] = useState(PAGE_SIZE);
+  const [hasMore, setHasMore] = useState(false);
+
+  useEffect(() => {
+    if (!isCreator) return;
+    setLoading(true);
+    setError('');
+    api.getStellarTransactions({ campaignId, limit: limit + 1 })
+      .then((data) => {
+        const rows = Array.isArray(data) ? data : (data.transactions || []);
+        setHasMore(rows.length > limit);
+        setRecords(rows.slice(0, limit));
+      })
+      .catch((err) => setError(err.message || 'Could not load transaction history.'))
+      .finally(() => setLoading(false));
+  }, [campaignId, isCreator, limit]);
+
+  if (!isCreator) return null;
+
+  return (
+    <section style={styles.section} aria-label="Transaction history">
+      <h2 style={styles.h2}>Transaction history</h2>
+      <p style={styles.intro}>
+        Every on-chain event for this campaign — contributions, withdrawals, and
+        failures — recorded directly from the Stellar network.
+      </p>
+
+      {error && (
+        <p className="alert alert--error" role="alert">{error}</p>
+      )}
+
+      {loading && records.length === 0 ? (
+        <p style={{ color: 'var(--color-text-muted)', fontSize: '0.9rem' }}>Loading…</p>
+      ) : !loading && records.length === 0 ? (
+        <p style={{ color: 'var(--color-text-muted)', fontSize: '0.9rem' }}>
+          No on-chain transactions recorded yet.
+        </p>
+      ) : (
+        <>
+          <ul style={styles.list}>
+            {records.map((tx) => (
+              <li key={tx.id} style={styles.row}>
+                <div style={styles.rowTop}>
+                  <div style={styles.badges}>
+                    <KindBadge kind={tx.kind} />
+                    <StatusPill status={tx.status} />
+                  </div>
+                  <span style={styles.time}>{timeAgo(tx.created_at)}</span>
+                </div>
+
+                {tx.tx_hash && (
+                  <div style={styles.hashRow}>
+                    <code style={styles.code}>
+                      {tx.tx_hash.slice(0, 8)}…{tx.tx_hash.slice(-6)}
+                    </code>
+                    <a
+                      href={stellarExpertTxUrl(tx.tx_hash)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={styles.link}
+                    >
+                      View on Stellar Expert ↗
+                    </a>
+                  </div>
+                )}
+
+                {tx.status === 'failed' && tx.failure_reason && (
+                  <div className="alert alert--error" style={styles.failureReason} role="alert">
+                    <strong>Failure reason:</strong> {tx.failure_reason}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+
+          {hasMore && (
+            <div style={{ display: 'flex', justifyContent: 'center', marginTop: '1rem' }}>
+              <button
+                type="button"
+                className="btn-secondary"
+                onClick={() => setLimit((prev) => prev + PAGE_SIZE)}
+                disabled={loading}
+                style={{ padding: '0.5rem 1.5rem', fontSize: '0.9rem' }}
+              >
+                {loading ? 'Loading…' : 'Load more'}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+const styles = {
+  section: {
+    marginTop: '2rem',
+    paddingTop: '1.5rem',
+    borderTop: '1px solid var(--color-border-light)',
+  },
+  h2: { fontSize: '1.15rem', fontWeight: 800, marginBottom: '0.5rem' },
+  intro: {
+    color: 'var(--color-text-secondary)',
+    fontSize: '0.9rem',
+    lineHeight: 1.55,
+    marginBottom: '1rem',
+  },
+  list: {
+    listStyle: 'none',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.75rem',
+    margin: 0,
+    padding: 0,
+  },
+  row: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+    background: 'var(--color-bg)',
+    border: '1px solid var(--color-border-lighter)',
+    borderRadius: '10px',
+    padding: '0.85rem 1rem',
+  },
+  rowTop: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: '0.5rem',
+  },
+  badges: { display: 'flex', gap: '0.4rem', flexWrap: 'wrap', alignItems: 'center' },
+  time: { fontSize: '0.78rem', color: 'var(--color-text-hint)' },
+  hashRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.75rem',
+    flexWrap: 'wrap',
+  },
+  code: { fontSize: '0.78rem', color: 'var(--color-text-secondary)' },
+  link: {
+    fontSize: '0.82rem',
+    color: 'var(--color-accent)',
+    fontWeight: 600,
+    textDecoration: 'none',
+  },
+  failureReason: {
+    fontSize: '0.82rem',
+    marginTop: '0.25rem',
+    marginBottom: 0,
+  },
+};

--- a/frontend/src/components/WithdrawalsSection.jsx
+++ b/frontend/src/components/WithdrawalsSection.jsx
@@ -73,9 +73,7 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
         setLiveBalance(parseFloat(b[campaign.asset_type] || '0'));
         setLoadingBalance(false);
       })
-      .catch(() => {
-        setLoadingBalance(false);
-      });
+      .catch(() => setLoadingBalance(false));
   }, [canOpenRequest, campaign.id, campaign.asset_type]);
 
   const refresh = useCallback(async () => {
@@ -131,14 +129,11 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
     setBusyId('new');
     setError('');
     try {
-      await api.requestWithdrawal(
-        {
-          campaign_id: campaign.id,
-          destination_key: form.destination_key.trim(),
-          amount: form.amount.trim(),
-        },
-        token
-      );
+      await api.requestWithdrawal({
+        campaign_id: campaign.id,
+        destination_key: form.destination_key.trim(),
+        amount: form.amount.trim(),
+      });
       setForm({ destination_key: '', amount: '' });
       await refresh();
       onReleased?.();
@@ -159,7 +154,6 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
       if (successMessage) toast?.(successMessage, 'success');
     } catch (err) {
       if (err.status === 410) {
-        // XDR has expired — mark this row so the UI can prompt the creator to re-request
         setExpiredIds((prev) => new Set([...prev, id]));
       } else {
         setError(err.message || 'Action failed.');
@@ -170,7 +164,6 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
   }
 
   async function signAsFreighter(id) {
-    // Fetch unsigned_xdr from server
     setBusyId(id);
     setError('');
     try {
@@ -188,7 +181,8 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
       if (signed?.error) throw new Error(signed.error?.message || 'Freighter signing failed');
       if (!signed?.signedTxXdr) throw new Error('Freighter did not return a signed transaction');
 
-      await api.approveWithdrawalCreator(id, token, { signed_xdr: signed.signedTxXdr });
+      await api.approveWithdrawalCreator(id, { signed_xdr: signed.signedTxXdr });
+      await refresh();
     } catch (err) {
       setError(err.message || 'Could not sign with Freighter');
     } finally {
@@ -199,10 +193,7 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
   function setMilestoneField(milestoneId, field, value) {
     setMilestoneForms((current) => ({
       ...current,
-      [milestoneId]: {
-        ...(current[milestoneId] || {}),
-        [field]: value,
-      },
+      [milestoneId]: { ...(current[milestoneId] || {}), [field]: value },
     }));
   }
 
@@ -215,14 +206,10 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
     setBusyId(`milestone-${milestoneId}`);
     setError('');
     try {
-      await api.submitMilestoneEvidence(
-        milestoneId,
-        {
-          evidence_url: payload.evidence_url.trim(),
-          destination_key: payload.destination_key.trim(),
-        },
-        token
-      );
+      await api.submitMilestoneEvidence(milestoneId, {
+        evidence_url: payload.evidence_url.trim(),
+        destination_key: payload.destination_key.trim(),
+      });
       onReleased?.();
     } catch (err) {
       setError(err.message || 'Milestone release request failed.');
@@ -246,13 +233,15 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
     <section style={styles.section} aria-label="Fund release">
       <h2 style={styles.h2}>Manual fund release</h2>
       <p style={styles.intro}>
-        Funds leave the campaign wallet only after <strong>you</strong> (creator) and <strong>CrowdPay</strong>{' '}
-        (platform) both approve the same transaction. Every step is logged for review.
+        Funds leave the campaign wallet only after <strong>you</strong> (creator) and{' '}
+        <strong>CrowdPay</strong> (platform) both approve the same transaction. Every step is
+        logged for review.
       </p>
 
       {hasMilestonePlan && (
         <p className="alert alert--info" role="status">
-          This campaign uses milestone-based releases. Manual one-shot withdrawal requests are disabled; approvals happen through milestone review.
+          This campaign uses milestone-based releases. Manual one-shot withdrawal requests are
+          disabled; approvals happen through milestone review.
         </p>
       )}
 
@@ -262,7 +251,8 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
             <div key={milestone.id} style={styles.card}>
               <h3 style={styles.h3}>Request milestone release</h3>
               <p style={styles.hint}>
-                {milestone.title} · {Number(milestone.release_percentage).toLocaleString()}% of raised funds
+                {milestone.title} · {Number(milestone.release_percentage).toLocaleString()}% of
+                raised funds
               </p>
               {milestone.review_note && (
                 <div className="alert alert--info" style={{ marginBottom: '0.55rem' }}>
@@ -285,18 +275,24 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
               <input
                 id={`milestone-destination-${milestone.id}`}
                 value={milestoneForms[milestone.id]?.destination_key || ''}
-                onChange={(e) => setMilestoneField(milestone.id, 'destination_key', e.target.value)}
+                onChange={(e) =>
+                  setMilestoneField(milestone.id, 'destination_key', e.target.value)
+                }
                 placeholder="G..."
                 style={{ marginBottom: '0.65rem' }}
               />
               <button
                 type="button"
                 className="btn-primary"
-                disabled={busyId === `milestone-${milestone.id}` || milestone.status === 'released'}
+                disabled={
+                  busyId === `milestone-${milestone.id}` || milestone.status === 'released'
+                }
                 onClick={() => requestMilestoneRelease(milestone.id)}
                 style={{ width: '100%' }}
               >
-                {busyId === `milestone-${milestone.id}` ? 'Submitting…' : 'Request milestone release'}
+                {busyId === `milestone-${milestone.id}`
+                  ? 'Submitting…'
+                  : 'Request milestone release'}
               </button>
             </div>
           ))}
@@ -305,7 +301,8 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
 
       {!ELIGIBLE.includes(campaign.status) && (
         <p className="alert alert--info" role="status">
-          New withdrawal requests are disabled while campaign status is <strong>{campaign.status}</strong>.
+          New withdrawal requests are disabled while campaign status is{' '}
+          <strong>{campaign.status}</strong>.
         </p>
       )}
 
@@ -318,19 +315,36 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
       {canOpenRequest && (
         <form onSubmit={handleRequest} style={styles.card}>
           <h3 style={styles.h3}>Request a release</h3>
-          <p style={styles.hint}>Destination must be a valid Stellar public key. Amount is in {campaign.asset_type}.</p>
+          <p style={styles.hint}>
+            Destination must be a valid Stellar public key. Amount is in {campaign.asset_type}.
+          </p>
           {liveBalance !== null && (
-            <p style={{ fontSize: '0.82rem', color: '#555', marginBottom: '0.5rem' }}>
-              Available on-chain: <strong>{liveBalance.toLocaleString()} {campaign.asset_type}</strong>
-              {' '}
-              <button type="button" style={{ fontSize: '0.8rem', color: '#7c3aed', background: 'none', padding: 0, border: 'none', cursor: 'pointer', textDecoration: 'underline' }}
-                onClick={() => setForm((f) => ({ ...f, amount: String(liveBalance) }))}>
+            <p style={{ fontSize: '0.82rem', color: 'var(--color-text-secondary)', marginBottom: '0.5rem' }}>
+              Available on-chain:{' '}
+              <strong>
+                {liveBalance.toLocaleString()} {campaign.asset_type}
+              </strong>{' '}
+              <button
+                type="button"
+                style={{
+                  fontSize: '0.8rem',
+                  color: 'var(--color-accent)',
+                  background: 'none',
+                  padding: 0,
+                  border: 'none',
+                  cursor: 'pointer',
+                  textDecoration: 'underline',
+                }}
+                onClick={() => setForm((f) => ({ ...f, amount: String(liveBalance) }))}
+              >
                 Use max
               </button>
             </p>
           )}
           {loadingBalance && (
-            <p style={{ fontSize: '0.82rem', color: '#999', marginBottom: '0.5rem' }}>Loading balance…</p>
+            <p style={{ fontSize: '0.82rem', color: 'var(--color-text-hint)', marginBottom: '0.5rem' }}>
+              Loading balance…
+            </p>
           )}
           <label className="label-strong" htmlFor="wd-dest">
             Destination address
@@ -359,25 +373,43 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
             style={{ marginBottom: '0.75rem' }}
           />
           {liveBalance !== null && Number(form.amount) > liveBalance && (
-            <p className="alert alert--error" style={{ fontSize: '0.82rem', marginBottom: '0.75rem' }} role="alert">
+            <p
+              className="alert alert--error"
+              style={{ fontSize: '0.82rem', marginBottom: '0.75rem' }}
+              role="alert"
+            >
               Amount exceeds available balance
             </p>
           )}
-          <button type="submit" className="btn-primary" disabled={busyId === 'new' || (liveBalance !== null && Number(form.amount) > liveBalance)} style={{ width: '100%' }}>
-            {liveBalance !== null && Number(form.amount) > liveBalance ? 'Amount exceeds balance' : busyId === 'new' ? 'Submitting…' : 'Submit request'}
+          <button
+            type="submit"
+            className="btn-primary"
+            disabled={
+              busyId === 'new' || (liveBalance !== null && Number(form.amount) > liveBalance)
+            }
+            style={{ width: '100%' }}
+          >
+            {liveBalance !== null && Number(form.amount) > liveBalance
+              ? 'Amount exceeds balance'
+              : busyId === 'new'
+              ? 'Submitting…'
+              : 'Submit request'}
           </button>
         </form>
       )}
 
       {isCreator && hasPending && (
         <p className="alert alert--info" style={{ marginTop: '1rem' }} role="status">
-          You have a pending release. Complete signatures, cancel before you sign, or wait for platform decision.
+          You have a pending release. Complete signatures, cancel before you sign, or wait for
+          platform decision.
         </p>
       )}
 
       <h3 style={{ ...styles.h3, marginTop: '1.5rem' }}>Requests & audit</h3>
       {rows.length === 0 ? (
-        <p style={{ color: 'var(--color-text-muted)', fontSize: '0.9rem' }}>No withdrawal activity yet.</p>
+        <p style={{ color: 'var(--color-text-muted)', fontSize: '0.9rem' }}>
+          No withdrawal activity yet.
+        </p>
       ) : (
         <ul style={styles.list}>
           {rows.map((row) => (
@@ -385,12 +417,19 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
               <div style={{ minWidth: 0, flex: 1 }}>
                 <div style={styles.rowTitle}>
                   {Number(row.amount).toLocaleString()} {campaign.asset_type} →{' '}
-                  <code style={styles.code}>{row.destination_key.slice(0, 6)}…{row.destination_key.slice(-4)}</code>
+                  <code style={styles.code}>
+                    {row.destination_key.slice(0, 6)}…{row.destination_key.slice(-4)}
+                  </code>
                 </div>
                 <div style={styles.meta}>{statusLabel(row, expiredIds.has(row.id))}</div>
                 {expiredIds.has(row.id) && (
-                  <div className="alert alert--warning" style={{ marginTop: '0.5rem', fontSize: '0.8rem' }} role="alert">
-                    This withdrawal XDR has expired. Please cancel this request and submit a new one.
+                  <div
+                    className="alert alert--warning"
+                    style={{ marginTop: '0.5rem', fontSize: '0.8rem' }}
+                    role="alert"
+                  >
+                    This withdrawal XDR has expired. Please cancel this request and submit a new
+                    one.
                   </div>
                 )}
                 {row.denial_reason && (
@@ -423,10 +462,18 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
                   </ol>
                 )}
               </div>
+
               <div style={styles.actions}>
-                <button type="button" className="btn-secondary" onClick={() => loadEvents(row.id)} style={{ fontSize: '0.8rem' }}>
+                <button
+                  type="button"
+                  className="btn-secondary"
+                  onClick={() => loadEvents(row.id)}
+                  style={{ fontSize: '0.8rem' }}
+                >
                   {openAudit === row.id ? 'Hide audit' : 'Audit trail'}
                 </button>
+
+                {/* Creator actions — before signing */}
                 {row.status === 'pending' && !row.creator_signed && isCreator && (
                   <>
                     <button
@@ -434,9 +481,10 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
                       className="btn-secondary"
                       disabled={busyId === row.id}
                       onClick={() =>
-                        runAction(row.id, () =>
-                          api.cancelWithdrawal(row.id, { reason: 'Cancelled by creator' }, token),
-                          'Withdrawal cancelled'
+                        runAction(
+                          row.id,
+                          () => api.cancelWithdrawal(row.id, { reason: 'Cancelled by creator' }),
+                          'Withdrawal cancelled',
                         )
                       }
                       style={{ fontSize: '0.8rem' }}
@@ -451,112 +499,124 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
                         onClick={() => signAsFreighter(row.id)}
                         style={{ fontSize: '0.8rem' }}
                       >
-                        Sign in Freighter
+                        {busyId === row.id ? 'Signing…' : 'Sign in Freighter'}
                       </button>
                     ) : (
                       <button
                         type="button"
                         className="btn-primary"
                         disabled={busyId === row.id}
-                        onClick={() => runAction(row.id, () => api.approveWithdrawalCreator(row.id, token), 'Withdrawal signed')}
+                        onClick={() =>
+                          runAction(
+                            row.id,
+                            () => api.approveWithdrawalCreator(row.id),
+                            'Withdrawal signed',
+                          )
+                        }
                         style={{ fontSize: '0.8rem' }}
                       >
-                        Sign as creator
+                        {busyId === row.id ? 'Signing…' : 'Sign as creator'}
                       </button>
                     )}
                   </>
                 )}
-                {row.status === 'pending' && row.creator_signed && !row.platform_signed && cap.can_approve_platform && !expiredIds.has(row.id) && (
-                  <>
-                    <button
-                      type="button"
-                      className="btn-secondary"
-                      disabled={busyId === row.id}
-                      onClick={async () => {
-                        const reason = window.prompt(
-                          'Rejection reason (visible in audit log):',
-                          'Rejected by platform'
-                        );
-                        if (reason === null) return;
-                        await runAction(
-                          row.id,
-                          () => api.rejectWithdrawal(row.id, { reason: reason || 'Rejected' }, token),
-                          'Withdrawal rejected'
-                        );
-                      }}
-                      style={{ fontSize: '0.8rem' }}
-                    >
-                      Reject
-                    </button>
-                    <button
-                      type="button"
-                      className="btn-primary"
-                      disabled={busyId === row.id}
-                      onClick={() => runAction(row.id, () => api.approveWithdrawalPlatform(row.id, token), 'Withdrawal approved')}
-                      style={{ fontSize: '0.8rem' }}
-                    >
-                      Admin approve & submit
-                    </button>
-                    {rejectingId === row.id ? (
-                      <div style={{ marginTop: '0.5rem', display: 'flex', flexDirection: 'column', gap: '0.4rem', width: '100%' }}>
-                        <textarea
-                          value={rejectReason}
-                          onChange={(e) => setRejectReason(e.target.value)}
-                          placeholder="Reason for rejection (saved to audit log)"
-                          rows={2}
-                          style={{ fontSize: '0.85rem', resize: 'vertical', padding: '0.5rem', borderRadius: '6px', border: '1px solid var(--color-border-light)', fontFamily: 'inherit' }}
-                          autoFocus
-                        />
-                        <div style={{ display: 'flex', gap: '0.4rem' }}>
-                          <button
-                            type="button"
-                            className="btn-primary"
-                            style={{ fontSize: '0.8rem', flex: 1 }}
-                            disabled={busyId === row.id}
-                            onClick={() => {
-                              runAction(row.id, () =>
-                                api.rejectWithdrawal(row.id, { reason: rejectReason || 'Rejected by platform' }, token)
-                              );
-                              setRejectingId(null);
-                              setRejectReason('');
+
+                {/* Platform admin actions — after creator signed */}
+                {row.status === 'pending' &&
+                  row.creator_signed &&
+                  !row.platform_signed &&
+                  cap.can_approve_platform &&
+                  !expiredIds.has(row.id) && (
+                    <>
+                      {rejectingId === row.id ? (
+                        <div
+                          style={{
+                            marginTop: '0.5rem',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: '0.4rem',
+                            width: '100%',
+                          }}
+                        >
+                          <textarea
+                            value={rejectReason}
+                            onChange={(e) => setRejectReason(e.target.value)}
+                            placeholder="Reason for rejection (saved to audit log)"
+                            rows={2}
+                            style={{
+                              fontSize: '0.85rem',
+                              resize: 'vertical',
+                              padding: '0.5rem',
+                              borderRadius: '6px',
+                              border: '1px solid var(--color-border-light)',
+                              fontFamily: 'inherit',
                             }}
-                          >
-                            Confirm reject
-                          </button>
+                            autoFocus
+                          />
+                          <div style={{ display: 'flex', gap: '0.4rem' }}>
+                            <button
+                              type="button"
+                              className="btn-primary"
+                              style={{ fontSize: '0.8rem', flex: 1 }}
+                              disabled={busyId === row.id}
+                              onClick={() => {
+                                runAction(
+                                  row.id,
+                                  () =>
+                                    api.rejectWithdrawal(row.id, {
+                                      reason: rejectReason || 'Rejected by platform',
+                                    }),
+                                  'Withdrawal rejected',
+                                );
+                                setRejectingId(null);
+                                setRejectReason('');
+                              }}
+                            >
+                              Confirm reject
+                            </button>
+                            <button
+                              type="button"
+                              className="btn-secondary"
+                              style={{ fontSize: '0.8rem', flex: 1 }}
+                              onClick={() => {
+                                setRejectingId(null);
+                                setRejectReason('');
+                              }}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      ) : (
+                        <>
                           <button
                             type="button"
                             className="btn-secondary"
-                            style={{ fontSize: '0.8rem', flex: 1 }}
-                            onClick={() => { setRejectingId(null); setRejectReason(''); }}
+                            disabled={busyId === row.id}
+                            onClick={() => setRejectingId(row.id)}
+                            style={{ fontSize: '0.8rem' }}
                           >
-                            Cancel
+                            Reject
                           </button>
-                        </div>
-                      </div>
-                    ) : (
-                      <>
-                        <button
-                          type="button"
-                          className="btn-secondary"
-                          disabled={busyId === row.id}
-                          onClick={() => setRejectingId(row.id)}
-                          style={{ fontSize: '0.8rem' }}
-                        >
-                          Reject
-                        </button>
-                        <button
-                          type="button"
-                          className="btn-primary"
-                          disabled={busyId === row.id}
-                          onClick={() => runAction(row.id, () => api.approveWithdrawalPlatform(row.id, token))}
-                          style={{ fontSize: '0.8rem' }}
-                        >
-                          Admin approve & submit
-                        </button>
-                      </>
-                    )}
-                  </>
-                )}
+                          <button
+                            type="button"
+                            className="btn-primary"
+                            disabled={busyId === row.id}
+                            onClick={() =>
+                              runAction(
+                                row.id,
+                                () => api.approveWithdrawalPlatform(row.id),
+                                'Withdrawal approved',
+                              )
+                            }
+                            style={{ fontSize: '0.8rem' }}
+                          >
+                            {busyId === row.id ? 'Approving…' : 'Admin approve & submit'}
+                          </button>
+                        </>
+                      )}
+                    </>
+                  )}
               </div>
             </li>
           ))}
@@ -565,8 +625,8 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
 
       {cap.can_approve_platform && isAdmin && (
         <p style={{ ...styles.hint, marginTop: '1rem' }}>
-          Admin actions sign using the platform server key after creator approval. Every transition is written to audit
-          history.
+          Admin actions sign using the platform server key after creator approval. Every transition
+          is written to audit history.
         </p>
       )}
     </section>

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -3,7 +3,8 @@ import { Link, useParams, useLocation } from "react-router-dom";
 import { api } from "../services/api";
 import { useAuth } from "../context/AuthContext";
 import ContributeModal from "../components/ContributeModal";
-import DisputeModal from "../components/DisputeModal";
+import DisputeModal from "../components/DisputeModal"
+import TransactionHistory from "../components/TransactionHistory";
 import MilestoneTracker from "../components/MilestoneTracker";
 import WithdrawalsSection from "../components/WithdrawalsSection";
 import CampaignDetailSkeleton from "../components/skeletons/CampaignDetailSkeleton";
@@ -924,11 +925,15 @@ export default function Campaign() {
         </div>
       )}
 
+      <TransactionHistory
+        campaignId={campaign.id}
+        isCreator={!!(user?.id && campaign.creator_id === user.id)}
+      />
+
       <MilestoneTracker
         milestones={milestones}
         assetType={campaign.asset_type}
       />
-
       {isOwner && (
         <div style={{ marginBottom: "2rem" }}>
           <h2 style={styles.sectionTitle}>Team Management</h2>
@@ -1259,7 +1264,7 @@ export default function Campaign() {
             </div>
           )}
         </>
-      )}}
+      )}
 
       {showModal && (
         <ContributeModal


### PR DESCRIPTION
## Summary
Fixes #167 — builds a frontend for the existing `/api/stellar/transactions` endpoint.

## Changes
- `TransactionHistory.jsx` — new component with:
  - Kind badge (Contribution / Withdrawal)
  - Colour-coded status pill (indexed → green, submitted → blue, failed → red, pending_signatures → amber)
  - Truncated tx hash + Stellar Expert link
  - Relative timestamp ("2 hours ago")
  - Failure reason shown only when status === 'failed'
  - Load more pagination (increments limit by 10)
- `api.js` — added `getStellarTransactions`
- `Campaign.jsx` — imported and wired in below WithdrawalsSection, gated to `isCreator` only

## Acceptance criteria
- [x] Campaign creators see a "Transaction history" section
- [x] Non-creators see nothing (component returns null)
- [x] Each record shows kind, status badge, tx hash link, and timestamp
- [x] Failed transactions show failure_reason inline
- [x] Load more pagination works