### PR TITLE
feat: allow anonymous contributions via Freighter

### DIFF
--- a/backend/src/routes/contributions.js
+++ b/backend/src/routes/contributions.js
@@ -213,8 +213,8 @@ router.get('/finalization/:txHash', requireAuth, asyncHandler(async (req, res) =
   });
 }));
 
-// Quote conversion before a path payment contribution
-router.get('/quote', requireAuth, contributionQuoteValidation, validateRequest, asyncHandler(async (req, res) => {
+// Quote conversion before a path payment contribution (unauthenticated allowed for guest flow)
+router.get('/quote', contributionQuoteValidation, validateRequest, asyncHandler(async (req, res) => {
   /**
    * @openapi
    * /api/contributions/quote:
@@ -288,6 +288,106 @@ router.get('/quote', requireAuth, contributionQuoteValidation, validateRequest, 
     path: bestPath.path,
     path_count: paths.length,
   });
+}));
+
+// Build unsigned XDR for guest (Freighter) contributors — no auth required
+router.post('/build-xdr', contributionPostLimiter, contributionValidation, validateRequest, asyncHandler(async (req, res) => {
+  const { campaign_id, amount, send_asset, sender_public_key } = req.body;
+
+  if (!sender_public_key) {
+    return res.status(422).json({ error: 'sender_public_key is required' });
+  }
+  if (!validateFreighterPublicKey(sender_public_key)) {
+    return res.status(422).json({ error: 'sender_public_key must be a valid Stellar public key' });
+  }
+
+  const campaign = await loadActiveCampaign(campaign_id);
+  if (!campaign) return res.status(404).json({ error: 'Campaign not found' });
+
+  if (campaign.min_contribution && parseFloat(amount) < parseFloat(campaign.min_contribution)) {
+    return res.status(400).json({ error: `Contribution amount is below the minimum limit of ${campaign.min_contribution} ${campaign.asset_type}` });
+  }
+
+  try {
+    const intent = await buildContributionIntent({
+      campaign,
+      amount,
+      sendAsset: send_asset,
+      contributorPublicKey: sender_public_key,
+    });
+
+    const unsignedXdr =
+      intent.kind === 'payment'
+        ? await buildUnsignedContributionPayment({
+            senderPublicKey: sender_public_key,
+            destinationPublicKey: campaign.wallet_public_key,
+            asset: send_asset,
+            amount,
+            memo: buildContributionMemo(campaign_id),
+          })
+        : await buildUnsignedContributionPathPayment({
+            senderPublicKey: sender_public_key,
+            destinationPublicKey: campaign.wallet_public_key,
+            sendAsset: send_asset,
+            sendMax: intent.sendMax,
+            destAmount: amount,
+            destAssetCode: campaign.asset_type,
+            memo: buildContributionMemo(campaign_id),
+          });
+
+    res.json({
+      unsigned_xdr: unsignedXdr,
+      conversion_quote: intent.conversionQuote,
+      network_passphrase: networkPassphrase,
+      network_name: isTestnet ? 'TESTNET' : 'PUBLIC',
+    });
+  } catch (err) {
+    if (err.statusCode === 422) return res.status(422).json({ error: err.message });
+    logger.error('Guest build-xdr failed', { campaign_id, error: err.message });
+    return res.status(503).json({ error: 'Could not build the transaction. Please try again.' });
+  }
+}));
+
+// Submit pre-signed XDR from Freighter — no auth required
+router.post('/guest', contributionPostLimiter, asyncHandler(async (req, res) => {
+  const { campaign_id, sender_public_key, signed_xdr, unsigned_xdr } = req.body;
+
+  if (!campaign_id || !sender_public_key || !signed_xdr || !unsigned_xdr) {
+    return res.status(400).json({ error: 'campaign_id, sender_public_key, signed_xdr, and unsigned_xdr are required' });
+  }
+
+  if (!validateFreighterPublicKey(sender_public_key)) {
+    return res.status(422).json({ error: 'sender_public_key must be a valid Stellar public key' });
+  }
+
+  const campaign = await loadActiveCampaign(campaign_id);
+  if (!campaign) return res.status(404).json({ error: 'Campaign not found' });
+
+  try {
+    validateSubmittedContributionXdr({ signedXdr: signed_xdr, unsignedXdr: unsigned_xdr, senderPublicKey: sender_public_key });
+  } catch (err) {
+    return res.status(422).json({ error: err.message });
+  }
+
+  let txHash;
+  try {
+    txHash = await submitPreparedTransaction(signed_xdr);
+  } catch (err) {
+    logger.error('Guest Freighter submission failed', { campaign_id, error: err.message });
+    sendAlert('Guest Freighter submission failed', { campaign_id, error: err.message });
+    return res.status(502).json({ error: 'Stellar network rejected the transaction', detail: err.message || String(err) });
+  }
+
+  const stellarTransactionId = await insertContributionSubmitted(null, {
+    txHash,
+    campaignId: campaign_id,
+    userId: null,
+    unsignedXdr: unsigned_xdr,
+    signedXdr: signed_xdr,
+    metadata: { flow: 'guest_freighter', sender_public_key },
+  });
+
+  res.status(202).json({ tx_hash: txHash, stellar_transaction_id: stellarTransactionId, message: 'Transaction submitted' });
 }));
 
 router.post('/prepare', requireAuth, contributionValidation, validateRequest, asyncHandler(async (req, res) => {

--- a/frontend/src/components/ContributeModal.jsx
+++ b/frontend/src/components/ContributeModal.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { api } from '../services/api';
 import { stellarExpertTxUrl } from '../config/stellar';
+import { isConnected, getPublicKey, signTransaction } from '@stellar/freighter-api';
 
 const SEND_OPTIONS = [
   { value: 'XLM', label: 'XLM', hint: 'Native Stellar' },
@@ -37,11 +38,11 @@ function friendlyFreighterError(err, fallback) {
   return fallback;
 }
 
-export default function ContributeModal({ campaign, onClose, onSuccess }) {
+export default function ContributeModal({ campaign, onClose, onSuccess, guestFreighterMode = false }) {
   const { token } = useAuth();
   const [amount, setAmount] = useState('');
   const [sendAsset, setSendAsset] = useState(campaign.asset_type);
-  const [paymentMethod, setPaymentMethod] = useState('custodial');
+  const [paymentMethod, setPaymentMethod] = useState(guestFreighterMode ? 'freighter' : 'custodial');
   const [anchorInfo, setAnchorInfo] = useState({ anchors: [] });
   const [selectedAnchorId, setSelectedAnchorId] = useState('');
   const [anchorSession, setAnchorSession] = useState(null);
@@ -68,6 +69,26 @@ export default function ContributeModal({ campaign, onClose, onSuccess }) {
 
   const isPathPayment = sendAsset !== campaign.asset_type;
   const destAmount = amount.trim();
+  const effectiveSendAsset = paymentMethod === 'anchor' ? selectedAnchorId
+    ? anchorInfo.anchors.find((a) => a.id === selectedAnchorId)?.asset?.code
+    : undefined
+    : sendAsset;
+  const selectedAnchor = anchorInfo.anchors.find((a) => a.id === selectedAnchorId) || null;
+
+  // Fetch anchor info and existing contributions on mount
+  useEffect(() => {
+    api.getAnchorInfo().then(setAnchorInfo).catch(() => {});
+    api.getContributions(campaign.id, { limit: 100 }).then((d) => setExistingContributions(d.contributions || [])).catch(() => {});
+  }, [campaign.id]);
+
+  // Check Freighter availability
+  useEffect(() => {
+    isConnected().then((res) => {
+      const connected = res?.isConnected ?? res;
+      setFreighterAvailable(!!connected);
+      setFreighterChecked(true);
+    }).catch(() => setFreighterChecked(true));
+  }, []);
 
   const fetchQuote = useCallback(async () => {
     if (!isPathPayment || !effectiveSendAsset || !destAmount || Number(destAmount) <= 0) {
@@ -142,6 +163,59 @@ export default function ContributeModal({ campaign, onClose, onSuccess }) {
     modal.addEventListener('keydown', trapTab);
     return () => modal.removeEventListener('keydown', trapTab);
   }, [phase]);
+
+  async function submitWithCustodial() {
+    return api.contribute({
+      campaign_id: campaign.id,
+      amount: destAmount,
+      send_asset: effectiveSendAsset,
+      display_name: displayName || undefined,
+    });
+  }
+
+  async function submitWithFreighter() {
+    const connected = await isConnected().then((r) => r?.isConnected ?? r).catch(() => false);
+    if (!connected) throw new Error('Freighter is not installed or not connected.');
+
+    const pkResult = await getPublicKey();
+    const senderPublicKey = pkResult?.publicKey ?? pkResult;
+    if (!senderPublicKey) throw new Error('Could not get public key from Freighter.');
+
+    setLoadingLabel('Building transaction…');
+    const { unsigned_xdr, network_name } = await api.buildContributionXdr({
+      campaign_id: campaign.id,
+      amount: destAmount,
+      send_asset: effectiveSendAsset,
+      sender_public_key: senderPublicKey,
+    });
+
+    setLoadingLabel('Waiting for Freighter signature…');
+    const signResult = await signTransaction(unsigned_xdr, { network: network_name });
+    const signedXdr = signResult?.signedTransaction ?? signResult;
+    if (!signedXdr) throw new Error('Freighter did not return a signed transaction.');
+
+    setLoadingLabel('Submitting…');
+    return api.guestContribute({
+      campaign_id: campaign.id,
+      sender_public_key: senderPublicKey,
+      signed_xdr: signedXdr,
+      unsigned_xdr,
+    });
+  }
+
+  async function submitWithAnchor() {
+    if (!selectedAnchorId) throw new Error('Please select a deposit partner.');
+    const session = await api.startAnchorDeposit({
+      campaign_id: campaign.id,
+      amount: destAmount,
+      anchor_id: selectedAnchorId,
+    });
+    setAnchorSession(session);
+    setPhase('anchor');
+    if (session.interactive_url) {
+      anchorPopupRef.current = window.open(session.interactive_url, '_blank', 'noopener,noreferrer,width=600,height=700');
+    }
+  }
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -257,6 +331,7 @@ export default function ContributeModal({ campaign, onClose, onSuccess }) {
                   Payment method
                 </legend>
                 <div className="asset-picker" role="radiogroup" aria-label="Contribution payment method">
+                  {!guestFreighterMode && (
                   <label
                     className={`asset-picker__option${paymentMethod === 'custodial' ? ' asset-picker__option--selected' : ''}`}
                   >
@@ -270,7 +345,8 @@ export default function ContributeModal({ campaign, onClose, onSuccess }) {
                     <div className="asset-picker__code">CrowdPay wallet</div>
                     <div className="asset-picker__hint">Uses your existing custodial balance</div>
                   </label>
-                  {freighterAvailable && (
+                  )}
+                  {(freighterAvailable || guestFreighterMode) && (
                     <label
                       className={`asset-picker__option${paymentMethod === 'freighter' ? ' asset-picker__option--selected' : ''}`}
                     >
@@ -301,9 +377,11 @@ export default function ContributeModal({ campaign, onClose, onSuccess }) {
                     </label>
                   )}
                 </div>
-                {freighterChecked && !freighterAvailable && (
+                {freighterChecked && !freighterAvailable && (paymentMethod === 'freighter' || guestFreighterMode) && (
                   <span id="contrib-wallet-help" style={styles.help}>
-                    Freighter extension not detected. Install it to contribute from your own Stellar wallet.
+                    Freighter extension not detected.{' '}
+                    <a href="https://www.freighter.app/" target="_blank" rel="noopener noreferrer">Install Freighter</a>{' '}
+                    to contribute from your own Stellar wallet.
                   </span>
                 )}
               </fieldset>

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Link, useParams, useLocation } from "react-router-dom";
 import { api } from "../services/api";
 import { useAuth } from "../context/AuthContext";
@@ -13,6 +13,7 @@ import VerificationBadge from "../components/VerificationBadge";
 import CampaignStatusBadge from "../components/CampaignStatusBadge";
 import { stellarExpertTxUrl } from "../config/stellar";
 import CampaignQRCode from "../components/CampaignQRCode";
+import { isConnected, getPublicKey } from "@stellar/freighter-api";
 
 function escapeHtml(text) {
   return text
@@ -138,6 +139,8 @@ export default function Campaign() {
   const [showDisputeModal, setShowDisputeModal] = useState(false);
   const [disputeSubmitted, setDisputeSubmitted] = useState(false);
   const [contributed, setContributed] = useState(false);
+  const contributeBtnRef = useRef(null);
+  const [freighterGuestMode, setFreighterGuestMode] = useState(false);
   const [showCreatedBanner, setShowCreatedBanner] = useState(
     !!location.state?.created,
   );
@@ -504,6 +507,20 @@ export default function Campaign() {
   ).toFixed(1);
   const canPostUpdate = user?.id && campaign.creator_id === user.id;
 
+  async function handleFreighterContribute() {
+    try {
+      const connected = await isConnected().then((r) => r?.isConnected ?? r).catch(() => false);
+      if (!connected) {
+        window.open('https://www.freighter.app/', '_blank', 'noopener,noreferrer');
+        return;
+      }
+      setFreighterGuestMode(true);
+      setShowModal(true);
+    } catch {
+      window.open('https://www.freighter.app/', '_blank', 'noopener,noreferrer');
+    }
+  }
+
   async function submitUpdate(e) {
     e.preventDefault();
     setUpdatesError("");
@@ -670,10 +687,23 @@ export default function Campaign() {
             Contribute
           </button>
         ) : (
-          <p style={{ color: "var(--color-text-secondary)", fontSize: "0.9rem", lineHeight: 1.5 }}>
-            Contributions are closed while this campaign is{" "}
-            <strong>{campaign.status}</strong>.
-          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.65rem' }}>
+            <Link
+              to="/login"
+              className="btn-primary"
+              style={{ ...styles.cta, textAlign: 'center', textDecoration: 'none', display: 'block' }}
+            >
+              Log in to contribute
+            </Link>
+            <button
+              type="button"
+              className="btn-secondary"
+              style={styles.cta}
+              onClick={handleFreighterContribute}
+            >
+              Contribute with Freighter
+            </button>
+          </div>
         )}
       </div>
 
@@ -1349,8 +1379,10 @@ export default function Campaign() {
       {showModal && (
         <ContributeModal
           campaign={campaign}
+          guestFreighterMode={freighterGuestMode}
           onClose={() => {
             setShowModal(false);
+            setFreighterGuestMode(false);
             contributeBtnRef.current?.focus();
           }}
           onSuccess={() => setContributed((v) => !v)}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -233,6 +233,8 @@ export const api = {
   contribute: (body) => request('POST', '/contributions', body),
   prepareContribution: (body) => request('POST', '/contributions/prepare', body),
   submitSignedContribution: (body) => request('POST', '/contributions/submit-signed', body),
+  buildContributionXdr: (body) => request('POST', '/contributions/build-xdr', body),
+  guestContribute: (body) => request('POST', '/contributions/guest', body),
   quoteContribution: ({ send_asset, dest_asset, dest_amount }) =>
     request('GET', '/contributions/quote', null, {
       query: { send_asset, dest_asset, dest_amount },


### PR DESCRIPTION
## Summary

Implements #178 — contributors can now fund campaigns directly from Freighter without creating a CrowdPay account.

## Changes

**Backend**
- `POST /api/contributions/build-xdr` (unauthenticated) — builds and returns unsigned XDR for a guest contributor given their public key
- `POST /api/contributions/guest` (unauthenticated) — validates and submits a pre-signed XDR from Freighter; records the transaction with `userId: null`
- `GET /api/contributions/quote` — removed `requireAuth` so the quote is accessible in the guest flow

**Frontend**
- `Campaign.jsx`: unauthenticated users now see "Log in to contribute" + "Contribute with Freighter" instead of the incorrect "contributions are closed" message
- `ContributeModal.jsx`: added `submitWithFreighter` (calls `build-xdr` then Freighter sign then `guest`), `submitWithCustodial`, `submitWithAnchor`; fixed missing `effectiveSendAsset`, `selectedAnchor`, freighter availability check, and anchor info fetch; accepts `guestFreighterMode` prop to pre-select Freighter and hide custodial option
- `api.js`: added `buildContributionXdr` and `guestContribute`

## Acceptance criteria

- [x] Users without an account can contribute using Freighter from the campaign page
- [x] The backend never handles or stores the contributor's private key in the guest flow
- [x] The contribution is indexed by the ledger monitor and reflected in the campaign's `raised_amount`
- [x] The guest flow handles: Freighter not installed (shows install link), user rejected signing, wrong network
- [x] Custodial (logged-in) flow is completely unaffected
- [x] Guest contributions appear in the contributions list (sender public key is the Freighter address)

Closes #178
