### PR TITLE
feat: add in-memory TTL cache for public campaign endpoints (#189)

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -97,6 +97,40 @@ app.get('/api/config', (_, res) =>
   res.json({ platform_fee_bps: parseInt(process.env.PLATFORM_FEE_BPS || '0', 10) })
 );
 
+// Public platform stats — used on the hero / landing section.
+// Cached for 60 s; invalidated by ledgerMonitor after each indexed contribution.
+const cache = require('./utils/cache');
+const STATS_CACHE_KEY = 'stats:public';
+app.get('/api/stats', async (_req, res) => {
+  const cached = cache.get(STATS_CACHE_KEY);
+  if (cached) return res.json(cached);
+
+  try {
+    const db = require('./config/database');
+    const [campaigns, raised, contributions] = await Promise.all([
+      db.query(`SELECT COUNT(*)::int AS total
+                FROM campaigns
+                WHERE deleted_at IS NULL AND status NOT IN ('draft', 'failed')`),
+      db.query(`SELECT COALESCE(SUM(raised_amount), 0)::numeric AS total
+                FROM campaigns
+                WHERE deleted_at IS NULL`),
+      db.query(`SELECT COUNT(*)::int AS total FROM contributions`),
+    ]);
+
+    const payload = {
+      total_campaigns: campaigns.rows[0].total,
+      total_raised: parseFloat(raised.rows[0].total),
+      total_contributions: contributions.rows[0].total,
+    };
+
+    cache.set(STATS_CACHE_KEY, payload, 60_000); // 60 s TTL
+    res.json(payload);
+  } catch (err) {
+    logger.error('Failed to fetch public stats', { error: err.message });
+    res.status(500).json({ error: 'Failed to fetch stats' });
+  }
+});
+
 app.get('/health/ledger', async (_req, res) => {
   try {
     const body = await getLedgerStreamHealth();

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -3,6 +3,7 @@ const db = require('../config/database');
 const logger = require('../config/logger');
 const { requireAuth, requireAdmin } = require('../middleware/auth');
 const { reconcileSingleCampaign } = require('../services/reconciliation');
+const cache = require('../utils/cache');
 
 router.use(requireAuth);
 router.use(requireAdmin);
@@ -117,6 +118,8 @@ router.patch('/campaigns/:id/suspend', async (req, res) => {
     });
 
     logger.info('Campaign suspended', { campaignId: id, adminId: req.user.userId, reason });
+    cache.invalidate(`campaigns:id:${id}`);
+    cache.invalidatePrefix('campaigns:list:');
     res.json({ message: 'Campaign suspended', campaign: updated[0] });
   } catch (err) {
     logger.error('Error suspending campaign', { error: err.message, campaignId: req.params.id });
@@ -157,6 +160,8 @@ router.patch('/campaigns/:id/restore', async (req, res) => {
     });
 
     logger.info('Campaign restored', { campaignId: id, adminId: req.user.userId });
+    cache.invalidate(`campaigns:id:${id}`);
+    cache.invalidatePrefix('campaigns:list:');
     res.json({ message: 'Campaign restored', campaign: updated[0] });
   } catch (err) {
     logger.error('Error restoring campaign', { error: err.message, campaignId: req.params.id });
@@ -192,6 +197,8 @@ router.delete('/campaigns/:id', async (req, res) => {
     });
 
     logger.info('Campaign deleted', { campaignId: id, adminId: req.user.userId, reason });
+    cache.invalidate(`campaigns:id:${id}`);
+    cache.invalidatePrefix('campaigns:list:');
     res.json({ message: 'Campaign deleted', campaign: updated[0] });
   } catch (err) {
     logger.error('Error deleting campaign', { error: err.message, campaignId: req.params.id });

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -26,6 +26,7 @@ const {
   validateRequest,
 } = require('../middleware/validation');
 const asyncHandler = require('../utils/asyncHandler');
+const cache = require('../utils/cache');
 
 const crypto = require('crypto');
 
@@ -198,6 +199,11 @@ router.get('/', getCampaignsValidation, validateRequest, asyncHandler(async (req
   const { search, status, asset, sort = 'newest' } = req.query;
   const limit = Math.min(Number(req.query.limit || 20), 100);
   const offset = Math.max(Number(req.query.offset || 0), 0);
+
+  const cacheKey = `campaigns:list:${JSON.stringify(req.query)}`;
+  const cached = cache.get(cacheKey);
+  if (cached) return res.json(cached);
+
   const filters = [];
   const params = [];
 
@@ -251,7 +257,9 @@ router.get('/', getCampaignsValidation, validateRequest, asyncHandler(async (req
   `;
   const result = await db.query(query, [...params, limit, offset]);
 
-  res.json({ total, limit, offset, campaigns: result.rows });
+  const payload = { total, limit, offset, campaigns: result.rows };
+  cache.set(cacheKey, payload, 30_000); // 30 s TTL
+  res.json(payload);
 }));
 
 router.get('/mine', requireAuth, asyncHandler(async (req, res) => {
@@ -361,6 +369,17 @@ router.get('/:id', asyncHandler(async (req, res) => {
    *       404:
    *         description: Not found
    */
+  const campaignId = req.params.id;
+  const isAuthenticated = !!req.headers.authorization?.startsWith('Bearer ');
+  const cacheKey = `campaigns:id:${campaignId}`;
+
+  // Only serve cached response for unauthenticated requests — authenticated
+  // requests need user_role which is caller-specific.
+  if (!isAuthenticated) {
+    const cached = cache.get(cacheKey);
+    if (cached) return res.json(cached);
+  }
+
   const query = `
     SELECT c.*, u.name AS creator_name,
            (SELECT COUNT(DISTINCT sender_public_key)::int FROM contributions WHERE campaign_id = $1) AS contributor_count
@@ -368,8 +387,8 @@ router.get('/:id', asyncHandler(async (req, res) => {
     JOIN users u ON u.id = c.creator_id
     WHERE c.id = $1
   `;
-  await refreshCampaignStatus(req.params.id);
-  const { rows } = await db.query(query, [req.params.id]);
+  await refreshCampaignStatus(campaignId);
+  const { rows } = await db.query(query, [campaignId]);
   if (!rows.length) return res.status(404).json({ error: 'Campaign not found' });
   
   const campaign = rows[0];
@@ -413,6 +432,11 @@ router.get('/:id', asyncHandler(async (req, res) => {
   const response = { ...campaign, user_role: userRole };
   if (campaign.status === 'suspended') {
     response.suspended_notice = 'This campaign has been suspended and cannot receive new contributions';
+  }
+
+  // Cache the public view (no user_role) for unauthenticated visitors
+  if (!isAuthenticated) {
+    cache.set(cacheKey, response, 15_000); // 15 s TTL
   }
 
   res.json(response);
@@ -811,6 +835,9 @@ router.post('/', requireAuth, requireRole('creator', 'admin'), createCampaignVal
   }
 
   watchCampaignWallet(campaign.id, wallet.publicKey);
+
+  // New campaign — bust the list cache so it appears immediately
+  cache.invalidatePrefix('campaigns:list:');
 
   res.status(201).json(campaign);
 }));

--- a/backend/src/services/ledgerMonitor.js
+++ b/backend/src/services/ledgerMonitor.js
@@ -16,6 +16,7 @@ const {
   emitWebhookEventForUser,
   WEBHOOK_EVENTS,
 } = require("./webhookDispatcher");
+const cache = require("../utils/cache");
 
 /** wallet_public_key -> stream metadata */
 const streamRegistry = new Map();
@@ -359,6 +360,11 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
 
   if (postCommitHooks) {
     setImmediate(() => {
+      // Bust public caches — contribution changes raised_amount and contributor_count
+      cache.invalidate(`campaigns:id:${postCommitHooks.campaignId}`);
+      cache.invalidatePrefix('campaigns:list:');
+      cache.invalidatePrefix('stats:');
+
       sendContributionReceipt(postCommitHooks.receiptPayload).catch((e) =>
         logger.error("[receipt] Email failed", {
           campaign_id: postCommitHooks.campaignId,

--- a/backend/src/utils/cache.js
+++ b/backend/src/utils/cache.js
@@ -1,0 +1,41 @@
+/**
+ * Simple in-process TTL cache backed by a Map.
+ *
+ * Suitable for single-instance MVP deployments. Not suitable for
+ * multi-instance deployments where cache coherency across processes
+ * is required — use Redis or a shared cache layer in that scenario.
+ */
+class TtlCache {
+  constructor() {
+    this._store = new Map();
+  }
+
+  get(key) {
+    const entry = this._store.get(key);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this._store.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(key, value, ttlMs) {
+    this._store.set(key, { value, expiresAt: Date.now() + ttlMs });
+  }
+
+  invalidate(key) {
+    this._store.delete(key);
+  }
+
+  /**
+   * Remove all entries whose key starts with the given prefix.
+   */
+  invalidatePrefix(prefix) {
+    for (const key of this._store.keys()) {
+      if (key.startsWith(prefix)) this._store.delete(key);
+    }
+  }
+}
+
+module.exports = new TtlCache();


### PR DESCRIPTION
- Add TtlCache utility (backend/src/utils/cache.js) backed by a Map
- Cache GET /api/campaigns list with 30s TTL, key includes query params
- Cache GET /api/campaigns/:id with 15s TTL (unauthenticated only)
- Add public GET /api/stats endpoint with 60s TTL
- Invalidate campaign/list/stats caches in ledgerMonitor after each indexed contribution
- Invalidate id + list caches on admin suspend, restore, and delete
- Invalidate list cache on new campaign creation
- Authenticated requests and /balance endpoint bypass cache entirely
- Documented as single-instance only; not suitable for multi-process deployments

closes #189 
