### PR TITLE
feat: add campaign categories and tag-based filtering (#175)

### DIFF
--- a/backend/db/migrations/20260602_campaign_categories.sql
+++ b/backend/db/migrations/20260602_campaign_categories.sql
@@ -1,0 +1,8 @@
+-- Issue #175: Add campaign categories for tag-based filtering
+ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS category TEXT
+  CHECK (category IN (
+    'technology', 'community', 'arts', 'education',
+    'environment', 'health', 'business', 'open_source', 'other'
+  ));
+
+CREATE INDEX IF NOT EXISTS campaigns_category_idx ON campaigns (category);

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -38,6 +38,10 @@ CREATE TABLE campaigns (
                         CHECK (status IN ('active', 'funded', 'in_progress', 'completed', 'closed', 'withdrawn', 'failed')),
   deadline            DATE,
   show_backer_amounts BOOLEAN DEFAULT TRUE,
+  category            TEXT CHECK (category IN (
+                        'technology', 'community', 'arts', 'education',
+                        'environment', 'health', 'business', 'open_source', 'other'
+                      )),
   created_at          TIMESTAMPTZ DEFAULT NOW()
 );
 
@@ -104,6 +108,7 @@ CREATE UNIQUE INDEX contributions_anchor_transaction_idx
   WHERE anchor_transaction_id IS NOT NULL;
 CREATE INDEX ON campaigns (status);
 CREATE INDEX ON campaigns (creator_id);
+CREATE INDEX ON campaigns (category);
 CREATE UNIQUE INDEX users_kyc_provider_reference_idx
   ON users (kyc_provider_reference)
   WHERE kyc_provider_reference IS NOT NULL;

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -5,6 +5,10 @@ const { getSupportedAssetCodes } = require('../services/stellarService');
 const SUPPORTED_ASSETS = getSupportedAssetCodes();
 const VALID_CAMPAIGN_STATUSES = ['active', 'funded', 'closed', 'failed'];
 const VALID_ORDER_BY = ['newest', 'ending_soon', 'most_funded', 'most_backed', 'closest_to_goal'];
+const VALID_CATEGORIES = [
+  'technology', 'community', 'arts', 'education',
+  'environment', 'health', 'business', 'open_source', 'other',
+];
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function isUuid(value) {
@@ -162,6 +166,10 @@ const createCampaignValidation = [
     .optional()
     .isBoolean()
     .withMessage('show_backer_amounts must be a boolean'),
+  body('category')
+    .optional({ nullable: true, checkFalsy: true })
+    .isIn(VALID_CATEGORIES)
+    .withMessage(`category must be one of: ${VALID_CATEGORIES.join(', ')}`),
 ];
 
 const createCampaignUpdateValidation = [
@@ -254,6 +262,10 @@ const getCampaignsValidation = [
     .optional()
     .isIn(SUPPORTED_ASSETS)
     .withMessage(`asset must be one of: ${SUPPORTED_ASSETS.join(', ')}`),
+  query('category')
+    .optional()
+    .isIn(VALID_CATEGORIES)
+    .withMessage(`category must be one of: ${VALID_CATEGORIES.join(', ')}`),
   query('sort')
     .optional()
     .isIn(VALID_ORDER_BY)

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -195,7 +195,7 @@ router.get('/', getCampaignsValidation, validateRequest, asyncHandler(async (req
    *                   items:
    *                     type: object
    */
-  const { search, status, asset, sort = 'newest' } = req.query;
+  const { search, status, asset, category, sort = 'newest' } = req.query;
   const limit = Math.min(Number(req.query.limit || 20), 100);
   const offset = Math.max(Number(req.query.offset || 0), 0);
   const filters = [];
@@ -220,6 +220,10 @@ router.get('/', getCampaignsValidation, validateRequest, asyncHandler(async (req
     filters.push(
       `(c.title ILIKE $${params.length} OR COALESCE(c.description, '') ILIKE $${params.length})`
     );
+  }
+  if (category) {
+    params.push(category);
+    filters.push(`c.category = $${params.length}`);
   }
 
   const whereClause = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
@@ -257,6 +261,18 @@ router.get('/', getCampaignsValidation, validateRequest, asyncHandler(async (req
 router.get('/mine', requireAuth, asyncHandler(async (req, res) => {
   const campaigns = await listCreatorCampaigns(req.user.userId);
   res.json(campaigns);
+}));
+
+// Category counts for active campaigns
+router.get('/categories', asyncHandler(async (req, res) => {
+  const { rows } = await db.query(
+    `SELECT category, COUNT(*)::int AS count
+     FROM campaigns
+     WHERE status = 'active' AND category IS NOT NULL AND deleted_at IS NULL
+     GROUP BY category
+     ORDER BY count DESC`
+  );
+  res.json(rows);
 }));
 
 router.get('/:id/milestones', asyncHandler(async (req, res) => {
@@ -685,7 +701,7 @@ router.post('/', requireAuth, requireRole('creator', 'admin'), createCampaignVal
    *       403:
    *         description: Forbidden
    */
-  const { title, description, target_amount, asset_type, deadline, milestones, min_contribution, max_contribution } = req.body;
+  const { title, description, target_amount, asset_type, deadline, milestones, min_contribution, max_contribution, category } = req.body;
 
   if (deadline) {
     const [year, month, day] = String(deadline).split('-').map(Number);
@@ -743,11 +759,11 @@ router.post('/', requireAuth, requireRole('creator', 'admin'), createCampaignVal
     const { rows } = await client.query(
       `INSERT INTO campaigns
          (title, description, target_amount, asset_type, wallet_public_key, creator_id, deadline, 
-          min_contribution, max_contribution, escrow_contract_id, milestones_contract_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+          min_contribution, max_contribution, escrow_contract_id, milestones_contract_id, category)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
        RETURNING *`,
       [title, description, target_amount, asset_type, wallet.publicKey, req.user.userId, deadline, 
-       min_contribution || null, max_contribution || null, escrowContractId, milestonesContractId]
+       min_contribution || null, max_contribution || null, escrowContractId, milestonesContractId, category || null]
     );
     campaign = rows[0];
 

--- a/backend/src/routes/campaigns.test.js
+++ b/backend/src/routes/campaigns.test.js
@@ -314,3 +314,134 @@ test('GET /api/campaigns supports search, asset filter, and sort', async () => {
   assert.ok(listQuery.params.includes('%solar%'));
   assert.ok(listQuery.params.includes('USDC'));
 });
+
+test('GET /api/campaigns/categories returns category counts', async () => {
+  const app = buildApp({
+    queryImpl: async (text, params) => {
+      return {
+        rows: [
+          { category: 'technology', count: '5' },
+          { category: 'education', count: '3' },
+        ],
+      };
+    },
+  });
+
+  const response = await request(app).get('/api/campaigns/categories');
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.body, [
+    { category: 'technology', count: '5' },
+    { category: 'education', count: '3' },
+  ]);
+});
+
+test('GET /api/campaigns supports category filter', async () => {
+  const queries = [];
+  const app = buildApp({
+    queryImpl: async (text, params) => {
+      queries.push({ text, params });
+      if (text.includes('AS total')) {
+        return { rows: [{ total: 1 }] };
+      }
+      return {
+        rows: [
+          {
+            id: 'camp-1',
+            title: 'Solar panels',
+            description: 'Clean energy',
+            asset_type: 'USDC',
+            status: 'active',
+            raised_amount: '80',
+            target_amount: '100',
+            category: 'technology',
+          },
+        ],
+      };
+    },
+  });
+
+  const response = await request(app).get('/api/campaigns?category=technology');
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.campaigns[0].category, 'technology');
+  const listQuery = queries.find((q) => q.text.includes('ORDER BY'));
+  assert.ok(listQuery);
+  assert.match(listQuery.text, /category = \$/i);
+  assert.ok(listQuery.params.includes('technology'));
+});
+
+test('POST /api/campaigns accepts valid category', async (t) => {
+  const previous = process.env.KYC_REQUIRED_FOR_CAMPAIGNS;
+  t.after(() => {
+    if (previous === undefined) delete process.env.KYC_REQUIRED_FOR_CAMPAIGNS;
+    else process.env.KYC_REQUIRED_FOR_CAMPAIGNS = previous;
+  });
+  process.env.KYC_REQUIRED_FOR_CAMPAIGNS = 'false';
+
+  const queries = [];
+  const app = buildApp({
+    authUser: { userId: 'creator-1', role: 'creator' },
+    queryImpl: async (text, params) => {
+      queries.push({ text, params });
+      if (text.includes('SELECT email, wallet_public_key, kyc_status FROM users')) {
+        return { rows: [{ wallet_public_key: 'GCREATOR', kyc_status: 'unverified' }] };
+      }
+      if (text.includes('INSERT INTO campaigns')) {
+        return {
+          rows: [
+            {
+              id: 'campaign-1',
+              title: 'Tech campaign',
+              asset_type: 'USDC',
+              creator_id: 'creator-1',
+              category: 'technology',
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    },
+    buildWithdrawalTransactionImpl: async () => '',
+    insertWithdrawalPendingSignaturesImpl: async () => 'tx-row',
+  });
+
+  const response = await request(app)
+    .post('/api/campaigns')
+    .set('Authorization', 'Bearer token')
+    .send({ title: 'Tech campaign', target_amount: '100', asset_type: 'USDC', category: 'technology' });
+
+  assert.equal(response.status, 201);
+  assert.equal(response.body.category, 'technology');
+  
+  const insertQuery = queries.find((q) => q.text.includes('INSERT INTO campaigns'));
+  assert.ok(insertQuery);
+  assert.ok(insertQuery.text.includes('category'));
+  assert.ok(insertQuery.params.includes('technology'));
+});
+
+test('POST /api/campaigns rejects invalid category', async (t) => {
+  const previous = process.env.KYC_REQUIRED_FOR_CAMPAIGNS;
+  t.after(() => {
+    if (previous === undefined) delete process.env.KYC_REQUIRED_FOR_CAMPAIGNS;
+    else process.env.KYC_REQUIRED_FOR_CAMPAIGNS = previous;
+  });
+  process.env.KYC_REQUIRED_FOR_CAMPAIGNS = 'false';
+
+  const app = buildApp({
+    authUser: { userId: 'creator-1', role: 'creator' },
+    queryImpl: async () => ({ rows: [] }),
+    buildWithdrawalTransactionImpl: async () => '',
+    insertWithdrawalPendingSignaturesImpl: async () => 'tx-row',
+  });
+
+  const response = await request(app)
+    .post('/api/campaigns')
+    .set('Authorization', 'Bearer token')
+    .send({ title: 'Tech campaign', target_amount: '100', asset_type: 'USDC', category: 'invalid_category' });
+
+  assert.equal(response.status, 400);
+  assert.ok(response.body.errors);
+  assert.ok(response.body.errors.some(e => e.msg && e.msg.includes('category must be one of')));
+});
+

--- a/frontend/src/components/CampaignCard.jsx
+++ b/frontend/src/components/CampaignCard.jsx
@@ -18,6 +18,18 @@ function daysLeft(deadline) {
   return `${diff}d left`;
 }
 
+const CATEGORY_LABELS = {
+  technology: 'Technology',
+  community: 'Community',
+  arts: 'Arts & Culture',
+  education: 'Education',
+  environment: 'Environment',
+  health: 'Health',
+  business: 'Business',
+  open_source: 'Open Source',
+  other: 'Other',
+};
+
 export default function CampaignCard({ campaign }) {
   const pct = Math.min(100, (campaign.raised_amount / campaign.target_amount) * 100).toFixed(1);
   const fillColor = progressColor(parseFloat(pct), campaign.status);
@@ -40,6 +52,11 @@ export default function CampaignCard({ campaign }) {
           <div style={{ display: 'flex', gap: '0.35rem', alignItems: 'center', flexWrap: 'wrap' }}>
             <span style={styles.asset}>{campaign.asset_type}</span>
             <CampaignStatusBadge status={campaign.status} />
+            {campaign.category && (
+              <span style={styles.categoryBadge}>
+                {CATEGORY_LABELS[campaign.category] || campaign.category}
+              </span>
+            )}
           </div>
           <VerificationBadge status={campaign.creator_kyc_status} compact />
         </div>
@@ -82,6 +99,7 @@ const styles = {
   card: { background: 'var(--color-bg)', border: '1px solid var(--color-border-light)', borderRadius: '10px', padding: '1.25rem', transition: 'box-shadow 0.15s' },
   header: { marginBottom: '0.6rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' },
   asset: { background: 'var(--color-accent-lightest)', color: 'var(--color-accent)', fontSize: '0.75rem', fontWeight: 700, padding: '2px 8px', borderRadius: '99px' },
+  categoryBadge: { background: 'var(--color-accent-lighter)', color: 'var(--color-accent-dark)', fontSize: '0.75rem', fontWeight: 700, padding: '2px 8px', borderRadius: '99px' },
   updates: { fontSize: '0.75rem', fontWeight: 700, color: 'var(--color-success-text)', marginBottom: '0.45rem' },
   title: { fontSize: '1.05rem', fontWeight: 700, marginBottom: '0.4rem', color: 'var(--color-text-primary)' },
   creator: { fontSize: '0.8rem', color: 'var(--color-text-hint)', marginBottom: '0.4rem' },

--- a/frontend/src/components/CampaignCard.test.jsx
+++ b/frontend/src/components/CampaignCard.test.jsx
@@ -53,4 +53,14 @@ describe('CampaignCard', () => {
     renderCard({ ...baseCampaign, status: 'failed' });
     expect(screen.getByText('Campaign ended')).toBeInTheDocument();
   });
+
+  it('shows category chip when category is present', () => {
+    renderCard({ ...baseCampaign, category: 'technology' });
+    expect(screen.getByText('Technology')).toBeInTheDocument();
+  });
+
+  it('does not show category chip when category is absent', () => {
+    renderCard({ ...baseCampaign, category: null });
+    expect(screen.queryByText('Technology')).toBeNull();
+  });
 });

--- a/frontend/src/pages/CreateCampaign.jsx
+++ b/frontend/src/pages/CreateCampaign.jsx
@@ -23,6 +23,18 @@ const ASSETS = [
     hint: 'Native Stellar asset. Simple for contributors who already hold XLM.',
   },
 ];
+
+const CATEGORIES = [
+  { value: 'technology',  label: 'Technology' },
+  { value: 'community',   label: 'Community' },
+  { value: 'arts',        label: 'Arts & Culture' },
+  { value: 'education',   label: 'Education' },
+  { value: 'environment', label: 'Environment' },
+  { value: 'health',      label: 'Health' },
+  { value: 'business',    label: 'Business' },
+  { value: 'open_source', label: 'Open Source' },
+  { value: 'other',       label: 'Other' },
+];
 function emptyMilestone() {
   return { title: '', description: '', release_percentage: '' };
 }
@@ -41,6 +53,7 @@ export default function CreateCampaign() {
     min_contribution: '',
     max_contribution: '',
     show_backer_amounts: true,
+    category: '',
   });
   const [coverImageFile, setCoverImageFile] = useState(null);
   const [coverImagePreview, setCoverImagePreview] = useState('');
@@ -223,6 +236,7 @@ export default function CreateCampaign() {
           target_amount: form.target_amount,
           asset_type: form.asset_type,
           deadline: form.deadline || undefined,
+          category: form.category || undefined,
           min_contribution: form.min_contribution ? Number(form.min_contribution) : undefined,
           max_contribution: form.max_contribution ? Number(form.max_contribution) : undefined,
           milestones: form.milestones.length
@@ -435,6 +449,18 @@ export default function CreateCampaign() {
                 ))}
               </div>
             </fieldset>
+
+            <div className="form-stack" style={{ marginTop: '1rem' }}>
+              <label className="label-strong" htmlFor="cc-category">
+                Category <span style={{ fontWeight: 500, color: 'var(--color-text-muted)' }}>(optional)</span>
+              </label>
+              <select id="cc-category" value={form.category} onChange={setField('category')}>
+                <option value="">Select a category</option>
+                {CATEGORIES.map((c) => (
+                  <option key={c.value} value={c.value}>{c.label}</option>
+                ))}
+              </select>
+            </div>
 
             {error && (
               <p className="alert alert--error" style={{ marginTop: '1rem' }} role="alert">

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -18,6 +18,17 @@ const SORT_OPTIONS = [
   { value: 'most_funded', label: 'Most funded' },
   { value: 'closest_to_goal', label: 'Closest to goal' },
 ];
+const CATEGORY_LABELS = {
+  technology: 'Technology',
+  community: 'Community',
+  arts: 'Arts & Culture',
+  education: 'Education',
+  environment: 'Environment',
+  health: 'Health',
+  business: 'Business',
+  open_source: 'Open Source',
+  other: 'Other',
+};
 const SEARCH_DEBOUNCE_MS = 450;
 
 export default function Home() {
@@ -33,19 +44,22 @@ export default function Home() {
   const [welcomeNewUser, setWelcomeNewUser] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchInput, setSearchInput] = useState(() => searchParams.get('search') || '');
+  const [categoryCounts, setCategoryCounts] = useState([]);
 
   const search = searchParams.get('search') || '';
   const status = searchParams.get('status') || '';
   const asset = searchParams.get('asset') || '';
+  const category = searchParams.get('category') || '';
   const sort = searchParams.get('sort') || 'newest';
 
   const hasActiveFilters =
-    Boolean(search.trim()) || Boolean(asset) || Boolean(status) || sort !== 'newest';
+    Boolean(search.trim()) || Boolean(asset) || Boolean(status) || Boolean(category) || sort !== 'newest';
 
   useEffect(() => {
     if (consumeJustRegistered()) {
       setWelcomeNewUser(true);
     }
+    api.getCampaignCategories().then(setCategoryCounts).catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -64,7 +78,7 @@ export default function Home() {
     setListError('');
     setLoading(true);
     api
-      .getCampaigns({ search, status, asset, sort, limit: 20, offset: 0 })
+      .getCampaigns({ search, status, asset, category, sort, limit: 20, offset: 0 })
       .then((data) => {
         const nextCampaigns = data.campaigns || [];
         const nextTotal = data.total || 0;
@@ -75,7 +89,7 @@ export default function Home() {
       })
       .catch((err) => setListError(err.message || 'Could not load campaigns.'))
       .finally(() => setLoading(false));
-  }, [search, status, asset, sort]);
+  }, [search, status, asset, category, sort]);
 
   async function loadMore() {
     if (loadingMore || !hasMore) return;
@@ -86,6 +100,7 @@ export default function Home() {
         search,
         status,
         asset,
+        category,
         sort,
         limit: 20,
         offset: page * 20,
@@ -242,6 +257,26 @@ export default function Home() {
             ))}
           </select>
         </label>
+      </div>
+
+      <div style={styles.categoryBar}>
+        <button
+          type="button"
+          style={category === '' ? { ...styles.pill, ...styles.pillActive } : styles.pill}
+          onClick={() => setFilters({ category: '' })}
+        >
+          All
+        </button>
+        {categoryCounts.map((cat) => (
+          <button
+            key={cat.category}
+            type="button"
+            style={category === cat.category ? { ...styles.pill, ...styles.pillActive } : styles.pill}
+            onClick={() => setFilters({ category: cat.category })}
+          >
+            {CATEGORY_LABELS[cat.category] || cat.category} ({cat.count})
+          </button>
+        ))}
       </div>
 
       <h2 style={styles.sectionTitle}>Active campaigns</h2>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -198,6 +198,7 @@ export const api = {
     startKyc: () => request('POST', '/users/me/kyc/start'),
 
   getCampaigns: (options = {}) => request('GET', '/campaigns', null, { query: options }),
+  getCampaignCategories: () => request('GET', '/campaigns/categories'),
   getCampaign: (id) => request('GET', `/campaigns/${id}`),
   getCampaignAnalytics: (id) => request('GET', `/campaigns/${id}/analytics`),
   getCampaignEmbed: (id) => request('GET', `/campaigns/${id}/embed`),


### PR DESCRIPTION
## Closes #175

## Summary
Implements campaign categories and tag-based filtering across the database, backend, and frontend.

## Changes

**Database**
- Added `20260602_campaign_categories.sql` migration with optional `category` column, CHECK constraint for valid values, and an index
- Updated `schema.sql` to keep new local setups in sync

**Backend**
- `validation.js` — added category validation in `createCampaignValidation` and query param filtering in `getCampaignsValidation`
- `campaigns.js` — added category filtering on `GET /`, `GET /categories` endpoint returning active campaign counts per category, and `category` field in `POST /` insertion

**Frontend**
- `api.js` — added `getCampaignCategories` for fetching category counts
- `CreateCampaign.jsx` — added category dropdown selector
- `Home.jsx` — added responsive category pill filter bar with real-time counts from the API
- `CampaignCard.jsx` — added visual category chip with theme-aware layout

## Testing
- ✅ 12/12 backend campaign tests pass including category filtering, creation validation, and counts endpoint
- ✅ 7/7 `CampaignCard` frontend tests pass