### PR TITLE
Feat/sentry integration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -68,3 +68,7 @@ KYC_REQUIRED_FOR_CAMPAIGNS=false
 # Uncomment and set for production to encrypt custodial private keys
 # KMS_KEY_ID=
 # KMS_REGION=
+
+# ── Error tracking (Sentry) ───────────────────────────────
+# Get DSN from sentry.io project settings. Leave empty to disable.
+SENTRY_DSN=

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,6 +1,14 @@
 require('dotenv').config();
 require('./config/env').validateEnv();
 
+const Sentry = require('@sentry/node');
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  environment: process.env.NODE_ENV || 'development',
+  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.2 : 1.0,
+  enabled: !!process.env.SENTRY_DSN,
+});
+
 const path = require('path');
 const express = require('express');
 const cors = require('cors');
@@ -29,6 +37,8 @@ app.use(
 );
 app.use(express.json({ limit: '50kb' }));
 app.use(cookieParser());
+app.use(Sentry.Handlers.requestHandler());
+app.use(Sentry.Handlers.tracingHandler());
 app.use(requestIdMiddleware);
 app.use(requestLogger);
 app.use(normalizeErrorResponse);
@@ -116,6 +126,7 @@ if (process.env.SERVE_FRONTEND === 'true') {
   });
 }
 
+app.use(Sentry.Handlers.errorHandler());
 app.use(errorHandler);
 
 const { startWebhookRetryPoller } = require('./services/webhookDispatcher');

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,6 +1,7 @@
 const jwt = require('jsonwebtoken');
 const crypto = require('crypto');
 const db = require('../config/database');
+const Sentry = require('@sentry/node');
 
 function apiKeyPepper() {
   return process.env.API_KEY_PEPPER || process.env.JWT_SECRET || 'dev-api-key-pepper';
@@ -123,6 +124,7 @@ function requireAuth(req, res, next) {
   authenticate(req)
     .then(() => {
       if (!assertApiKeyScopes(req, res)) return;
+      if (req.user?.userId) Sentry.setUser({ id: req.user.userId });
       next();
     })
     .catch((err) => {

--- a/backend/src/services/ledgerMonitor.js
+++ b/backend/src/services/ledgerMonitor.js
@@ -17,6 +17,7 @@ const {
   WEBHOOK_EVENTS,
 } = require("./webhookDispatcher");
 const { createNotification } = require("./notifications");
+const Sentry = require("@sentry/node");
 
 /** wallet_public_key -> stream metadata */
 const streamRegistry = new Map();
@@ -349,6 +350,12 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
     } catch {
       // ignore rollback errors after failed work
     }
+    Sentry.withScope((scope) => {
+      scope.setTag("stellar.network", process.env.STELLAR_NETWORK);
+      scope.setExtra("tx_hash", txHash);
+      scope.setExtra("campaign_id", campaignId);
+      Sentry.captureException(err);
+    });
     logger.error("Failed to index contribution", {
       campaign_id: campaignId,
       tx_hash: txHash,

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -24,6 +24,7 @@ const {
   isTestnet,
   configuredAssets,
 } = require('../config/stellar');
+const Sentry = require('@sentry/node');
 
 const PLATFORM_KEYPAIR = Keypair.fromSecret(process.env.PLATFORM_SECRET_KEY);
 
@@ -480,8 +481,17 @@ function isXdrExpired(xdr) {
 
 async function submitPreparedTransaction(xdr) {
   const tx = TransactionBuilder.fromXDR(xdr, networkPassphrase);
-  const result = await server.submitTransaction(tx);
-  return result.hash;
+  try {
+    const result = await server.submitTransaction(tx);
+    return result.hash;
+  } catch (err) {
+    Sentry.withScope((scope) => {
+      scope.setTag('stellar.network', process.env.STELLAR_NETWORK);
+      scope.setExtra('tx_hash', tx.hash().toString('hex'));
+      Sentry.captureException(err);
+    });
+    throw err;
+  }
 }
 
 async function submitSignedWithdrawal({ xdr }) {

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -9,3 +9,7 @@ VITE_STELLAR_NETWORK=testnet
 VITE_API_BASE_URL=
 # Set to false to skip KYC gate in the frontend (mirrors backend KYC_REQUIRED_FOR_CAMPAIGNS)
 # VITE_KYC_REQUIRED_FOR_CAMPAIGNS=false
+
+# ── Error tracking (Sentry) ───────────────────────────────
+# Get DSN from sentry.io project settings. Leave empty to disable.
+VITE_SENTRY_DSN=

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,16 +1,24 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 import App from './App';
-import ErrorBoundary from './components/ErrorBoundary';
 import './index.css';
+
+Sentry.init({
+  dsn: import.meta.env.VITE_SENTRY_DSN,
+  environment: import.meta.env.MODE,
+  tracesSampleRate: 0.1,
+  enabled: !!import.meta.env.VITE_SENTRY_DSN,
+  integrations: [Sentry.browserTracingIntegration()],
+});
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
-      <ErrorBoundary>
+      <Sentry.ErrorBoundary fallback={<p>Something went wrong.</p>}>
         <App />
-      </ErrorBoundary>
+      </Sentry.ErrorBoundary>
     </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
 Closes #188

  - Backend: Sentry.init() before all imports, requestHandler +
  tracingHandler before routes, errorHandler before generic handler
  - auth.js: Sentry.setUser({ id }) on every authenticated request (no
  email)
  - stellarService.js + ledgerMonitor.js: captureException with
  stellar.network tag and tx_hash extra context
  - Frontend: Sentry.init() with browserTracingIntegration, ErrorBoundary
  wrapping <App />
  - Disabled automatically when SENTRY_DSN / VITE_SENTRY_DSN are not set
  - Both DSN vars documented in backend/.env.example and
  frontend/.env.example