### PR TITLE
test(#466): add coverage for walletService and wallets routes

### DIFF
--- a/backend/src/routes/wallets.test.js
+++ b/backend/src/routes/wallets.test.js
@@ -1,0 +1,287 @@
+// NOTE: backend/src/routes/wallets.js is not mounted anywhere in src/index.js
+// (verified: no `app.use` references it, no other module requires it). These
+// tests exercise the router in isolation, the same way other route test files
+// in this repo do — they do NOT prove the routes are reachable end-to-end in
+// the running app. See PR description for details.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const proxyquire = require('proxyquire').noCallThru();
+
+const CAMPAIGN_ID = '11111111-1111-1111-1111-111111111111';
+// Fake, obviously-non-real Stellar-shaped public key used only as a stand-in string.
+const FAKE_WALLET_PUBLIC_KEY = 'GFAKEWALLETPUBLICKEYFORTESTINGONLY0000000000000000000000';
+const FAKE_ENCRYPTED_SECRET = 'fake:ciphertext:for-tests-only';
+const FAKE_DECRYPTED_SECRET = 'fake-decrypted-secret-for-tests-only';
+
+function buildApp({ queryImpl, stellarImpl, walletServiceImpl, userId = 'creator-1', role = 'creator' } = {}) {
+  const stellarStub = {
+    getAccountMultisigConfig: async () => ({
+      thresholds: { med_threshold: 2 },
+      signers: [{ key: 'GSIGNERFAKE', weight: 1 }],
+    }),
+    getWalletTransactionHistory: async () => [],
+    getWalletPayments: async () => [],
+    recoverWalletFromSecret: (secret) => ({ publicKey: FAKE_WALLET_PUBLIC_KEY, secret }),
+    ...stellarImpl,
+  };
+  const walletServiceStub = {
+    decryptSecret: (encrypted) => `decrypted(${encrypted})`,
+    ...walletServiceImpl,
+  };
+
+  const router = proxyquire('./wallets', {
+    '../config/database': { query: queryImpl },
+    '../services/stellarService': stellarStub,
+    '../services/walletService': walletServiceStub,
+    '../middleware/auth': {
+      requireAuth: (req, _res, next) => {
+        req.user = { userId, role };
+        next();
+      },
+    },
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/wallets', router);
+  return { app };
+}
+
+function campaignRow(overrides = {}) {
+  return {
+    wallet_public_key: FAKE_WALLET_PUBLIC_KEY,
+    creator_id: 'creator-1',
+    ...overrides,
+  };
+}
+
+// GET /:campaignId/config
+
+test('GET /api/wallets/:campaignId/config returns multisig config for the owning creator', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({ rows: [campaignRow()] }),
+  });
+
+  const res = await request(app).get(`/api/wallets/${CAMPAIGN_ID}/config`);
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body, {
+    thresholds: { med_threshold: 2 },
+    signers: [{ key: 'GSIGNERFAKE', weight: 1 }],
+  });
+});
+
+test('GET /api/wallets/:campaignId/config returns 404 for unknown campaign', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({ rows: [] }),
+  });
+
+  const res = await request(app).get(`/api/wallets/${CAMPAIGN_ID}/config`);
+
+  assert.equal(res.status, 404);
+  assert.deepEqual(res.body, { error: 'Campaign not found' });
+});
+
+test('GET /api/wallets/:campaignId/config returns 403 for a non-owner', async () => {
+  const { app } = buildApp({
+    userId: 'someone-else',
+    queryImpl: async () => ({ rows: [campaignRow()] }),
+  });
+
+  const res = await request(app).get(`/api/wallets/${CAMPAIGN_ID}/config`);
+
+  assert.equal(res.status, 403);
+  assert.deepEqual(res.body, { error: 'Unauthorized' });
+});
+
+// GET /:campaignId/transactions
+
+test('GET /api/wallets/:campaignId/transactions returns history using the default limit', async () => {
+  let receivedLimit;
+  const { app } = buildApp({
+    queryImpl: async () => ({ rows: [campaignRow()] }),
+    stellarImpl: {
+      getWalletTransactionHistory: async (publicKey, limit) => {
+        receivedLimit = limit;
+        assert.equal(publicKey, FAKE_WALLET_PUBLIC_KEY);
+        return [{ hash: 'tx-1' }];
+      },
+    },
+  });
+
+  const res = await request(app).get(`/api/wallets/${CAMPAIGN_ID}/transactions`);
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body, [{ hash: 'tx-1' }]);
+  assert.equal(receivedLimit, 50);
+});
+
+test('GET /api/wallets/:campaignId/transactions honors a custom ?limit=', async () => {
+  let receivedLimit;
+  const { app } = buildApp({
+    queryImpl: async () => ({ rows: [campaignRow()] }),
+    stellarImpl: {
+      getWalletTransactionHistory: async (_publicKey, limit) => {
+        receivedLimit = limit;
+        return [];
+      },
+    },
+  });
+
+  const res = await request(app).get(`/api/wallets/${CAMPAIGN_ID}/transactions?limit=5`);
+
+  assert.equal(res.status, 200);
+  assert.equal(receivedLimit, 5);
+});
+
+test('GET /api/wallets/:campaignId/transactions returns 404 for unknown campaign', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({ rows: [] }),
+  });
+
+  const res = await request(app).get(`/api/wallets/${CAMPAIGN_ID}/transactions`);
+
+  assert.equal(res.status, 404);
+});
+
+test('GET /api/wallets/:campaignId/transactions returns 403 for a non-owner', async () => {
+  const { app } = buildApp({
+    userId: 'someone-else',
+    queryImpl: async () => ({ rows: [campaignRow()] }),
+  });
+
+  const res = await request(app).get(`/api/wallets/${CAMPAIGN_ID}/transactions`);
+
+  assert.equal(res.status, 403);
+});
+
+// GET /:campaignId/payments
+
+test('GET /api/wallets/:campaignId/payments returns payment history using the default limit', async () => {
+  let receivedLimit;
+  const { app } = buildApp({
+    queryImpl: async () => ({ rows: [campaignRow()] }),
+    stellarImpl: {
+      getWalletPayments: async (publicKey, limit) => {
+        receivedLimit = limit;
+        assert.equal(publicKey, FAKE_WALLET_PUBLIC_KEY);
+        return [{ id: 'pay-1' }];
+      },
+    },
+  });
+
+  const res = await request(app).get(`/api/wallets/${CAMPAIGN_ID}/payments`);
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body, [{ id: 'pay-1' }]);
+  assert.equal(receivedLimit, 100);
+});
+
+test('GET /api/wallets/:campaignId/payments honors a custom ?limit=', async () => {
+  let receivedLimit;
+  const { app } = buildApp({
+    queryImpl: async () => ({ rows: [campaignRow()] }),
+    stellarImpl: {
+      getWalletPayments: async (_publicKey, limit) => {
+        receivedLimit = limit;
+        return [];
+      },
+    },
+  });
+
+  const res = await request(app).get(`/api/wallets/${CAMPAIGN_ID}/payments?limit=7`);
+
+  assert.equal(res.status, 200);
+  assert.equal(receivedLimit, 7);
+});
+
+test('GET /api/wallets/:campaignId/payments returns 404 for unknown campaign', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({ rows: [] }),
+  });
+
+  const res = await request(app).get(`/api/wallets/${CAMPAIGN_ID}/payments`);
+
+  assert.equal(res.status, 404);
+});
+
+test('GET /api/wallets/:campaignId/payments returns 403 for a non-owner', async () => {
+  const { app } = buildApp({
+    userId: 'someone-else',
+    queryImpl: async () => ({ rows: [campaignRow()] }),
+  });
+
+  const res = await request(app).get(`/api/wallets/${CAMPAIGN_ID}/payments`);
+
+  assert.equal(res.status, 403);
+});
+
+// POST /:campaignId/recover
+
+test('POST /api/wallets/:campaignId/recover decrypts the stored secret and returns the public key', async () => {
+  let decryptedArg;
+  let recoverArg;
+  const { app } = buildApp({
+    queryImpl: async () => ({
+      rows: [{ wallet_secret_encrypted: FAKE_ENCRYPTED_SECRET, creator_id: 'creator-1' }],
+    }),
+    walletServiceImpl: {
+      decryptSecret: (encrypted) => {
+        decryptedArg = encrypted;
+        return FAKE_DECRYPTED_SECRET;
+      },
+    },
+    stellarImpl: {
+      recoverWalletFromSecret: (secret) => {
+        recoverArg = secret;
+        return { publicKey: FAKE_WALLET_PUBLIC_KEY, secret };
+      },
+    },
+  });
+
+  const res = await request(app).post(`/api/wallets/${CAMPAIGN_ID}/recover`).send({});
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body, { publicKey: FAKE_WALLET_PUBLIC_KEY });
+  assert.equal(decryptedArg, FAKE_ENCRYPTED_SECRET);
+  assert.equal(recoverArg, FAKE_DECRYPTED_SECRET);
+});
+
+test('POST /api/wallets/:campaignId/recover returns 400 when no encrypted secret is stored', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({
+      rows: [{ wallet_secret_encrypted: null, creator_id: 'creator-1' }],
+    }),
+  });
+
+  const res = await request(app).post(`/api/wallets/${CAMPAIGN_ID}/recover`).send({});
+
+  assert.equal(res.status, 400);
+  assert.deepEqual(res.body, { error: 'No encrypted secret stored for this campaign' });
+});
+
+test('POST /api/wallets/:campaignId/recover returns 404 for unknown campaign', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({ rows: [] }),
+  });
+
+  const res = await request(app).post(`/api/wallets/${CAMPAIGN_ID}/recover`).send({});
+
+  assert.equal(res.status, 404);
+});
+
+test('POST /api/wallets/:campaignId/recover returns 403 for a non-owner', async () => {
+  const { app } = buildApp({
+    userId: 'someone-else',
+    queryImpl: async () => ({
+      rows: [{ wallet_secret_encrypted: FAKE_ENCRYPTED_SECRET, creator_id: 'creator-1' }],
+    }),
+  });
+
+  const res = await request(app).post(`/api/wallets/${CAMPAIGN_ID}/recover`).send({});
+
+  assert.equal(res.status, 403);
+});

