### PR TITLE
fix: remove duplicate showEmbedSection useState in Campaign.jsx (#390)

### DIFF
--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -158,7 +158,6 @@ export default function Campaign() {
   const [embedCopied, setEmbedCopied] = useState(false);
   const [badgeCopied, setBadgeCopied] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
-  const [showEmbedSection, setShowEmbedSection] = useState(false);
   const [isEditingCampaign, setIsEditingCampaign] = useState(false);
   const [editFormData, setEditFormData] = useState({
     title: '',


### PR DESCRIPTION
Closes #390

## Changes
- Removed duplicate `showEmbedSection` useState declaration (was declared twice at lines 157 and 161)
- Kept single declaration at line 157: `const [showEmbedSection, setShowEmbedSection] = useState(false);`

## Problem
JavaScript destructuring silently overwrites the first binding with the second, so toggling the embed section used a stale state setter that didn't trigger re-renders correctly.

## Acceptance Criteria
- [x] Only one `showEmbedSection` useState declaration remains
- [x] App builds without errors