### PR TITLE
Replace absolute timestamps with relative times

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,9 +10,12 @@
       "dependencies": {
         "@stellar/freighter-api": "^4.1.0",
         "easymde": "^2.18.0",
+        "i18next": "^25.3.2",
+        "i18next-browser-languagedetector": "^8.2.0",
         "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-i18next": "^15.7.3",
         "react-router-dom": "^6.23.1",
         "react-simplemde-editor": "^5.2.0"
       },
@@ -87,7 +90,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -295,7 +297,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -437,7 +438,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -461,7 +461,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1529,7 +1528,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1773,7 +1773,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1833,6 +1832,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2102,7 +2102,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2584,7 +2583,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2606,7 +2606,6 @@
       "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.20.0.tgz",
       "integrity": "sha512-V1Z5f92TfR42Na852OWnIZMbM7zotWQYTddNaLYZFVKj7APBbyZ3FYJ27gBw2grMW3R6Qdv9J8n5Ij7XRSIgXQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/codemirror": "^5.60.10",
         "@types/marked": "^4.0.7",
@@ -2894,7 +2893,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3566,6 +3564,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3592,6 +3599,46 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.10.10",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+      "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-lite": {
@@ -4183,7 +4230,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -4363,6 +4409,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4775,7 +4822,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4847,6 +4893,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4928,7 +4975,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4941,7 +4987,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4950,12 +4995,39 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.4.tgz",
+      "integrity": "sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.4.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -6010,7 +6082,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -6159,6 +6230,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/frontend/src/components/NotificationDropdown.jsx
+++ b/frontend/src/components/NotificationDropdown.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '../services/api';
+import RelativeTime from './RelativeTime';
 
 export default function NotificationDropdown({ notifications, onMarkRead, onMarkAllRead, onClose }) {
   const navigate = useNavigate();
@@ -31,7 +32,7 @@ export default function NotificationDropdown({ notifications, onMarkRead, onMark
           >
             <div style={styles.itemTitle}>{n.title}</div>
             {n.body && <div style={styles.itemBody}>{n.body}</div>}
-            <div style={styles.itemTime}>{new Date(n.created_at).toLocaleString()}</div>
+            <div style={styles.itemTime}><RelativeTime date={n.created_at} /></div>
           </button>
         ))
       )}

--- a/frontend/src/components/RelativeTime.jsx
+++ b/frontend/src/components/RelativeTime.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useRelativeTime } from '../hooks/useRelativeTime';
+
+export default function RelativeTime({ date, title }) {
+  const label = useRelativeTime(date);
+  if (!date) return null;
+  const dateObj = new Date(date);
+  if (isNaN(dateObj.getTime())) return null;
+
+  return (
+    <time
+      dateTime={dateObj.toISOString()}
+      title={title ?? dateObj.toLocaleString()}
+    >
+      {label}
+    </time>
+  );
+}

--- a/frontend/src/components/WithdrawalsSection.jsx
+++ b/frontend/src/components/WithdrawalsSection.jsx
@@ -3,6 +3,7 @@ import { api } from '../services/api';
 import { getNetwork, signTransaction } from '@stellar/freighter-api';
 import { stellarExpertTxUrl } from '../config/stellar';
 import { useToast } from '../context/ToastContext';
+import RelativeTime from './RelativeTime';
 
 const ELIGIBLE = ['active', 'funded'];
 
@@ -455,7 +456,7 @@ export default function WithdrawalsSection({ campaign, milestones = [], user, to
                         {ev.note ? ` — ${ev.note}` : ''}
                         <span style={{ color: 'var(--color-text-muted)' }}>
                           {' '}
-                          ({new Date(ev.created_at).toLocaleString()})
+                          (<RelativeTime date={ev.created_at} />)
                         </span>
                       </li>
                     ))}