--- a/backend/src/services/walletService.test.js
+++ b/backend/src/services/walletService.test.js
@@ -1,0 +1,68 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const MODULE_PATH = './walletService';
+// Fake 32-byte key expressed as hex — not a production key, generated for tests only.
+const FAKE_KEY_HEX = 'a1'.repeat(32);
+const FAKE_SECRET = 'this-is-a-fake-test-wallet-secret';
+
+function freshWalletService(keyHex) {
+  process.env.WALLET_ENCRYPTION_KEY = keyHex;
+  delete require.cache[require.resolve(MODULE_PATH)];
+  return require(MODULE_PATH);
+}
+
+test('encryptSecret produces an iv:authTag:ciphertext envelope that decryptSecret reverses', (t) => {
+  const walletService = freshWalletService(FAKE_KEY_HEX);
+
+  const encrypted = walletService.encryptSecret(FAKE_SECRET);
+
+  const parts = encrypted.split(':');
+  assert.equal(parts.length, 3);
+  assert.match(parts[0], /^[0-9a-f]{32}$/); // 16-byte IV
+  assert.match(parts[1], /^[0-9a-f]{32}$/); // 16-byte GCM auth tag
+  assert.notEqual(encrypted, FAKE_SECRET);
+
+  const decrypted = walletService.decryptSecret(encrypted);
+  assert.equal(decrypted, FAKE_SECRET);
+
+  t.after(() => {
+    delete process.env.WALLET_ENCRYPTION_KEY;
+  });
+});
+
+test('decryptSecret throws when the ciphertext or auth tag has been tampered with', (t) => {
+  const walletService = freshWalletService(FAKE_KEY_HEX);
+
+  const encrypted = walletService.encryptSecret(FAKE_SECRET);
+  const [ivHex, authTagHex, cipherHex] = encrypted.split(':');
+
+  // Flip one hex character in the ciphertext to simulate tampering.
+  const flippedChar = cipherHex[0] === '0' ? '1' : '0';
+  const tamperedCipher = flippedChar + cipherHex.slice(1);
+  const tamperedCiphertext = `${ivHex}:${authTagHex}:${tamperedCipher}`;
+
+  assert.throws(() => walletService.decryptSecret(tamperedCiphertext));
+
+  // Flip one hex character in the auth tag itself.
+  const flippedTagChar = authTagHex[0] === '0' ? '1' : '0';
+  const tamperedTag = flippedTagChar + authTagHex.slice(1);
+  const tamperedAuthTag = `${ivHex}:${tamperedTag}:${cipherHex}`;
+
+  assert.throws(() => walletService.decryptSecret(tamperedAuthTag));
+
+  t.after(() => {
+    delete process.env.WALLET_ENCRYPTION_KEY;
+  });
+});
+
+test('decryptSecret throws on malformed input missing the expected iv:authTag:ciphertext parts', (t) => {
+  const walletService = freshWalletService(FAKE_KEY_HEX);
+
+  assert.throws(() => walletService.decryptSecret('not-encrypted-data'));
+  assert.throws(() => walletService.decryptSecret(''));
+
+  t.after(() => {
+    delete process.env.WALLET_ENCRYPTION_KEY;
+  });
+});


