### PR TITLE
feat: implement per-campaign contribution limits (min, max, per-user …

### DIFF
--- a/backend/db/migrations/20260428_contribution_limits.sql
+++ b/backend/db/migrations/20260428_contribution_limits.sql
@@ -1,3 +1,4 @@
 -- Issue 64: Minimum and maximum contribution limits per campaign
 ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS min_contribution NUMERIC(20, 7);
 ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS max_contribution NUMERIC(20, 7);
+ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS max_per_user NUMERIC(20, 7);

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -38,6 +38,9 @@ CREATE TABLE campaigns (
                         CHECK (status IN ('active', 'funded', 'in_progress', 'completed', 'closed', 'withdrawn', 'failed')),
   deadline            DATE,
   show_backer_amounts BOOLEAN DEFAULT TRUE,
+  min_contribution    NUMERIC(20, 7),
+  max_contribution    NUMERIC(20, 7),
+  max_per_user        NUMERIC(20, 7),
   created_at          TIMESTAMPTZ DEFAULT NOW()
 );
 

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -136,6 +136,16 @@ const createCampaignValidation = [
       }
       return true;
     }),
+  body('max_per_user')
+    .optional({ nullable: true, checkFalsy: true })
+    .isFloat({ gt: 0 })
+    .withMessage('Per-contributor cap must be greater than zero')
+    .custom((value, { req }) => {
+      if (value && req.body.min_contribution && parseFloat(value) <= parseFloat(req.body.min_contribution)) {
+        throw new Error('Per-contributor cap must be greater than minimum contribution');
+      }
+      return true;
+    }),
   body('milestones')
     .optional({ nullable: true })
     .custom((value) => {

--- a/backend/src/middleware/validation.test.js
+++ b/backend/src/middleware/validation.test.js
@@ -71,3 +71,38 @@ test('register validation passes for valid payload', async () => {
   });
   assert.equal(result.ok, true);
 });
