### PR TITLE
feat: add in-app notification bell with polling and dropdown

### DIFF
--- a/backend/db/migrations/20260601_notifications.sql
+++ b/backend/db/migrations/20260601_notifications.sql
@@ -1,0 +1,12 @@
+CREATE TABLE notifications (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type        TEXT NOT NULL,
+  title       TEXT NOT NULL,
+  body        TEXT,
+  link        TEXT,
+  read_at     TIMESTAMPTZ,
+  created_at  TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX ON notifications (user_id, created_at DESC);
+CREATE INDEX ON notifications (user_id) WHERE read_at IS NULL;

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -91,6 +91,7 @@ app.use('/api/api-keys', require('./routes/apiKeys'));
 app.use('/api/webhooks', require('./routes/webhooks'));
 app.use('/api/milestones', require('./routes/milestones'));
 app.use('/api', require('./routes/disputes'));
+app.use('/api/notifications', require('./routes/notifications'));
 
 app.get('/health', (_, res) => res.json({ status: 'ok' }));
 app.get('/api/config', (_, res) =>

--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -1,0 +1,36 @@
+const router = require('express').Router();
+const db = require('../config/database');
+const { requireAuth } = require('../middleware/auth');
+
+router.get('/', requireAuth, async (req, res) => {
+  const { rows } = await db.query(
+    `SELECT id, type, title, body, link, read_at, created_at
+     FROM notifications
+     WHERE user_id = $1
+     ORDER BY created_at DESC
+     LIMIT 20`,
+    [req.user.userId]
+  );
+  res.json(rows);
+});
+
+router.patch('/read-all', requireAuth, async (req, res) => {
+  await db.query(
+    `UPDATE notifications SET read_at = NOW() WHERE user_id = $1 AND read_at IS NULL`,
+    [req.user.userId]
+  );
+  res.json({ ok: true });
+});
+
+router.patch('/:id/read', requireAuth, async (req, res) => {
+  const { rows } = await db.query(
+    `UPDATE notifications SET read_at = NOW()
+     WHERE id = $1 AND user_id = $2 AND read_at IS NULL
+     RETURNING id`,
+    [req.params.id, req.user.userId]
+  );
+  if (!rows.length) return res.status(404).json({ error: 'Notification not found' });
+  res.json({ ok: true });
+});
+
+module.exports = router;

--- a/backend/src/routes/withdrawals.js
+++ b/backend/src/routes/withdrawals.js
@@ -21,6 +21,7 @@ const {
 const { sendEmail } = require('../services/emailService');
 const { emitWebhookEventForUser, WEBHOOK_EVENTS } = require('../services/webhookDispatcher');
 const { withDecryptedWalletSecret } = require('../services/walletSecrets');
+const { createNotification } = require('../services/notifications');
 
 const ALLOWED_CAMPAIGN_STATUS_FOR_REQUEST = ['active', 'funded'];
 
@@ -485,7 +486,7 @@ const platformApproveHandler = async (req, res) => {
 
     // Notify creator
     const { rows: cRows } = await db.query(
-      `SELECT u.email FROM users u JOIN campaigns c ON c.creator_id = u.id WHERE c.id = $1`,
+      `SELECT u.email, c.creator_id FROM users u JOIN campaigns c ON c.creator_id = u.id WHERE c.id = $1`,
       [requestRow.campaign_id]
     );
     if (cRows.length) {
@@ -494,6 +495,12 @@ const platformApproveHandler = async (req, res) => {
         subject: 'Withdrawal Approved',
         text: `Your withdrawal for ${requestRow.amount} has been approved by the platform. Transaction Hash: ${txHash}`
       });
+      createNotification(cRows[0].creator_id, {
+        type: 'withdrawal_approved',
+        title: 'Withdrawal approved',
+        body: `Your withdrawal of ${requestRow.amount} was approved and submitted on-chain.`,
+        link: `/campaigns/${requestRow.campaign_id}`,
+      }).catch(() => {});
     }
 
     const withdrawalRow = updated[0];
@@ -656,7 +663,7 @@ router.post('/:id/reject', requireAuth, requirePlatformApprover, async (req, res
     await client.query('COMMIT');
 
     const { rows: cRows } = await db.query(
-      `SELECT u.email FROM users u JOIN campaigns c ON c.creator_id = u.id WHERE c.id = $1`,
+      `SELECT u.email, c.creator_id FROM users u JOIN campaigns c ON c.creator_id = u.id WHERE c.id = $1`,
       [requestRow.campaign_id]
     );
     if (cRows.length) {
@@ -665,6 +672,12 @@ router.post('/:id/reject', requireAuth, requirePlatformApprover, async (req, res
         subject: 'Withdrawal Rejected',
         text: `Your withdrawal request has been rejected by the platform. Reason: ${reason}`
       });
+      createNotification(cRows[0].creator_id, {
+        type: 'withdrawal_rejected',
+        title: 'Withdrawal rejected',
+        body: `Your withdrawal request was rejected. Reason: ${reason}`,
+        link: `/campaigns/${requestRow.campaign_id}`,
+      }).catch(() => {});
     }
 
     res.json(updated[0]);

--- a/backend/src/services/ledgerMonitor.js
+++ b/backend/src/services/ledgerMonitor.js
@@ -16,6 +16,7 @@ const {
   emitWebhookEventForUser,
   WEBHOOK_EVENTS,
 } = require("./webhookDispatcher");
+const { createNotification } = require("./notifications");
 
 /** wallet_public_key -> stream metadata */
 const streamRegistry = new Map();
@@ -375,6 +376,13 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
         logger.error("Contribution webhook emit failed", { error: e.message }),
       );
 
+      createNotification(postCommitHooks.creatorId, {
+        type: 'contribution_received',
+        title: 'New contribution received',
+        body: `${postCommitHooks.contributionPayload.amount} ${postCommitHooks.contributionPayload.asset} received.`,
+        link: `/campaigns/${postCommitHooks.campaignId}`,
+      }).catch(() => {});
+
       if (postCommitHooks.fundedCampaign) {
         emitWebhookEventForUser(
           postCommitHooks.fundedCampaign.creator_id,
@@ -383,6 +391,13 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
         ).catch((e) =>
           logger.error("Funded webhook emit failed", { error: e.message }),
         );
+
+        createNotification(postCommitHooks.fundedCampaign.creator_id, {
+          type: 'goal_reached',
+          title: 'Goal reached!',
+          body: `Your campaign "${postCommitHooks.fundedCampaign.title}" has reached its funding goal.`,
+          link: `/campaigns/${postCommitHooks.campaignId}`,
+        }).catch(() => {});
       }
     });
   }

--- a/backend/src/services/notifications.js
+++ b/backend/src/services/notifications.js
@@ -1,0 +1,16 @@
+const db = require('../config/database');
+const logger = require('../config/logger');
+
+async function createNotification(userId, { type, title, body, link }) {
+  try {
+    await db.query(
+      `INSERT INTO notifications (user_id, type, title, body, link)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [userId, type, title, body || null, link || null]
+    );
+  } catch (err) {
+    logger.error('Failed to create notification', { user_id: userId, type, error: err.message });
+  }
+}
+
+module.exports = { createNotification };

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useTheme } from '../context/ThemeContext';
 import { api } from '../services/api';
+import NotificationDropdown from './NotificationDropdown';
 
 export default function Navbar() {
   const { user, logout } = useAuth();
@@ -10,13 +11,47 @@ export default function Navbar() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
 
+  const [notifications, setNotifications] = useState([]);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const bellRef = useRef(null);
+
+  const unread = notifications.filter((n) => !n.read_at).length;
+
+  useEffect(() => {
+    if (!user) {
+      setNotifications([]);
+      return;
+    }
+    const fetchNotifs = () => api.getNotifications().then(setNotifications).catch(() => {});
+    fetchNotifs();
+    const id = setInterval(fetchNotifs, 30_000);
+    return () => clearInterval(id);
+  }, [user]);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    if (!showDropdown) return;
+    function handleOutside(e) {
+      if (bellRef.current && !bellRef.current.contains(e.target)) {
+        setShowDropdown(false);
+      }
+    }
+    document.addEventListener('mousedown', handleOutside);
+    return () => document.removeEventListener('mousedown', handleOutside);
+  }, [showDropdown]);
+
   function handleLogout() {
     logout();
     navigate('/');
   }
 
-  function closeMenu() {
-    setMenuOpen(false);
+  function handleMarkRead(id) {
+    setNotifications((prev) => prev.map((n) => n.id === id ? { ...n, read_at: new Date().toISOString() } : n));
+  }
+
+  async function handleMarkAllRead() {
+    await api.markAllNotificationsRead().catch(() => {});
+    setNotifications((prev) => prev.map((n) => ({ ...n, read_at: n.read_at || new Date().toISOString() })));
   }
 
   return (
@@ -28,6 +63,24 @@ export default function Navbar() {
             <>
               <Link to="/campaigns/new" style={styles.link} aria-current={pathname === '/campaigns/new' ? 'page' : undefined}>Start Campaign</Link>
               <span style={styles.name} aria-hidden="true">{user.name}</span>
+              <div style={styles.bellWrap} ref={bellRef}>
+                <button
+                  onClick={() => setShowDropdown((v) => !v)}
+                  style={styles.bellBtn}
+                  aria-label={`${unread} unread notifications`}
+                >
+                  🔔
+                  {unread > 0 && <span style={styles.badge}>{unread}</span>}
+                </button>
+                {showDropdown && (
+                  <NotificationDropdown
+                    notifications={notifications}
+                    onMarkRead={handleMarkRead}
+                    onMarkAllRead={handleMarkAllRead}
+                    onClose={() => setShowDropdown(false)}
+                  />
+                )}
+              </div>
               <button onClick={handleLogout} className="btn-secondary" style={{ padding: '0.4rem 0.9rem' }}>
                 Logout
               </button>
@@ -54,4 +107,32 @@ const styles = {
   balance: { color: 'var(--color-text-hint)', fontSize: '0.8rem', fontFamily: 'monospace' },
   balanceLoading: { color: 'var(--color-text-muted)', fontSize: '0.8rem' },
   themeToggle: { background: 'transparent', border: 'none', fontSize: '1.2rem', cursor: 'pointer', padding: '0.4rem 0.6rem', borderRadius: '6px', transition: 'background 0.15s' },
+  bellWrap: { position: 'relative' },
+  bellBtn: {
+    background: 'transparent',
+    border: 'none',
+    fontSize: '1.1rem',
+    cursor: 'pointer',
+    padding: '0.3rem 0.5rem',
+    borderRadius: '6px',
+    position: 'relative',
+    lineHeight: 1,
+  },
+  badge: {
+    position: 'absolute',
+    top: '-2px',
+    right: '-4px',
+    background: 'var(--color-accent, #6366f1)',
+    color: '#fff',
+    fontSize: '0.65rem',
+    fontWeight: 700,
+    minWidth: '16px',
+    height: '16px',
+    borderRadius: '8px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '0 3px',
+    lineHeight: 1,
+  },
 };

--- a/frontend/src/components/NotificationDropdown.jsx
+++ b/frontend/src/components/NotificationDropdown.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { api } from '../services/api';
+
+export default function NotificationDropdown({ notifications, onMarkRead, onMarkAllRead, onClose }) {
+  const navigate = useNavigate();
+
+  async function handleClick(notif) {
+    onClose();
+    if (!notif.read_at) {
+      await api.markNotificationRead(notif.id).catch(() => {});
+      onMarkRead(notif.id);
+    }
+    if (notif.link) navigate(notif.link);
+  }
+
+  return (
+    <div style={styles.dropdown}>
+      <div style={styles.header}>
+        <span style={styles.headerTitle}>Notifications</span>
+        <button style={styles.markAll} onClick={onMarkAllRead}>Mark all as read</button>
+      </div>
+      {notifications.length === 0 ? (
+        <div style={styles.empty}>No notifications yet.</div>
+      ) : (
+        notifications.map((n) => (
+          <button
+            key={n.id}
+            style={{ ...styles.item, background: n.read_at ? 'transparent' : 'var(--color-accent-muted, rgba(99,102,241,0.08))' }}
+            onClick={() => handleClick(n)}
+          >
+            <div style={styles.itemTitle}>{n.title}</div>
+            {n.body && <div style={styles.itemBody}>{n.body}</div>}
+            <div style={styles.itemTime}>{new Date(n.created_at).toLocaleString()}</div>
+          </button>
+        ))
+      )}
+    </div>
+  );
+}
+
+const styles = {
+  dropdown: {
+    position: 'absolute',
+    top: '110%',
+    right: 0,
+    width: '320px',
+    background: 'var(--color-bg)',
+    border: '1px solid var(--color-border)',
+    borderRadius: '10px',
+    boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+    zIndex: 100,
+    overflow: 'hidden',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '0.75rem 1rem',
+    borderBottom: '1px solid var(--color-border)',
+  },
+  headerTitle: {
+    fontWeight: 700,
+    fontSize: '0.9rem',
+    color: 'var(--color-text)',
+  },
+  markAll: {
+    background: 'transparent',
+    border: 'none',
+    color: 'var(--color-accent)',
+    fontSize: '0.78rem',
+    cursor: 'pointer',
+    padding: 0,
+  },
+  item: {
+    display: 'block',
+    width: '100%',
+    textAlign: 'left',
+    padding: '0.75rem 1rem',
+    border: 'none',
+    borderBottom: '1px solid var(--color-border)',
+    cursor: 'pointer',
+    transition: 'filter 0.1s',
+  },
+  itemTitle: {
+    fontWeight: 600,
+    fontSize: '0.85rem',
+    color: 'var(--color-text)',
+    marginBottom: '2px',
+  },
+  itemBody: {
+    fontSize: '0.78rem',
+    color: 'var(--color-text-secondary)',
+    marginBottom: '4px',
+  },
+  itemTime: {
+    fontSize: '0.72rem',
+    color: 'var(--color-text-hint)',
+  },
+  empty: {
+    padding: '1.5rem 1rem',
+    textAlign: 'center',
+    color: 'var(--color-text-secondary)',
+    fontSize: '0.85rem',
+  },
+};

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -282,4 +282,8 @@ export const api = {
   createWebhook: (body) => request('POST', '/webhooks', body),
   listWebhookDeliveries: (options = {}) => request('GET', '/webhooks/deliveries', null, { query: options }),
   deleteWebhook: (id) => request('DELETE', `/webhooks/${id}`),
+
+  getNotifications: () => request('GET', '/notifications'),
+  markNotificationRead: (id) => request('PATCH', `/notifications/${id}/read`, {}),
+  markAllNotificationsRead: () => request('PATCH', '/notifications/read-all', {}),
 };


### PR DESCRIPTION
Closes #190 

  Implements the notification bell feature per issue spec:

  - DB: adds `notifications` table with read/unread indexes (migration
  20260601)
  - Backend: `createNotification()` helper + 3 REST endpoints (GET, PATCH
  /read-all, PATCH /:id/read)
  - Triggers: contribution received, goal reached (ledgerMonitor),
  withdrawal approved/rejected (withdrawals)
  - Frontend: Navbar bell icon with unread count badge, 30s polling,
  auto-cleanup on logout
  - Frontend: NotificationDropdown with highlight for unread,
  click-to-navigate, mark-all-read button