### PR DESCRIPTION
addresses #466

## Summary
Adds 18 tests covering the two security-sensitive items #466 flags as high priority: the wallet secret encryption service and the wallets router (including the wallet recovery endpoint). Scoped deliberately to keep the PR reviewable; happy to follow up with further slices from the issue list (auth routes next, noting users.test.js already covers part of auth).

## Changes
- `backend/src/services/walletService.test.js` (3 tests): encrypt/decrypt round-trip through the `iv:authTag:ciphertext` envelope, GCM tamper detection, and malformed-input rejection.
- `backend/src/routes/wallets.test.js` (15 tests): `GET /:campaignId/config`, `/transactions`, `/payments` and `POST /:campaignId/recover`, each covering the happy path plus 404 unknown campaign and 403 non-owner, with default and custom `?limit=` on the list endpoints, and 400 when no encrypted secret is stored on recover.

Follows the repo's existing colocated `<name>.test.js` convention (`node --test`, supertest, `proxyquire(...).noCallThru()`, stubbed `../config/database` and `../middleware/auth`). No application source changed. Test fixtures use obviously fake keys and secrets.

## Finding: `routes/wallets.js` is never mounted
While writing these tests I found that `backend/src/routes/wallets.js` is not wired into the app. `backend/src/index.js` mounts 25 route modules via `app.use(...)`; wallets is not among them, and a grep of `backend/src` found no other file requiring or mounting it (no separate `app.js`, `index.js` is the sole entry point).

