### PR TITLE
feat(#471): harden wallet recovery endpoint with admin access, rate limiting, and audit logging

### DIFF
--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1126,3 +1126,4 @@ router.get('/campaigns/:id/contributions', async (req, res) => {
 });
 
 module.exports = router;
+module.exports.logAdminAction = logAdminAction;

--- a/backend/src/routes/wallets.js
+++ b/backend/src/routes/wallets.js
@@ -1,6 +1,8 @@
 const router = require('express').Router();
+const rateLimit = require('express-rate-limit');
 const db = require('../config/database');
 const { requireAuth } = require('../middleware/auth');
+const { logAdminAction } = require('./admin');
 const {
   getAccountMultisigConfig,
   getWalletTransactionHistory,
@@ -9,6 +11,16 @@ const {
 } = require('../services/stellarService');
 const { decryptSecret } = require('../services/walletService');
 
+const isTest = process.env.NODE_ENV === 'test';
+const recoverLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: isTest ? 100000 : 3,
+  message: { error: 'Too many requests, please try again later.' },
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => isTest,
+});
+
 // Get wallet configuration (signers, thresholds)
 router.get('/:campaignId/config', requireAuth, async (req, res) => {
   const { rows } = await db.query(
@@ -16,7 +28,7 @@ router.get('/:campaignId/config', requireAuth, async (req, res) => {
     [req.params.campaignId]
   );
   if (!rows.length) return res.status(404).json({ error: 'Campaign not found' });
-  if (rows[0].creator_id !== req.user.userId) {
+  if (rows[0].creator_id !== req.user.userId && req.user.role !== 'admin') {
     return res.status(403).json({ error: 'Unauthorized' });
   }
 
@@ -31,7 +43,7 @@ router.get('/:campaignId/transactions', requireAuth, async (req, res) => {
     [req.params.campaignId]
   );
   if (!rows.length) return res.status(404).json({ error: 'Campaign not found' });
-  if (rows[0].creator_id !== req.user.userId) {
+  if (rows[0].creator_id !== req.user.userId && req.user.role !== 'admin') {
     return res.status(403).json({ error: 'Unauthorized' });
   }
 
@@ -47,7 +59,7 @@ router.get('/:campaignId/payments', requireAuth, async (req, res) => {
     [req.params.campaignId]
   );
   if (!rows.length) return res.status(404).json({ error: 'Campaign not found' });
-  if (rows[0].creator_id !== req.user.userId) {
+  if (rows[0].creator_id !== req.user.userId && req.user.role !== 'admin') {
     return res.status(403).json({ error: 'Unauthorized' });
   }
 
@@ -56,14 +68,22 @@ router.get('/:campaignId/payments', requireAuth, async (req, res) => {
   res.json(payments);
 });
 
-// Recover wallet keypair (admin only - requires encrypted secret)
-router.post('/:campaignId/recover', requireAuth, async (req, res) => {
+// Recover wallet keypair (owner or admin; requires encrypted secret)
+router.post('/:campaignId/recover', recoverLimiter, requireAuth, async (req, res) => {
   const { rows } = await db.query(
     'SELECT wallet_secret_encrypted, creator_id FROM campaigns WHERE id = $1',
     [req.params.campaignId]
   );
   if (!rows.length) return res.status(404).json({ error: 'Campaign not found' });
-  if (rows[0].creator_id !== req.user.userId) {
+
+  const isOwner = rows[0].creator_id === req.user.userId;
+  const isAdmin = req.user.role === 'admin';
+  if (!isOwner && !isAdmin) {
+    await logAdminAction(req.user.userId, 'wallet_recover', 'campaign', req.params.campaignId, {
+      campaignId: req.params.campaignId,
+      outcome: 'denied',
+      requesterId: req.user.userId,
+    });
     return res.status(403).json({ error: 'Unauthorized' });
   }
   if (!rows[0].wallet_secret_encrypted) {
@@ -72,6 +92,11 @@ router.post('/:campaignId/recover', requireAuth, async (req, res) => {
 
   const secret = decryptSecret(rows[0].wallet_secret_encrypted);
   const wallet = recoverWalletFromSecret(secret);
+  await logAdminAction(req.user.userId, 'wallet_recover', 'campaign', req.params.campaignId, {
+    campaignId: req.params.campaignId,
+    outcome: 'success',
+    requesterId: req.user.userId,
+  });
   res.json({ publicKey: wallet.publicKey });
 });
 

--- a/backend/src/routes/wallets.recovery.test.js
+++ b/backend/src/routes/wallets.recovery.test.js
@@ -1,0 +1,292 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const proxyquire = require('proxyquire').noCallThru();
+
+// Complements backend/src/routes/wallets.test.js (from PR #466, which covers the
+// happy path, 400 no-secret, 404 unknown campaign, and 403 non-owner). This file
+// covers the controls added for issue #471: 401 unauthenticated, owner-or-admin
+// access, rate limiting, and audit logging on /recover.
+
+// wallets.js reads process.env.NODE_ENV once, at require time, to size its rate
+// limiter. Force NODE_ENV to 'test' here so this file's assertions hold regardless
+// of how it's invoked (npm test vs. a direct `node --test` on this file), matching
+// what npm test's env wrapper already guarantees. Restored after all tests in this
+// file run so nothing leaks to a process that reuses this env (e.g. a direct,
+// single-file `node --test` invocation of multiple suites).
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+process.env.NODE_ENV = 'test';
+test.after(() => {
+  process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+});
+
+function buildApp({
+  queryImpl,
+  authUser,
+  authError,
+  rateLimitStub,
+  stellarServiceImpl = {},
+  walletServiceImpl = {},
+} = {}) {
+  const logCalls = [];
+  const router = proxyquire('./wallets', {
+    '../config/database': {
+      query: queryImpl,
+    },
+    '../middleware/auth': {
+      requireAuth: (req, res, next) => {
+        if (authError) {
+          return res.status(401).json({ error: authError });
+        }
+        req.user = authUser || { userId: 'owner-1', role: 'creator' };
+        next();
+      },
+    },
+    './admin': {
+      logAdminAction: async (...args) => {
+        logCalls.push(args);
+      },
+    },
+    '../services/stellarService': {
+      getAccountMultisigConfig: async () => ({ signers: [], thresholds: {} }),
+      getWalletTransactionHistory: async () => [],
+      getWalletPayments: async () => [],
+      recoverWalletFromSecret: () => ({ publicKey: 'GRECOVEREDPUBLICKEYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' }),
+      ...stellarServiceImpl,
+    },
+    '../services/walletService': {
+      decryptSecret: () => 'SFAKESECRETSEEDVALUENOTREALNOTREALNOTREALNOTREALNOTRE',
+      ...walletServiceImpl,
+    },
+    ...(rateLimitStub ? { 'express-rate-limit': rateLimitStub } : {}),
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/wallets', router);
+  return { app, logCalls };
+}
+
+// --- 401 unauthenticated ---
+
+test('GET /:campaignId/config returns 401 when unauthenticated', async () => {
+  const { app } = buildApp({ authError: 'Missing token' });
+  const res = await request(app).get('/api/wallets/camp-1/config');
+  assert.equal(res.status, 401);
+});
+
+test('GET /:campaignId/transactions returns 401 when unauthenticated', async () => {
+  const { app } = buildApp({ authError: 'Missing token' });
+  const res = await request(app).get('/api/wallets/camp-1/transactions');
+  assert.equal(res.status, 401);
+});
+
+test('GET /:campaignId/payments returns 401 when unauthenticated', async () => {
+  const { app } = buildApp({ authError: 'Missing token' });
+  const res = await request(app).get('/api/wallets/camp-1/payments');
+  assert.equal(res.status, 401);
+});
+
+test('POST /:campaignId/recover returns 401 when unauthenticated', async () => {
+  const { app } = buildApp({ authError: 'Missing token' });
+  const res = await request(app).post('/api/wallets/camp-1/recover');
+  assert.equal(res.status, 401);
+});
+
+// --- owner-or-admin access ---
+
+test('GET /:campaignId/config allows an admin who does not own the campaign', async () => {
+  const { app } = buildApp({
+    authUser: { userId: 'admin-1', role: 'admin' },
+    queryImpl: async () => ({ rows: [{ wallet_public_key: 'GPUBKEY', creator_id: 'owner-1' }] }),
+  });
+  const res = await request(app).get('/api/wallets/camp-1/config');
+  assert.equal(res.status, 200);
+});
+
+test('GET /:campaignId/transactions allows an admin who does not own the campaign', async () => {
+  const { app } = buildApp({
+    authUser: { userId: 'admin-1', role: 'admin' },
+    queryImpl: async () => ({ rows: [{ wallet_public_key: 'GPUBKEY', creator_id: 'owner-1' }] }),
+  });
+  const res = await request(app).get('/api/wallets/camp-1/transactions');
+  assert.equal(res.status, 200);
+});
+
+test('GET /:campaignId/payments allows an admin who does not own the campaign', async () => {
+  const { app } = buildApp({
+    authUser: { userId: 'admin-1', role: 'admin' },
+    queryImpl: async () => ({ rows: [{ wallet_public_key: 'GPUBKEY', creator_id: 'owner-1' }] }),
+  });
+  const res = await request(app).get('/api/wallets/camp-1/payments');
+  assert.equal(res.status, 200);
+});
+
+test('POST /:campaignId/recover allows an admin who does not own the campaign', async () => {
+  const { app, logCalls } = buildApp({
+    authUser: { userId: 'admin-1', role: 'admin' },
+    queryImpl: async () => ({ rows: [{ wallet_secret_encrypted: 'ENCRYPTEDBLOB', creator_id: 'owner-1' }] }),
+  });
+  const res = await request(app).post('/api/wallets/camp-1/recover');
+  assert.equal(res.status, 200);
+  assert.equal(res.body.publicKey, 'GRECOVEREDPUBLICKEYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+  assert.equal(logCalls.length, 1);
+});
+
+test('POST /:campaignId/recover still rejects a non-owner, non-admin user', async () => {
+  const { app, logCalls } = buildApp({
+    authUser: { userId: 'stranger-1', role: 'contributor' },
+    queryImpl: async () => ({ rows: [{ wallet_secret_encrypted: 'ENCRYPTEDBLOB', creator_id: 'owner-1' }] }),
+  });
+  const res = await request(app).post('/api/wallets/camp-1/recover');
+  assert.equal(res.status, 403);
+  assert.equal(logCalls.length, 1);
+});
+
+// --- audit logging on /recover ---
+
+test('POST /:campaignId/recover logs a denied attempt for a non-owner, non-admin requester', async () => {
+  const { app, logCalls } = buildApp({
+    authUser: { userId: 'stranger-1', role: 'contributor' },
+    queryImpl: async () => ({ rows: [{ wallet_secret_encrypted: 'ENCRYPTEDBLOB', creator_id: 'owner-1' }] }),
+  });
+  const res = await request(app).post('/api/wallets/camp-1/recover');
+  assert.equal(res.status, 403);
+
+  assert.equal(logCalls.length, 1);
+  const [adminUserId, actionType, targetType, targetId, details] = logCalls[0];
+  assert.equal(adminUserId, 'stranger-1');
+  assert.equal(actionType, 'wallet_recover');
+  assert.equal(targetType, 'campaign');
+  assert.equal(targetId, 'camp-1');
+  assert.equal(details.outcome, 'denied');
+  assert.equal(details.requesterId, 'stranger-1');
+  assert.equal(details.campaignId, 'camp-1');
+});
+
+test('POST /:campaignId/recover logs a success attempt for the owner', async () => {
+  const { app, logCalls } = buildApp({
+    authUser: { userId: 'owner-1', role: 'creator' },
+    queryImpl: async () => ({ rows: [{ wallet_secret_encrypted: 'ENCRYPTEDBLOB', creator_id: 'owner-1' }] }),
+  });
+  const res = await request(app).post('/api/wallets/camp-1/recover');
+  assert.equal(res.status, 200);
+
+  assert.equal(logCalls.length, 1);
+  const [adminUserId, actionType, targetType, targetId, details] = logCalls[0];
+  assert.equal(adminUserId, 'owner-1');
+  assert.equal(actionType, 'wallet_recover');
+  assert.equal(targetType, 'campaign');
+  assert.equal(targetId, 'camp-1');
+  assert.equal(details.outcome, 'success');
+  assert.equal(details.requesterId, 'owner-1');
+});
+
+test('POST /:campaignId/recover does not write an audit entry when there is no stored secret', async () => {
+  const { app, logCalls } = buildApp({
+    authUser: { userId: 'owner-1', role: 'creator' },
+    queryImpl: async () => ({ rows: [{ wallet_secret_encrypted: null, creator_id: 'owner-1' }] }),
+  });
+  const res = await request(app).post('/api/wallets/camp-1/recover');
+  assert.equal(res.status, 400);
+  assert.equal(logCalls.length, 0);
+});
+
+test('POST /:campaignId/recover audit details never include the decrypted secret or key material', async () => {
+  const { app, logCalls } = buildApp({
+    authUser: { userId: 'owner-1', role: 'creator' },
+    queryImpl: async () => ({ rows: [{ wallet_secret_encrypted: 'ENCRYPTEDBLOB', creator_id: 'owner-1' }] }),
+    walletServiceImpl: { decryptSecret: () => 'SSUPERSECRETSEEDVALUENOTREALNOTREALNOTREALNOTREALNOTR' },
+  });
+  const res = await request(app).post('/api/wallets/camp-1/recover');
+  assert.equal(res.status, 200);
+
+  const details = logCalls[0][4];
+  const serialized = JSON.stringify(details);
+  assert.ok(!serialized.includes('SSUPERSECRETSEEDVALUENOTREALNOTREALNOTREALNOTREALNOTR'));
+  assert.ok(!serialized.includes(res.body.publicKey));
+  assert.deepEqual(Object.keys(details).sort(), ['campaignId', 'outcome', 'requesterId']);
+});
+
+// --- rate limiting on /recover ---
+//
+// The route wires up a module-level `rateLimit(...)` call at require time, and
+// `isTest` is read from process.env.NODE_ENV once, at that same moment. Rather than
+// flip NODE_ENV around real requests (which risks leaking into other tests running
+// in this process) or trying to force a genuine 429 while NODE_ENV=test disables the
+// limiter, we proxyquire 'express-rate-limit' with a stub that just records the
+// config object it was constructed with, and assert on that. The one place we do
+// toggle NODE_ENV, we do it synchronously around a single proxyquire call with no
+// `await` in between, so no other test can observe the mutated value.
+
+test('recover rate limiter is constructed mirroring the contributions.js limiter shape', () => {
+  let capturedConfig = null;
+  const rateLimitStub = (config) => {
+    capturedConfig = config;
+    return (req, res, next) => next();
+  };
+
+  proxyquire('./wallets', {
+    'express-rate-limit': rateLimitStub,
+    '../config/database': { query: async () => ({ rows: [] }) },
+    '../middleware/auth': { requireAuth: (req, res, next) => next() },
+    './admin': { logAdminAction: async () => {} },
+    '../services/stellarService': {},
+    '../services/walletService': {},
+  });
+
+  assert.ok(capturedConfig);
+  assert.equal(capturedConfig.windowMs, 60 * 1000);
+  assert.equal(capturedConfig.standardHeaders, true);
+  assert.equal(capturedConfig.legacyHeaders, false);
+  assert.deepEqual(capturedConfig.message, { error: 'Too many requests, please try again later.' });
+  assert.equal(typeof capturedConfig.skip, 'function');
+  // NODE_ENV is forced to 'test' at the top of this file, so isTest is true here.
+  assert.equal(capturedConfig.max, 100000);
+  assert.equal(capturedConfig.skip(), true);
+});
+
+test('recover rate limiter caps at 3/min outside test mode', () => {
+  let capturedConfig = null;
+  const rateLimitStub = (config) => {
+    capturedConfig = config;
+    return (req, res, next) => next();
+  };
+
+  const originalNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'production';
+  try {
+    proxyquire('./wallets', {
+      'express-rate-limit': rateLimitStub,
+      '../config/database': { query: async () => ({ rows: [] }) },
+      '../middleware/auth': { requireAuth: (req, res, next) => next() },
+      './admin': { logAdminAction: async () => {} },
+      '../services/stellarService': {},
+      '../services/walletService': {},
+    });
+  } finally {
+    process.env.NODE_ENV = originalNodeEnv;
+  }
+
+  assert.ok(capturedConfig);
+  assert.equal(capturedConfig.max, 3);
+  assert.equal(capturedConfig.skip(), false);
+});
+
+test('POST /:campaignId/recover runs requests through the rate limiter middleware', async () => {
+  let limiterInvocations = 0;
+  const rateLimitStub = () => (req, res, next) => {
+    limiterInvocations += 1;
+    next();
+  };
+  const { app } = buildApp({
+    authUser: { userId: 'owner-1', role: 'creator' },
+    queryImpl: async () => ({ rows: [{ wallet_secret_encrypted: 'ENCRYPTEDBLOB', creator_id: 'owner-1' }] }),
+    rateLimitStub,
+  });
+
+  const res = await request(app).post('/api/wallets/camp-1/recover');
+  assert.equal(res.status, 200);
+  assert.equal(limiterInvocations, 1);
+});


### PR DESCRIPTION
Closes #471

## Summary
`POST /:campaignId/recover` decrypts a campaign's wallet secret and returns the recovered keypair's public key. On main it is protected by `requireAuth` plus an inline ownership check only, with no rate limiting, no audit logging, and no admin access, despite its own comment claiming `admin only`. This PR implements those controls and adds tests for them.

Because the controls #471 asks to verify did not exist, this is a small security-hardening change plus tests, rather than a tests-only PR.

## Changes

**`backend/src/routes/wallets.js`**
- Owner-or-admin authorization on all four wallet routes (`/config`, `/transactions`, `/payments`, `/recover`), using the codebase's dominant `req.user.role === 'admin'` convention. Applied to all four rather than only `/recover`, since an admin who can already recover the secret gains nothing from being blocked on the read-only routes, and it keeps the ownership logic uniform.
- Dedicated per-route rate limiter on `/recover`: 3 requests/minute, mirroring the existing `contributions.js` limiter shape (`express-rate-limit`, already a dependency, with the same `skip`-in-test behaviour). Stricter than the 5/min used there because this endpoint returns key material. The read routes are left to the global `/api` limiter.
- Audit logging of recovery attempts, both successful and denied (403), via the existing `admin_actions` table and `logAdminAction` helper.
- Corrected the stale `admin only` comment to match the behaviour now implemented.

**`backend/src/routes/admin.js`** — exports the existing `logAdminAction` helper (one added line, no behavioural change) so wallets can reuse it rather than duplicating audit-log logic.

**`backend/src/routes/wallets.recovery.test.js`** (new, 16 tests) — 401 unauthenticated, admin bypass where a non-owner non-admin would be denied, rate limiter configuration, and audit logging on both success and denial, including an assertion that no secret or derived key material appears in the logged details.

## Security notes
- No key material is logged. The audit `details` payload contains only `campaignId`, `outcome`, and `requesterId`. The decrypted secret exists only between `decryptSecret` and `recoverWalletFromSecret`, and the response still returns `publicKey` only.
- Denied attempts are logged before the 403 is returned, so unauthorised access attempts are captured.
- Requests for a non-existent campaign return 404 before any logging, so probes against unknown campaign ids are not audited. That seemed right (there is no access decision to record), but happy to change it if you'd prefer probe attempts captured too.

## Points for maintainer review
- **Reuse of `admin_actions`.** This table already exists and its `target_type` check permits `'campaign'`, so no migration is needed. The caveat is that a denied non-admin attempt writes that user's id into `admin_user_id`, which stretches the column's original meaning. I chose reuse over introducing a new table or migration, but if you'd rather have a dedicated wallet-access audit table, say the word and I'll switch it.
- **Rate limit value.** 3/min is my judgement for an endpoint that returns key material. Easy to adjust.

## Relationship to #466
My open PR for #466 adds `backend/src/routes/wallets.test.js`, covering this router's happy path, 400 no-secret, 404 unknown campaign, and 403 non-owner. This PR deliberately uses a separate filename (`wallets.recovery.test.js`) so the two do not collide, and does not duplicate those cases. The two are independent and can merge in either order.

## Note: this router is still not mounted
`backend/src/routes/wallets.js` is not wired into `backend/src/index.js` (25 other route modules are; a grep of `backend/src` finds nothing requiring or mounting this one), so these endpoints are currently unreachable in the running app. This PR hardens the router but does not mount it, since choosing a mount path and checking for route collisions is an application decision. Flagged in more detail in the #466 PR. Happy to open a follow-up for the mounting if useful.

## Verification
- New tests: 16/16 passing, verified both with `NODE_ENV` unset and through the `npm test` env wrapper.
- Full suite unchanged at 261 passing / 8 failing; all 8 failures are pre-existing and in files this PR does not touch (`sanitize`, `middleware/auth`, `routes/admin` env, `routes/users` x2, `services/referralService` x2, `services/userDashboard`), several from `ECONNREFUSED 127.0.0.1:5432` with no local Postgres. Verified `routes/admin.test.js` fails identically on an unmodified branch, so the `admin.js` export does not cause it.
- Note `npm test` hangs without `--test-force-exit` due to a pre-existing keep-alive socket leak in `users.test.js`.