+
+test('createCampaign validation rejects negative max_per_user', async () => {
+  const result = await runValidation(createCampaignValidation, {
+    title: 'Valid Title',
+    target_amount: '10',
+    asset_type: 'USDC',
+    max_per_user: '-5',
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => e.path === 'max_per_user'));
+});
+
+test('createCampaign validation rejects max_per_user less than or equal to min_contribution', async () => {
+  const result = await runValidation(createCampaignValidation, {
+    title: 'Valid Title',
+    target_amount: '100',
+    asset_type: 'USDC',
+    min_contribution: '10',
+    max_per_user: '10',
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => e.path === 'max_per_user' && e.msg === 'Per-contributor cap must be greater than minimum contribution'));
+});
+
+test('createCampaign validation passes with valid limit parameters', async () => {
+  const result = await runValidation(createCampaignValidation, {
+    title: 'Valid Title',
+    target_amount: '100',
+    asset_type: 'USDC',
+    min_contribution: '10',
+    max_contribution: '50',
+    max_per_user: '80',
+  });
+  assert.equal(result.ok, true);
+});

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -685,7 +685,7 @@ router.post('/', requireAuth, requireRole('creator', 'admin'), createCampaignVal
    *       403:
    *         description: Forbidden
    */
-  const { title, description, target_amount, asset_type, deadline, milestones, min_contribution, max_contribution } = req.body;
+  const { title, description, target_amount, asset_type, deadline, milestones, min_contribution, max_contribution, max_per_user } = req.body;
 
   if (deadline) {
     const [year, month, day] = String(deadline).split('-').map(Number);
@@ -743,11 +743,11 @@ router.post('/', requireAuth, requireRole('creator', 'admin'), createCampaignVal
     const { rows } = await client.query(
       `INSERT INTO campaigns
          (title, description, target_amount, asset_type, wallet_public_key, creator_id, deadline, 
-          min_contribution, max_contribution, escrow_contract_id, milestones_contract_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+          min_contribution, max_contribution, max_per_user, escrow_contract_id, milestones_contract_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
        RETURNING *`,
       [title, description, target_amount, asset_type, wallet.publicKey, req.user.userId, deadline, 
-       min_contribution || null, max_contribution || null, escrowContractId, milestonesContractId]
+       min_contribution || null, max_contribution || null, max_per_user || null, escrowContractId, milestonesContractId]
     );
     campaign = rows[0];
 

--- a/backend/src/routes/contributions.js
+++ b/backend/src/routes/contributions.js
@@ -314,18 +314,33 @@ router.post('/prepare', requireAuth, contributionValidation, validateRequest, as
   const campaign = await loadActiveCampaign(campaign_id);
   if (!campaign) return res.status(404).json({ error: 'Campaign not found' });
 
-  if (campaign.min_contribution && parseFloat(amount) < parseFloat(campaign.min_contribution)) {
-    return res.status(400).json({ error: `Contribution amount is below the minimum limit of ${campaign.min_contribution} ${campaign.asset_type}` });
+  // 1. Minimum contribution check
+  if (campaign.min_contribution && Number(amount) < Number(campaign.min_contribution)) {
+    return res.status(400).json({
+      error: `Minimum contribution is ${campaign.min_contribution} ${campaign.asset_type}`,
+    });
   }
 
-  if (campaign.max_contribution) {
-    const { rows: sumRows } = await db.query(
-      'SELECT COALESCE(SUM(amount), 0) as total FROM contributions WHERE campaign_id = $1 AND sender_public_key = $2',
+  // 2. Maximum contribution check
+  if (campaign.max_contribution && Number(amount) > Number(campaign.max_contribution)) {
+    return res.status(400).json({
+      error: `Maximum contribution is ${campaign.max_contribution} ${campaign.asset_type}`,
+    });
+  }
+
+  // 3. Per-user cap check
+  if (campaign.max_per_user) {
+    const { rows: userTotal } = await db.query(
+      `SELECT COALESCE(SUM(amount), 0) AS total
+       FROM contributions
+       WHERE campaign_id = $1 AND sender_public_key = $2`,
       [campaign_id, sender_public_key]
     );
-    const totalExisting = parseFloat(sumRows[0].total);
-    if (totalExisting + parseFloat(amount) > parseFloat(campaign.max_contribution)) {
-      return res.status(400).json({ error: `Contribution violates the maximum limit of ${campaign.max_contribution} ${campaign.asset_type} per backer` });
+    const alreadyContributed = Number(userTotal[0].total);
+    if (alreadyContributed + Number(amount) > Number(campaign.max_per_user)) {
+      return res.status(400).json({
+        error: `You have already contributed ${alreadyContributed} ${campaign.asset_type}. The per-contributor limit is ${campaign.max_per_user}.`,
+      });
     }
   }
 
@@ -500,18 +515,33 @@ router.post('/', contributionPostLimiter, requireAuth, contributionValidation, v
   );
   const contributorPublicKey = users[0].wallet_public_key;
 
-  if (campaign.min_contribution && parseFloat(amount) < parseFloat(campaign.min_contribution)) {
-    return res.status(400).json({ error: `Contribution amount is below the minimum limit of ${campaign.min_contribution} ${campaign.asset_type}` });
+  // 1. Minimum contribution check
+  if (campaign.min_contribution && Number(amount) < Number(campaign.min_contribution)) {
+    return res.status(400).json({
+      error: `Minimum contribution is ${campaign.min_contribution} ${campaign.asset_type}`,
+    });
   }
 
-  if (campaign.max_contribution) {
-    const { rows: sumRows } = await db.query(
-      'SELECT COALESCE(SUM(amount), 0) as total FROM contributions WHERE campaign_id = $1 AND sender_public_key = $2',
+  // 2. Maximum contribution check
+  if (campaign.max_contribution && Number(amount) > Number(campaign.max_contribution)) {
+    return res.status(400).json({
+      error: `Maximum contribution is ${campaign.max_contribution} ${campaign.asset_type}`,
+    });
+  }
+
+  // 3. Per-user cap check
+  if (campaign.max_per_user) {
+    const { rows: userTotal } = await db.query(
+      `SELECT COALESCE(SUM(amount), 0) AS total
+       FROM contributions
+       WHERE campaign_id = $1 AND sender_public_key = $2`,
       [campaign_id, contributorPublicKey]
     );
-    const totalExisting = parseFloat(sumRows[0].total);
-    if (totalExisting + parseFloat(amount) > parseFloat(campaign.max_contribution)) {
-      return res.status(400).json({ error: `Contribution violates the maximum limit of ${campaign.max_contribution} ${campaign.asset_type} per backer` });
+    const alreadyContributed = Number(userTotal[0].total);
+    if (alreadyContributed + Number(amount) > Number(campaign.max_per_user)) {
+      return res.status(400).json({
+        error: `You have already contributed ${alreadyContributed} ${campaign.asset_type}. The per-contributor limit is ${campaign.max_per_user}.`,
+      });
     }
   }
 

--- a/backend/src/routes/contributions.test.js
+++ b/backend/src/routes/contributions.test.js
@@ -771,3 +771,98 @@ test('POST /api/contributions includes platform_fee_amount in response and metad
   assert.equal(response.body.platform_fee_amount, 0.15);
   assert.equal(capturedMetadata.platform_fee_amount, 0.15);
 });
+
+test('POST /api/contributions validates min_contribution limit', async () => {
+  const app = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns')) {
+        return {
+          rows: [{
+            id: '11111111-1111-1111-1111-111111111111',
+            status: 'active',
+            asset_type: 'USDC',
+            wallet_public_key: VALID_G,
+            min_contribution: '15.0000000',
+          }],
+        };
+      }
+      if (text.includes('FROM users')) {
+        return { rows: [{ wallet_secret_encrypted: 'SSECRET', wallet_public_key: 'GSENDER' }] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/contributions')
+    .set('Authorization', 'Bearer token')
+    .send({ campaign_id: '11111111-1111-1111-1111-111111111111', amount: '10.0000000', send_asset: 'USDC' });
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.error, 'Minimum contribution is 15.0000000 USDC');
+});
+
+test('POST /api/contributions validates max_contribution limit', async () => {
+  const app = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns')) {
+        return {
+          rows: [{
+            id: '11111111-1111-1111-1111-111111111111',
+            status: 'active',
+            asset_type: 'USDC',
+            wallet_public_key: VALID_G,
+            max_contribution: '50.0000000',
+          }],
+        };
+      }
+      if (text.includes('FROM users')) {
+        return { rows: [{ wallet_secret_encrypted: 'SSECRET', wallet_public_key: 'GSENDER' }] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/contributions')
+    .set('Authorization', 'Bearer token')
+    .send({ campaign_id: '11111111-1111-1111-1111-111111111111', amount: '60.0000000', send_asset: 'USDC' });
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.error, 'Maximum contribution is 50.0000000 USDC');
+});
+
+test('POST /api/contributions validates cumulative max_per_user cap', async () => {
+  const app = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns')) {
+        return {
+          rows: [{
+            id: '11111111-1111-1111-1111-111111111111',
+            status: 'active',
+            asset_type: 'USDC',
+            wallet_public_key: VALID_G,
+            max_per_user: '100.0000000',
+          }],
+        };
+      }
+      if (text.includes('FROM users')) {
+        return { rows: [{ wallet_secret_encrypted: 'SSECRET', wallet_public_key: 'GSENDER' }] };
+      }
+      if (text.includes('COALESCE(SUM(amount)')) {
+        return {
+          rows: [{ total: '80.0000000' }],
+        };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/contributions')
+    .set('Authorization', 'Bearer token')
+    .send({ campaign_id: '11111111-1111-1111-1111-111111111111', amount: '30.0000000', send_asset: 'USDC' });
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.error, 'You have already contributed 80 USDC. The per-contributor limit is 100.0000000.');
+});

--- a/frontend/src/components/ContributeModal.jsx
+++ b/frontend/src/components/ContributeModal.jsx
@@ -1,4 +1,10 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
+import {
+  getNetwork,
+  isConnected as isFreighterConnected,
+  requestAccess,
+  signTransaction,
+} from '@stellar/freighter-api';
 import { useAuth } from '../context/AuthContext';
 import { api } from '../services/api';
 import { stellarExpertTxUrl } from '../config/stellar';
@@ -38,7 +44,7 @@ function friendlyFreighterError(err, fallback) {
 }
 
 export default function ContributeModal({ campaign, onClose, onSuccess }) {
-  const { token } = useAuth();
+  const { token, user } = useAuth();
   const [amount, setAmount] = useState('');
   const [sendAsset, setSendAsset] = useState(campaign.asset_type);
   const [paymentMethod, setPaymentMethod] = useState('custodial');
@@ -66,7 +72,18 @@ export default function ContributeModal({ campaign, onClose, onSuccess }) {
 
   const modalRef = useRef(null);
 
-  const isPathPayment = sendAsset !== campaign.asset_type;
+  useEffect(() => {
+    if (campaign?.id) {
+      api.getContributions(campaign.id)
+        .then((data) => setExistingContributions(data?.contributions || []))
+        .catch(() => setExistingContributions([]));
+    }
+  }, [campaign?.id]);
+
+  const selectedAnchor = anchorInfo.anchors.find((anchor) => anchor.id === selectedAnchorId) || null;
+  const effectiveSendAsset =
+    paymentMethod === 'anchor' ? selectedAnchor?.asset?.code || campaign.asset_type : sendAsset;
+  const isPathPayment = effectiveSendAsset !== campaign.asset_type;
   const destAmount = amount.trim();
 
   const fetchQuote = useCallback(async () => {
@@ -116,6 +133,100 @@ export default function ContributeModal({ campaign, onClose, onSuccess }) {
   }, [onClose]);
 
   useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const connection = await isFreighterConnected();
+        if (active) {
+          setFreighterAvailable(Boolean(connection?.isConnected));
+        }
+      } catch {
+        if (active) {
+          setFreighterAvailable(false);
+        }
+      } finally {
+        if (active) {
+          setFreighterChecked(true);
+        }
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    api
+      .getAnchorInfo()
+      .then((info) => {
+        if (!active) return;
+        setAnchorInfo(info || { anchors: [] });
+        const firstAvailable = (info?.anchors || []).find((anchor) => anchor.available);
+        if (firstAvailable) {
+          setSelectedAnchorId(firstAvailable.id);
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setAnchorInfo({ anchors: [] });
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (phase !== 'anchor' || !anchorSession?.id) return undefined;
+    let stopped = false;
+
+    const closePopup = () => {
+      if (anchorPopupRef.current && !anchorPopupRef.current.closed) {
+        anchorPopupRef.current.close();
+      }
+    };
+
+    const poll = async () => {
+      try {
+        const next = await api.getAnchorDepositStatus(anchorSession.id, token);
+        if (stopped) return;
+        setAnchorSession(next);
+        if (next.contribution_tx_hash) {
+          setResult({
+            tx_hash: next.contribution_tx_hash,
+            conversion_quote: next.conversion_quote,
+            anchor_transaction_id: next.anchor_transaction_id,
+            anchor_id: next.anchor_id,
+          });
+          setPhase('success');
+          closePopup();
+          onSuccess();
+          return;
+        }
+        if (next.status === 'failed') {
+          setError(next.last_error || 'The anchor deposit could not be completed.');
+          setPhase('form');
+          closePopup();
+        }
+      } catch (err) {
+        if (!stopped) {
+          setError(err.message || 'Could not refresh the anchor deposit status.');
+        }
+      }
+    };
+
+    poll();
+    const intervalId = window.setInterval(poll, 4000);
+    return () => {
+      stopped = true;
+      window.clearInterval(intervalId);
+    };
+  }, [anchorSession?.id, onSuccess, phase, token]);
+
+  useEffect(() => {
     const modal = modalRef.current;
     if (!modal) return;
     const focusable = modal.querySelectorAll(
@@ -143,6 +254,97 @@ export default function ContributeModal({ campaign, onClose, onSuccess }) {
     return () => modal.removeEventListener('keydown', trapTab);
   }, [phase]);
 
+  async function submitWithCustodial() {
+    setLoadingLabel('Submitting with CrowdPay wallet…');
+    return api.contribute(
+      { campaign_id: campaign.id, amount: destAmount, send_asset: sendAsset, display_name: displayName.trim() || undefined },
+      token
+    );
+  }
+
+  async function submitWithFreighter() {
+    setLoadingLabel('Connecting to Freighter…');
+    const access = await requestAccess();
+    if (access?.error) {
+      throw new Error(friendlyFreighterError(access.error, 'Could not connect to Freighter.'));
+    }
+    const signerAddress = access?.address;
+    if (!signerAddress) {
+      throw new Error('Freighter did not return a Stellar account.');
+    }
+
+    setLoadingLabel('Preparing transaction…');
+    const prepared = await api.prepareContribution(
+      {
+        campaign_id: campaign.id,
+        amount: destAmount,
+        send_asset: sendAsset,
+        sender_public_key: signerAddress,
+        display_name: displayName.trim() || undefined,
+      },
+      token
+    );
+
+    setLoadingLabel('Checking Freighter network…');
+    const network = await getNetwork();
+    if (network?.error) {
+      throw new Error(friendlyFreighterError(network.error, 'Could not read Freighter network.'));
+    }
+    if (network?.networkPassphrase !== prepared.network_passphrase) {
+      const current = network?.network || 'another network';
+      throw new Error(`Freighter is connected to ${current}. Switch it to ${prepared.network_name} and try again.`);
+    }
+
+    setLoadingLabel('Waiting for signature…');
+    const signed = await signTransaction(prepared.unsigned_xdr, {
+      networkPassphrase: prepared.network_passphrase,
+      address: signerAddress,
+    });
+    if (signed?.error) {
+      throw new Error(friendlyFreighterError(signed.error, 'Freighter could not sign this transaction.'));
+    }
+    if (!signed?.signedTxXdr) {
+      throw new Error('Freighter did not return a signed transaction.');
+    }
+
+    setLoadingLabel('Submitting signed transaction…');
+    return api.submitSignedContribution(
+      {
+        prepare_token: prepared.prepare_token,
+        signed_xdr: signed.signedTxXdr,
+      },
+      token
+    );
+  }
+
+  async function submitWithAnchor() {
+    if (!selectedAnchorId) {
+      throw new Error('No deposit anchor is available right now.');
+    }
+
+    const popup = window.open('', 'crowdpay-anchor-deposit', 'popup,width=520,height=780');
+    anchorPopupRef.current = popup;
+
+    setLoadingLabel('Preparing deposit flow…');
+    const session = await api.startAnchorDeposit(
+      {
+        campaign_id: campaign.id,
+        amount: destAmount,
+        anchor_id: selectedAnchorId,
+      },
+      token
+    );
+
+    if (popup && !popup.closed) {
+      popup.location.href = session.interactive_url;
+    } else {
+      window.open(session.interactive_url, '_blank', 'noopener,noreferrer');
+    }
+
+    setAnchorSession(session);
+    setPhase('anchor');
+  }
+
   async function handleSubmit(e) {
     e.preventDefault();
     if (!destAmount || Number(destAmount) <= 0) {
@@ -152,19 +354,25 @@ export default function ContributeModal({ campaign, onClose, onSuccess }) {
 
     const amountNum = Number(destAmount);
     if (campaign.min_contribution && amountNum < Number(campaign.min_contribution)) {
-      setError(`Contribution amount is below the minimum limit of ${campaign.min_contribution} ${campaign.asset_type}.`);
+      setError(`Minimum contribution is ${campaign.min_contribution} ${campaign.asset_type}`);
       return;
     }
-    if (campaign.max_contribution) {
-      const existingSum = existingContributions
-        .filter((c) => c.sender_public_key === user?.wallet_public_key)
-        .reduce((sum, c) => sum + Number(c.amount), 0);
-
-      if (existingSum + amountNum > Number(campaign.max_contribution)) {
-        setError(`Contribution violates the maximum limit of ${campaign.max_contribution} ${campaign.asset_type} per backer.`);
+    if (campaign.max_contribution && amountNum > Number(campaign.max_contribution)) {
+      setError(`Maximum contribution is ${campaign.max_contribution} ${campaign.asset_type}`);
+      return;
+    }
+    if (campaign.max_per_user) {
+      const existingSum = user?.wallet_public_key
+        ? existingContributions
+            .filter((c) => c.sender_public_key === user.wallet_public_key)
+            .reduce((sum, c) => sum + Number(c.amount), 0)
+        : 0;
+      if (existingSum + amountNum > Number(campaign.max_per_user)) {
+        setError(`You have already contributed ${existingSum} ${campaign.asset_type}. The per-contributor limit is ${campaign.max_per_user}.`);
         return;
       }
     }
+
     setLoading(true);
     setLoadingLabel('Submitting…');
     setError('');
@@ -386,22 +594,36 @@ export default function ContributeModal({ campaign, onClose, onSuccess }) {
                   aria-describedby="contrib-amount-help"
                 />
                 <span id="contrib-amount-help" style={styles.help}>
-                  This is the credited amount toward the campaign goal, in {campaign.asset_type}.
-                  {(() => {
-                    if (!campaign.max_contribution) return null;
-                    const existingSum = existingContributions
-                      .filter((c) => c.sender_public_key === user?.wallet_public_key)
-                      .reduce((sum, c) => sum + Number(c.amount), 0);
-                    if (existingSum > 0) {
-                      const remaining = Math.max(0, Number(campaign.max_contribution) - existingSum);
-                      return (
-                        <span style={{ display: 'block', marginTop: '0.25rem', color: 'var(--color-accent)', fontWeight: 600 }}>
-                          You can contribute up to {remaining.toLocaleString()} {campaign.asset_type} more.
-                        </span>
-                      );
-                    }
-                    return null;
-                  })()}
+                  <span style={{ display: 'block', marginBottom: '0.25rem' }}>
+                    This is the credited amount toward the campaign goal, in {campaign.asset_type}.
+                  </span>
+                  {(campaign.min_contribution || campaign.max_contribution || campaign.max_per_user) && (
+                    <span style={{ display: 'block', marginTop: '0.35rem', borderTop: '1px dashed var(--color-border-lighter)', paddingTop: '0.35rem' }}>
+                      <strong>Limits for this campaign:</strong>
+                      <ul style={{ margin: '0.25rem 0 0', paddingLeft: '1rem', listStyleType: 'disc' }}>
+                        {campaign.min_contribution && (
+                          <li>Minimum per contribution: {Number(campaign.min_contribution).toLocaleString()} {campaign.asset_type}</li>
+                        )}
+                        {campaign.max_contribution && (
+                          <li>Maximum per contribution: {Number(campaign.max_contribution).toLocaleString()} {campaign.asset_type}</li>
+                        )}
+                        {campaign.max_per_user && (() => {
+                          const existingSum = user?.wallet_public_key
+                            ? existingContributions
+                                .filter((c) => c.sender_public_key === user.wallet_public_key)
+                                .reduce((sum, c) => sum + Number(c.amount), 0)
+                            : 0;
+                          const remaining = Math.max(0, Number(campaign.max_per_user) - existingSum);
+                          return (
+                            <li>
+                              Per-contributor limit: {Number(campaign.max_per_user).toLocaleString()} {campaign.asset_type}
+                              {existingSum > 0 && ` (You have contributed ${existingSum.toLocaleString()} ${campaign.asset_type}; ${remaining.toLocaleString()} remaining)`}
+                            </li>
+                          );
+                        })()}
+                      </ul>
+                    </span>
+                  )}
                 </span>
               </div>
 

--- a/frontend/src/components/ContributeModal.test.jsx
+++ b/frontend/src/components/ContributeModal.test.jsx
@@ -110,6 +110,45 @@ describe('ContributeModal', () => {
     });
   });
 
+  it('validates minimum contribution limit', async () => {
+    const user = userEvent.setup();
+    renderModal({ min_contribution: '5' });
+    await user.clear(screen.getByLabelText(/amount campaign receives/i));
+    await user.type(screen.getByLabelText(/amount campaign receives/i), '4');
+    await user.click(screen.getByRole('button', { name: /confirm payment/i }));
+    expect(await screen.findByText(/Minimum contribution is 5 USDC/i)).toBeInTheDocument();
+    expect(mockContribute).not.toHaveBeenCalled();
+  });
+
+  it('validates maximum contribution limit', async () => {
+    const user = userEvent.setup();
+    renderModal({ max_contribution: '100' });
+    await user.clear(screen.getByLabelText(/amount campaign receives/i));
+    await user.type(screen.getByLabelText(/amount campaign receives/i), '101');
+    await user.click(screen.getByRole('button', { name: /confirm payment/i }));
+    expect(await screen.findByText(/Maximum contribution is 100 USDC/i)).toBeInTheDocument();
+    expect(mockContribute).not.toHaveBeenCalled();
+  });
+
+  it('validates cumulative per-contributor cap', async () => {
+    const { api } = await import('../services/api');
+    api.getContributions.mockResolvedValueOnce({
+      contributions: [
+        { sender_public_key: 'GUSER', amount: '30' }
+      ]
+    });
+
+    const user = userEvent.setup();
+    renderModal({ max_per_user: '50' });
+    
+    await user.clear(screen.getByLabelText(/amount campaign receives/i));
+    await user.type(screen.getByLabelText(/amount campaign receives/i), '25');
+    await user.click(screen.getByRole('button', { name: /confirm payment/i }));
+    
+    expect(await screen.findByText(/You have already contributed 30 USDC. The per-contributor limit is 50./i)).toBeInTheDocument();
+    expect(mockContribute).not.toHaveBeenCalled();
+  });
+
   it('closes on cancel', async () => {
     const user = userEvent.setup();
     renderModal();

--- a/frontend/src/pages/CreateCampaign.jsx
+++ b/frontend/src/pages/CreateCampaign.jsx
@@ -40,6 +40,7 @@ export default function CreateCampaign() {
     milestones: [],
     min_contribution: '',
     max_contribution: '',
+    max_per_user: '',
     show_backer_amounts: true,
   });
   const [coverImageFile, setCoverImageFile] = useState(null);
@@ -142,6 +143,15 @@ export default function CreateCampaign() {
       setError('Enter a fundraising goal greater than zero.');
       return false;
     }
+    setError('');
+    return true;
+  }
+
+  function validateStep2() {
+    if (form.deadline && form.deadline < today) {
+      setError('Deadline must be today or in the future.');
+      return false;
+    }
     if (form.min_contribution && Number(form.min_contribution) <= 0) {
       setError('Minimum contribution must be greater than zero.');
       return false;
@@ -160,14 +170,15 @@ export default function CreateCampaign() {
         return false;
       }
     }
-    setError('');
-    return true;
-  }
-
-  function validateStep2() {
-    if (form.deadline && form.deadline < today) {
-      setError('Deadline must be today or in the future.');
-      return false;
+    if (form.max_per_user) {
+      if (Number(form.max_per_user) <= 0) {
+        setError('Per-contributor cap must be greater than zero.');
+        return false;
+      }
+      if (form.min_contribution && Number(form.max_per_user) <= Number(form.min_contribution)) {
+        setError('Per-contributor cap must be greater than minimum contribution.');
+        return false;
+      }
     }
 
     setError('');
@@ -225,6 +236,7 @@ export default function CreateCampaign() {
           deadline: form.deadline || undefined,
           min_contribution: form.min_contribution ? Number(form.min_contribution) : undefined,
           max_contribution: form.max_contribution ? Number(form.max_contribution) : undefined,
+          max_per_user: form.max_per_user ? Number(form.max_per_user) : undefined,
           milestones: form.milestones.length
             ? form.milestones.map((milestone) => ({
                 title: milestone.title.trim(),
@@ -377,37 +389,7 @@ export default function CreateCampaign() {
               />
             </div>
 
-            <div style={{ marginTop: '1.25rem', border: '1px dashed var(--color-border)', padding: '1rem', borderRadius: '8px' }}>
-              <h3 style={{ fontSize: '1rem', fontWeight: 700, marginBottom: '0.5rem' }}>Contribution limits (Optional)</h3>
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem' }}>
-                <div className="form-stack">
-                  <label className="label-strong" htmlFor="cc-min-contrib">Min contribution</label>
-                  <input
-                    id="cc-min-contrib"
-                    type="number"
-                    inputMode="decimal"
-                    min="0.0000001"
-                    step="any"
-                    value={form.min_contribution}
-                    onChange={setField('min_contribution')}
-                    placeholder="e.g. 5"
-                  />
-                </div>
-                <div className="form-stack">
-                  <label className="label-strong" htmlFor="cc-max-contrib">Max contribution</label>
-                  <input
-                    id="cc-max-contrib"
-                    type="number"
-                    inputMode="decimal"
-                    min="0.0000001"
-                    step="any"
-                    value={form.max_contribution}
-                    onChange={setField('max_contribution')}
-                    placeholder="e.g. 500"
-                  />
-                </div>
-              </div>
-            </div>
+            {/* Contribution limits moved to Step 2 Advanced limits */}
 
             <fieldset style={{ border: 'none', margin: '1.25rem 0 0', padding: 0 }}>
               <legend className="label-strong" style={{ marginBottom: '0.5rem' }}>
@@ -564,6 +546,26 @@ export default function CreateCampaign() {
               If unchecked, backers will be listed but their individual amounts will be hidden from the public.
             </p>
 
+            <details style={{ marginTop: '1rem' }}>
+              <summary style={{ cursor: 'pointer', fontWeight: 600, fontSize: '0.9rem' }}>
+                Contribution limits (optional)
+              </summary>
+              <div style={{ marginTop: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+                <div className="form-stack">
+                  <label htmlFor="cc-min">Minimum per contribution ({form.asset_type})</label>
+                  <input id="cc-min" type="number" min="0" step="any" value={form.min_contribution} onChange={setField('min_contribution')} placeholder="No minimum" />
+                </div>
+                <div className="form-stack">
+                  <label htmlFor="cc-max">Maximum per contribution ({form.asset_type})</label>
+                  <input id="cc-max" type="number" min="0" step="any" value={form.max_contribution} onChange={setField('max_contribution')} placeholder="No maximum" />
+                </div>
+                <div className="form-stack">
+                  <label htmlFor="cc-maxuser">Per-contributor cap ({form.asset_type})</label>
+                  <input id="cc-maxuser" type="number" min="0" step="any" value={form.max_per_user} onChange={setField('max_per_user')} placeholder="No cap" />
+                </div>
+              </div>
+            </details>
+
             {error && (
               <p className="alert alert--error" style={{ marginTop: '1rem' }} role="alert">
                 {error}
@@ -669,6 +671,7 @@ export default function CreateCampaign() {
               <strong>Launch summary:</strong> {form.title || 'Untitled'} with a goal of {form.target_amount || '—'} {form.asset_type}
               {form.min_contribution && ` (Min: ${form.min_contribution} ${form.asset_type})`}
               {form.max_contribution && ` (Max: ${form.max_contribution} ${form.asset_type})`}
+              {form.max_per_user && ` (Cap: ${form.max_per_user} ${form.asset_type})`}
               {form.milestones.length ? ` and ${form.milestones.length} milestone release${form.milestones.length > 1 ? 's' : ''}.` : ' and no milestone plan.'}
             </div>
 


### PR DESCRIPTION
## Closes #184

## Summary
Implements per-campaign contribution limits: minimum per contribution, maximum per contribution, and a cumulative per-user cap — enforced at the database, backend, and frontend layers.

## Changes

**Database**
- Added `min_contribution`, `max_contribution`, and `max_per_user` (`NUMERIC(20,7)`) columns to `campaigns`
- Migration `20260428_contribution_limits.sql` applies all three columns

**Backend**
- `validation.js` — added `max_per_user` validation with cross-field check against `min_contribution`
- `campaigns.js` — stores `max_per_user` on campaign create
- `contributions.js` — enforces all three limits on custodial and Freighter contribute routes: min check, max check, and cumulative per-user cap via existing contributions query

**Frontend**
- `CreateCampaign.jsx` — collapsible "Contribution limits (optional)" section on Step 2 with three numeric inputs, cross-field validation, API submission, and limit display on Step 3 summary
- `ContributeModal.jsx` — loads existing contributions, displays limit hints when configured, validates all three limits on submission

## Files Changed

| File | Change |
|---|---|
| `backend/db/schema.sql` | Added 3 limit columns |
| `backend/db/migrations/20260428_contribution_limits.sql` | Added `max_per_user` column |
| `backend/src/middleware/validation.js` | `max_per_user` validation rule |
| `backend/src/routes/campaigns.js` | Store `max_per_user` on create |
| `backend/src/routes/contributions.js` | Enforce limits on contribute |
| `frontend/src/pages/CreateCampaign.jsx` | Limits UI on Step 2 |
| `frontend/src/components/ContributeModal.jsx` | Limit hints and validation |
| `backend/src/middleware/validation.test.js` | 3 new validation tests |
| `backend/src/routes/contributions.test.js` | 3 new integration tests |
| `frontend/src/components/ContributeModal.test.jsx` | 3 new frontend tests |

## Testing
- ✅ `ContributeModal.test.jsx` — 8/8 pass (3 new limit tests)
- ✅ `validation.test.js` — all pass (3 new limit validation tests)
- ✅ `contributions.test.js` — 3/3 new limit tests pass

> **Note:** 3 pre-existing Freighter tests fail due to a missing `JWT_SECRET` env var. Unrelated to this change.