### PR TITLE
#186 Add user profile page: edit display name and view wallet address

### DIFF
--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -101,4 +101,28 @@ router.get('/me/contributions', requireAuth, asyncHandler(async (req, res) => {
   res.json(rows);
 }));
 
+// GET /api/users/me — already proposed in issue #163, implement together
+router.get('/me', requireAuth, async (req, res) => {
+  const { rows } = await db.query(
+    `SELECT id, email, name, wallet_public_key, created_at FROM users WHERE id = $1`,
+    [req.user.userId]
+  );
+  if (!rows.length) return res.status(404).json({ error: 'User not found' });
+  res.json(rows[0]);
+});
+
+// PATCH /api/users/me — update display name only
+router.patch('/me', requireAuth, async (req, res) => {
+  const { name } = req.body;
+  if (!name || !name.trim()) {
+    return res.status(400).json({ error: 'name is required' });
+  }
+  const { rows } = await db.query(
+    `UPDATE users SET name = $1 WHERE id = $2
+     RETURNING id, email, name, wallet_public_key, created_at`,
+    [name.trim(), req.user.userId]
+  );
+  res.json(rows[0]);
+});
+
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import AdminDashboard from './pages/AdminDashboard';
 import AcceptInvite from './pages/AcceptInvite';
 import Developer from './pages/Developer';
 import Dashboard from './pages/Dashboard';
+import Profile from './pages/Profile';
 import NotFound from './pages/NotFound';
 import { AuthProvider } from './context/AuthContext';
 import { ThemeProvider } from './context/ThemeContext';
@@ -37,6 +38,7 @@ export default function App() {
           <Route path="/admin" element={<AdminDashboard />} />
           <Route path="/developer" element={<Developer />} />
           <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/profile" element={<Profile />} />
           <Route path="/my-contributions" element={<Navigate to="/dashboard?tab=contributions" replace />} />
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -27,6 +27,7 @@ export default function Navbar() {
           {user ? (
             <>
               <Link to="/campaigns/new" style={styles.link} aria-current={pathname === '/campaigns/new' ? 'page' : undefined}>Start Campaign</Link>
+              <Link to="/profile" style={styles.link} aria-current={pathname === '/profile' ? 'page' : undefined}>Profile</Link>
               <span style={styles.name} aria-hidden="true">{user.name}</span>
               <button onClick={handleLogout} className="btn-secondary" style={{ padding: '0.4rem 0.9rem' }}>
                 Logout

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,0 +1,144 @@
+import React, { useState, useEffect } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { stellarExpertAccountUrl } from '../config/stellar';
+
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || '').replace(/\/+$/, '');
+const BASE_URL = import.meta.env.VITE_API_URL || `${API_BASE_URL}/api`;
+
+export default function Profile() {
+  const { user, token, ready, updateUser } = useAuth();
+  const [name, setName] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (user) {
+      setName(user.name || '');
+    }
+  }, [user]);
+
+  if (!ready) {
+    return (
+      <main className="container page-narrow" style={{ paddingTop: '3rem' }}>
+        <p className="alert alert--info">Loading session…</p>
+      </main>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  const handleSave = async (e) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      setError('Display name is required');
+      return;
+    }
+    setSaving(true);
+    setError('');
+    setSuccess('');
+    try {
+      const res = await fetch(`${BASE_URL}/users/me`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({ name: name.trim() })
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to update profile');
+      }
+      const updatedUser = await res.json();
+      if (updateUser) updateUser(updatedUser);
+      setSuccess('Profile updated successfully');
+      setTimeout(() => setSuccess(''), 3000);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(user.wallet_public_key);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <main className="container page-narrow" style={{ paddingTop: '3rem', paddingBottom: '4rem' }}>
+      <h1 style={{ fontSize: '1.75rem', fontWeight: 800, marginBottom: '1.5rem' }}>Your Profile</h1>
+      
+      <div className="campaign-card" style={{ marginBottom: '2rem' }}>
+        <h2 style={{ fontSize: '1.15rem', fontWeight: 700, marginBottom: '1rem' }}>Account details</h2>
+        
+        {error && <p className="alert alert--error" style={{ marginBottom: '1rem' }}>{error}</p>}
+        {success && <p className="alert alert--success" style={{ marginBottom: '1rem' }}>{success}</p>}
+        
+        <form onSubmit={handleSave}>
+          <div className="form-stack" style={{ marginBottom: '1.25rem' }}>
+            <label htmlFor="profile-name" className="label-strong">Display name</label>
+            <input 
+              id="profile-name" 
+              value={name} 
+              onChange={(e) => setName(e.target.value)} 
+              placeholder="Your display name"
+            />
+          </div>
+          
+          <div className="form-stack" style={{ marginBottom: '1.25rem' }}>
+            <label className="label-strong">Email address</label>
+            <input 
+              value={user.email || ''} 
+              disabled 
+              style={{ background: 'var(--color-surface)', color: 'var(--color-text-secondary)', cursor: 'not-allowed' }} 
+            />
+          </div>
+          
+          <div className="form-stack" style={{ marginBottom: '1.5rem' }}>
+            <label className="label-strong">Member since</label>
+            <input 
+              value={user.created_at ? new Date(user.created_at).toLocaleDateString() : '—'} 
+              disabled 
+              style={{ background: 'var(--color-surface)', color: 'var(--color-text-secondary)', cursor: 'not-allowed' }} 
+            />
+          </div>
+          
+          <button type="submit" className="btn-primary" disabled={saving || !name.trim() || name === user.name}>
+            {saving ? 'Saving…' : 'Save changes'}
+          </button>
+        </form>
+      </div>
+
+      <div className="campaign-card">
+        <h2 style={{ fontSize: '1.15rem', fontWeight: 700, marginBottom: '0.5rem' }}>Your Stellar wallet</h2>
+        <p style={{ color: 'var(--color-text-secondary)', fontSize: '0.9rem', marginBottom: '1rem' }}>
+          This is a custodial wallet managed by CrowdPay.
+        </p>
+        
+        <div style={{ background: 'var(--color-surface)', padding: '1rem', borderRadius: '8px', marginBottom: '1rem' }}>
+          <code style={{ wordBreak: 'break-all', color: 'var(--color-text-primary)' }}>
+            {user.wallet_public_key}
+          </code>
+        </div>
+        
+        <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+          <button type="button" className="btn-secondary" onClick={handleCopy}>
+            {copied ? 'Copied!' : 'Copy address'}
+          </button>
+          {typeof stellarExpertAccountUrl === 'function' && (
+            <a href={stellarExpertAccountUrl(user.wallet_public_key)} target="_blank" rel="noopener noreferrer" className="btn-secondary" style={{ display: 'inline-flex', alignItems: 'center', textDecoration: 'none' }}>
+              View on Stellar Expert ↗
+            </a>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #186

Added a user profile page with account management features, including display name updates, wallet address visibility with copy-to-clipboard support, and account details. Also added authenticated profile routes and user profile API endpoints.


#186 