Practical effect: `POST /:campaignId/recover`, which decrypts a campaign's wallet secret and returns the raw Stellar keypair, is currently unreachable in the running application, as are the config/transactions/payments read endpoints. The router itself looks production-ready (auth, ownership checks, and error handling are all present), so this appears unintentional rather than deliberate.

These tests mount the router directly in an isolated test app, the same way the repo's other route tests work, so they verify the router behaves correctly, not that it is served. Wiring it up (choosing the mount path, checking for route collisions) is an application change and out of scope for a test-coverage PR, so I have left it alone and am flagging it for a maintainer decision. The test file carries a header comment stating the same, so future readers don't mistake these for end-to-end coverage. Happy to open a separate issue or PR for the mounting if useful.

## Notes for reviewers
- `npm test` currently hangs indefinitely: the pre-existing `src/routes/users.test.js` leaves two self-connected TCP sockets open (a supertest keep-alive handle leak), and since `node --test` runs each file in its own child process the suite never exits. Running `node --test --test-force-exit` (a runtime flag only, no script or source change) lets it complete. Worth addressing separately, as it affects any contributor or CI run.
- With force-exit, the full suite is 271 tests, 263 passing, 8 failing. All 8 failures are in files this PR does not touch (`sanitize`, `middleware/auth`, `routes/admin`, `routes/users` x2, `services/referralService` x2, `services/userDashboard`). Several are `ECONNREFUSED 127.0.0.1:5432` (no local Postgres in my sandbox) and others look like assertions that have drifted from the current source. None reference `walletService.js` or `wallets.js`, and `node --test` isolates each file per process, so they are independent of this change.
- The new tests pass in isolation: 18/18.