### PR TITLE
fix: enforce future campaign deadlines and add step summary

### DIFF
--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -686,6 +686,23 @@ router.post('/', requireAuth, requireRole('creator', 'admin'), createCampaignVal
    */
   const { title, description, target_amount, asset_type, deadline, milestones, min_contribution, max_contribution } = req.body;
 
+  if (deadline) {
+    const [year, month, day] = String(deadline).split('-').map(Number);
+    const deadlineDate = new Date(year, month - 1, day);
+    const todayDate = new Date();
+    todayDate.setHours(0, 0, 0, 0);
+
+    if (
+      Number.isNaN(deadlineDate.getTime()) ||
+      deadlineDate.getFullYear() !== year ||
+      deadlineDate.getMonth() + 1 !== month ||
+      deadlineDate.getDate() !== day ||
+      deadlineDate < todayDate
+    ) {
+      return res.status(400).json({ error: 'deadline must be a future date' });
+    }
+  }
+
   let normalizedMilestones;
   try {
     normalizedMilestones = normalizeMilestonesInput(milestones);

--- a/backend/src/routes/campaigns.test.js
+++ b/backend/src/routes/campaigns.test.js
@@ -194,6 +194,37 @@ test('POST /api/campaigns returns 400 with validation errors for invalid payload
   assert.ok(response.body.errors.length >= 1);
 });
 
+test('POST /api/campaigns returns 400 for past deadline', async () => {
+  process.env.KYC_REQUIRED_FOR_CAMPAIGNS = 'false';
+  const app = buildApp({
+    authUser: { userId: 'creator-1', role: 'creator' },
+    queryImpl: async (text) => {
+      if (text.includes('SELECT email, wallet_public_key, kyc_status FROM users')) {
+        return { rows: [{ email: 'creator@test.com', wallet_public_key: 'GCREATOR', kyc_status: 'verified' }] };
+      }
+      return { rows: [] };
+    },
+    buildWithdrawalTransactionImpl: async () => '',
+    insertWithdrawalPendingSignaturesImpl: async () => 'tx-row',
+  });
+
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  const pastDeadline = yesterday.toISOString().split('T')[0];
+
+  const response = await request(app)
+    .post('/api/campaigns')
+    .set('Authorization', 'Bearer token')
+    .send({ title: 'Old deadline', target_amount: '100', asset_type: 'USDC', deadline: pastDeadline });
+
+  assert.equal(response.status, 400);
+  assert.ok(Array.isArray(response.body.errors) || response.body.error);
+  assert.ok(
+    (response.body.errors || []).some((error) => String(error.msg || error).toLowerCase().includes('deadline must be in the future')) ||
+    String(response.body.error).toLowerCase().includes('deadline must be a future date')
+  );
+});
+
 test('POST /api/campaigns/:id/trigger-refunds creates refund requests for contributions', async () => {
   const created = [];
   const queryImpl = async (text, params) => {

--- a/frontend/src/pages/CreateCampaign.jsx
+++ b/frontend/src/pages/CreateCampaign.jsx
@@ -47,6 +47,7 @@ export default function CreateCampaign() {
   const [isDragOverCover, setIsDragOverCover] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const today = new Date().toISOString().split('T')[0];
   const [showCreatorTips, setShowCreatorTips] = useState(isCreatorOnboardingVisible);
 
   useEffect(() => {
@@ -163,6 +164,16 @@ export default function CreateCampaign() {
     return true;
   }
 
+  function validateStep2() {
+    if (form.deadline && form.deadline < today) {
+      setError('Deadline must be today or in the future.');
+      return false;
+    }
+
+    setError('');
+    return true;
+  }
+
   function validateMilestones() {
     if (form.milestones.length === 0) {
       setError('');
@@ -201,7 +212,7 @@ export default function CreateCampaign() {
 
   async function handleSubmit(e) {
     e.preventDefault();
-    if (!validateStep1() || !validateMilestones()) return;
+    if (!validateStep1() || !validateStep2() || !validateMilestones()) return;
     setLoading(true);
     setError('');
     try {
@@ -448,6 +459,41 @@ export default function CreateCampaign() {
 
         {step === 2 && (
           <>
+            <div
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                alignItems: 'center',
+                gap: '0.75rem',
+                background: '#f8fafc',
+                border: '1px solid #d1d5db',
+                borderRadius: '12px',
+                padding: '1rem',
+                marginBottom: '1rem',
+              }}
+            >
+              <button
+                type="button"
+                onClick={() => {
+                  setError('');
+                  setStep(1);
+                }}
+                style={{
+                  border: 'none',
+                  background: 'transparent',
+                  color: 'var(--color-accent)',
+                  padding: 0,
+                  cursor: 'pointer',
+                  fontWeight: 600,
+                }}
+              >
+                ← Edit
+              </button>
+              <span style={{ fontWeight: 700 }}>{form.title || 'Untitled campaign'}</span>
+              <span style={{ color: 'var(--color-text-muted)' }}>
+                Goal: {form.target_amount || '—'} {form.asset_type || ''}
+              </span>
+            </div>
             <div className="form-stack">
               <label className="label-strong" htmlFor="cc-desc">
                 Description <span style={{ fontWeight: 500, color: 'var(--color-text-muted)' }}>(optional)</span>
@@ -501,7 +547,7 @@ export default function CreateCampaign() {
               <label className="label-strong" htmlFor="cc-deadline">
                 Deadline <span style={{ fontWeight: 500, color: 'var(--color-text-muted)' }}>(optional)</span>
               </label>
-              <input id="cc-deadline" type="date" value={form.deadline} onChange={setField('deadline')} />
+              <input id="cc-deadline" type="date" min={today} value={form.deadline} onChange={setField('deadline')} />
             </div>
 
             <div className="form-stack" style={{ marginTop: '1.25rem', flexDirection: 'row', alignItems: 'center', gap: '0.5rem' }}>
@@ -520,13 +566,6 @@ export default function CreateCampaign() {
               If unchecked, backers will be listed but their individual amounts will be hidden from the public.
             </p>
 
-            <div className="alert alert--info" style={{ marginTop: '1.25rem' }} role="status">
-              <strong>Summary:</strong> Goal of {form.target_amount || '—'} {form.asset_type}
-              {form.min_contribution && ` (Min: ${form.min_contribution} ${form.asset_type})`}
-              {form.max_contribution && ` (Max: ${form.max_contribution} ${form.asset_type})`} — “{form.title || 'Untitled'}”.
-              A multisig campaign wallet will be created when you launch.
-            </div>
-
             {error && (
               <p className="alert alert--error" style={{ marginTop: '1rem' }} role="alert">
                 {error}
@@ -534,7 +573,14 @@ export default function CreateCampaign() {
             )}
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: '0.65rem', marginTop: '1.25rem' }}>
-              <button type="button" className="btn-primary" style={{ width: '100%' }} onClick={() => setStep(3)}>
+              <button
+                type="button"
+                className="btn-primary"
+                style={{ width: '100%' }}
+                onClick={() => {
+                  if (validateStep2()) setStep(3);
+                }}
+              >
                 Continue to milestones
               </button>
               <button


### PR DESCRIPTION
## PR summary
Fix campaign creation by enforcing future deadlines on both frontend and backend, adding a Step 2 summary of Step 1 inputs with an edit shortcut, and protecting the POST campaign API against past deadline submissions

Closes #144 
Closes #151 
Closes #191 
Closes #193 

### What changed
CreateCampaign.jsx

- Added min={today} to the deadline date picker so users cannot select past dates.
- Added validateStep2() to reject past deadlines before advancing or submitting.
- Added a compact Step 1 summary panel on Step 2 with an ← Edit button.
- Removed the old lower info alert summary from Step 2.
- campaigns.js

- Added POST /api/campaigns validation to reject invalid or past deadlines with 400.
- campaigns.test.js

- Added regression coverage for past deadline submission returning 400.