--- a/frontend/src/hooks/useRelativeTime.js
+++ b/frontend/src/hooks/useRelativeTime.js
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+
+function getRelative(date) {
+  if (!date) return '';
+  const dateObj = new Date(date);
+  if (isNaN(dateObj.getTime())) return '';
+
+  const seconds = Math.round((dateObj.getTime() - Date.now()) / 1000);
+  const abs = Math.abs(seconds);
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+  if (abs < 60)     return rtf.format(Math.round(seconds), 'second');
+  if (abs < 3600)   return rtf.format(Math.round(seconds / 60), 'minute');
+  if (abs < 86400)  return rtf.format(Math.round(seconds / 3600), 'hour');
+  if (abs < 604800) return rtf.format(Math.round(seconds / 86400), 'day');
+  // Fall back to absolute date for older events
+  return dateObj.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+export function useRelativeTime(date) {
+  const [label, setLabel] = useState(() => getRelative(date));
+  useEffect(() => {
+    setLabel(getRelative(date));
+    const id = setInterval(() => setLabel(getRelative(date)), 30_000);
+    return () => clearInterval(id);
+  }, [date]);
+  return label;
+}

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -3,6 +3,7 @@ import { Link, useParams, useLocation, useNavigate } from "react-router-dom";
 import { api } from "../services/api";
 import { useAuth } from "../context/AuthContext";
 import ContributeModal from "../components/ContributeModal";
+import RelativeTime from "../components/RelativeTime";
 import DisputeModal from "../components/DisputeModal";
 import TransactionHistory from "../components/TransactionHistory";
 import MilestoneTracker from "../components/MilestoneTracker";
@@ -89,11 +90,7 @@ function ContributionRow({ c }) {
               {c.sender_public_key.slice(0, 4)}…{c.sender_public_key.slice(-4)}
             </button>
             {" • "}
-            {new Date(c.created_at).toLocaleDateString(undefined, {
-              month: "short",
-              day: "numeric",
-              year: "numeric",
-            })}
+            <RelativeTime date={c.created_at} />
           </div>
           {c.refund_status && (
             <div style={styles.refundTag}>
@@ -1643,7 +1640,7 @@ export default function Campaign() {
                   }}
                 >
                   {update.author_name} •{" "}
-                  {new Date(update.created_at).toLocaleString()}
+                  <RelativeTime date={update.created_at} />
                 </span>
               </div>
               <div
@@ -1853,7 +1850,7 @@ export default function Campaign() {
                       }}
                     >
                       {update.author_name} •{" "}
-                      {new Date(update.created_at).toLocaleString()}
+                      <RelativeTime date={update.created_at} />
                     </span>
                   </div>
 

--- a/frontend/src/test/RelativeTime.test.jsx
+++ b/frontend/src/test/RelativeTime.test.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { useRelativeTime } from '../hooks/useRelativeTime';
+import RelativeTime from '../components/RelativeTime';
+
+// Helper component to test useRelativeTime hook
+function HookTestComponent({ date }) {
+  const label = useRelativeTime(date);
+  return <span data-testid="hook-label">{label}</span>;
+}
+
+describe('useRelativeTime Hook & RelativeTime Component', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders relative time for recent events', () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    // 10 seconds ago
+    const tenSecsAgo = new Date(now - 10000).toISOString();
+    render(<RelativeTime date={tenSecsAgo} />);
+    
+    const el = screen.getByRole('time');
+    expect(el).toBeInTheDocument();
+    
+    const expected = new Intl.RelativeTimeFormat('en', { numeric: 'auto' }).format(-10, 'second');
+    expect(el.textContent).toBe(expected);
+    expect(el.getAttribute('title')).toBe(new Date(tenSecsAgo).toLocaleString());
+  });
+
+  it('renders relative time in minutes/hours/days', () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    // 5 minutes ago
+    const fiveMinAgo = new Date(now - 5 * 60 * 1000).toISOString();
+    const { rerender } = render(<RelativeTime date={fiveMinAgo} />);
+    
+    const expectedMin = new Intl.RelativeTimeFormat('en', { numeric: 'auto' }).format(-5, 'minute');
+    expect(screen.getByRole('time').textContent).toBe(expectedMin);
+
+    // 3 hours ago
+    const threeHoursAgo = new Date(now - 3 * 3600 * 1000).toISOString();
+    rerender(<RelativeTime date={threeHoursAgo} />);
+    
+    const expectedHour = new Intl.RelativeTimeFormat('en', { numeric: 'auto' }).format(-3, 'hour');
+    expect(screen.getByRole('time').textContent).toBe(expectedHour);
+
+    // 2 days ago
+    const twoDaysAgo = new Date(now - 2 * 24 * 3600 * 1000).toISOString();
+    rerender(<RelativeTime date={twoDaysAgo} />);
+    
+    const expectedDay = new Intl.RelativeTimeFormat('en', { numeric: 'auto' }).format(-2, 'day');
+    expect(screen.getByRole('time').textContent).toBe(expectedDay);
+  });
+
+  it('falls back to absolute short date for events older than 7 days', () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    // 8 days ago
+    const eightDaysAgo = new Date(now - 8 * 24 * 3600 * 1000).toISOString();
+    render(<RelativeTime date={eightDaysAgo} />);
+    const el = screen.getByRole('time');
+    expect(el.textContent).toBe(new Date(eightDaysAgo).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' }));
+  });
+
+  it('updates the time label automatically every 30 seconds', () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    const date = new Date(now).toISOString();
+    render(<RelativeTime date={date} />);
+    const el = screen.getByRole('time');
+    
+    const expectedNow = new Intl.RelativeTimeFormat('en', { numeric: 'auto' }).format(0, 'second');
+    expect(el.textContent).toBe(expectedNow);
+
+    // Advance time by 30 seconds
+    act(() => {
+      vi.advanceTimersByTime(30000);
+    });
+
+    const expected30sAgo = new Intl.RelativeTimeFormat('en', { numeric: 'auto' }).format(-30, 'second');
+    expect(el.textContent).toBe(expected30sAgo);
+  });
+
+  it('handles invalid or empty dates gracefully', () => {
+    const { container: container1 } = render(<RelativeTime date="" />);
+    expect(container1.firstChild).toBeNull();
+
+    const { container: container2 } = render(<RelativeTime date="invalid-date" />);
+    expect(container2.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
- completed the implementation to display human-friendly relative times (e.g., "2 hours ago") for recent events within the last 7 days. For events older than 7 days, the UI falls back to showing short absolute date strings.

Changes Made
1. Created Custom useRelativeTime Hook
Added a utility hook that uses the browser-native Intl.RelativeTimeFormat to calculate time differences relative to now and automatically update the label every 30 seconds:

useRelativeTime.js
2. Created <RelativeTime /> Component
Created a wrapper component that renders a semantic <time> element with full date-time metadata, plus a native browser tooltip (title attribute) with the absolute locale time shown on hover:

RelativeTime.jsx
3. Integrated <RelativeTime /> into the UI
Replaced instances of raw locale date strings:

Withdrawal Release Audits: Replaced raw string in 
WithdrawalsSection.jsx
.
Campaign Backer Wall / Contributions: Updated contribution row rows in 
Campaign.jsx
.
Campaign Updates: Updated the update feed timestamps in 
Campaign.jsx
.
Notifications: Updated the notification feed entries in 
NotificationDropdown.jsx

- Closes #192 