### PR TITLE
feat: implement incoming webhook processing

### DIFF
--- a/backend/src/routes/webhooks.js
+++ b/backend/src/routes/webhooks.js
@@ -5,7 +5,11 @@ const db = require('../config/database');
 const logger = require('../config/logger');
 const { requireAuth } = require('../middleware/auth');
 const { ALL_WEBHOOK_EVENTS, processDelivery } = require('../services/webhookDispatcher');
-const { processIncomingWebhook } = require('../services/webhookService');
+const {
+  processIncomingWebhook,
+  verifyWebhookSignature,
+  WebhookError,
+} = require('../services/webhookService');
 
 function isValidWebhookUrl(urlString) {
   try {
@@ -34,7 +38,7 @@ function normalizeEvents(events) {
 router.post('/incoming/:id', express.raw({ type: 'application/json' }), async (req, res) => {
   try {
     const { rows } = await db.query(
-      `SELECT secret FROM webhooks WHERE id = $1 AND revoked_at IS NULL`,
+      `SELECT id, user_id, secret FROM webhooks WHERE id = $1 AND revoked_at IS NULL`,
       [req.params.id]
     );
 
@@ -44,7 +48,7 @@ router.post('/incoming/:id', express.raw({ type: 'application/json' }), async (r
 
     const webhook = rows[0];
     const rawBody = req.body;
-    
+
     // Some services might use variations like X-Signature-256 or x-signature
     const headerSig = req.headers['x-signature-256'] || req.headers['x-signature'];
 
@@ -52,12 +56,8 @@ router.post('/incoming/:id', express.raw({ type: 'application/json' }), async (r
       return res.status(401).json({ error: 'Missing signature header' });
     }
 
-    const expectedSig = crypto
-      .createHmac('sha256', webhook.secret)
-      .update(rawBody)
-      .digest('hex');
-
-    if (expectedSig !== headerSig) {
+    // Constant-time HMAC-SHA256 comparison (tolerates a `sha256=` prefix).
+    if (!verifyWebhookSignature(webhook.secret, rawBody, headerSig)) {
       logger.warn('Failed webhook signature verification', { webhookId: req.params.id });
       return res.status(401).json({ error: 'Invalid signature' });
     }
@@ -69,10 +69,20 @@ router.post('/incoming/:id', express.raw({ type: 'application/json' }), async (r
       return res.status(400).json({ error: 'Invalid JSON payload' });
     }
 
-    await processIncomingWebhook(req.params.id, payload);
+    const result = await processIncomingWebhook(webhook.id, payload, {
+      ownerUserId: webhook.user_id,
+    });
 
-    res.status(200).json({ success: true });
+    res.status(200).json({ success: true, ...result });
   } catch (err) {
+    if (err instanceof WebhookError) {
+      logger.warn('Rejected incoming webhook', {
+        webhookId: req.params.id,
+        status: err.status,
+        error: err.message,
+      });
+      return res.status(err.status).json({ error: err.message });
+    }
     logger.error('Error processing incoming webhook', { error: err.message, webhookId: req.params.id });
     res.status(500).json({ error: 'Internal server error' });
   }

--- a/backend/src/routes/webhooks.test.js
+++ b/backend/src/routes/webhooks.test.js
@@ -1,5 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const crypto = require('crypto');
 const express = require('express');
 const request = require('supertest');
 const proxyquire = require('proxyquire').noCallThru();
@@ -47,4 +48,109 @@ test('POST /api/webhooks/deliveries/:id/replay requeues a failed delivery for th
 
   assert.equal(res.body.message, 'Replay queued');
   assert.deepEqual(queued, ['delivery-1']);
+});
+
+// --- POST /api/webhooks/incoming/:id (signature + dispatch) ------------------
+
+const WEBHOOK_ID = 'wh-1';
+const OWNER = 'owner-1';
+const SECRET = 'whsec_test';
+
+// Wire the incoming route to the REAL webhookService (so signature verification
+// and type routing are exercised end-to-end), backed by a scripted db. The
+// webhook-secret lookup returns `webhookRow`; every other query is resolved by
+// `serviceQuery` so handlers can be steered per test.
+function buildIncomingApp({
+  webhookRow = { id: WEBHOOK_ID, user_id: OWNER, secret: SECRET },
+  serviceQuery = async () => ({ rows: [] }),
+} = {}) {
+  const router = proxyquire('./webhooks', {
+    '../config/database': {
+      query: async (sql, params) => {
+        if (sql.includes('FROM webhooks WHERE id = $1 AND revoked_at IS NULL')) {
+          return { rows: webhookRow ? [webhookRow] : [] };
+        }
+        return serviceQuery(sql, params);
+      },
+    },
+    '../middleware/auth': { requireAuth: (req, _res, next) => next() },
+    '../services/webhookDispatcher': { ALL_WEBHOOK_EVENTS: [], processDelivery: async () => {} },
+    '../services/webhookService': proxyquire('../services/webhookService', {
+      '../config/database': { query: async (sql, params) => serviceQuery(sql, params) },
+      '../config/logger': { info: () => {}, warn: () => {}, error: () => {} },
+      './notifications': { createNotification: async () => {} },
+    }),
+  });
+
+  const app = express();
+  app.use('/api/webhooks', router);
+  return { app };
+}
+
+function sign(secret, body) {
+  return crypto.createHmac('sha256', secret).update(body).digest('hex');
+}
+
+function post(app, body, sig) {
+  const req = request(app)
+    .post(`/api/webhooks/incoming/${WEBHOOK_ID}`)
+    .set('Content-Type', 'application/json');
+  if (sig !== null) req.set('x-signature-256', sig);
+  return req.send(body);
+}
+
+test('POST /incoming/:id returns 404 when the webhook is unknown', async () => {
+  const { app } = buildIncomingApp({ webhookRow: null });
+  await post(app, '{}', 'whatever').expect(404);
+});
+
+test('POST /incoming/:id returns 401 when the signature header is missing', async () => {
+  const { app } = buildIncomingApp();
+  await post(app, '{}', null).expect(401);
+});
+
+test('POST /incoming/:id returns 401 on an invalid signature', async () => {
+  const { app } = buildIncomingApp();
+  const body = JSON.stringify({ type: 'contribution.confirmed', tx_hash: 't' });
+  await post(app, body, 'deadbeef').expect(401);
+});
+
+test('POST /incoming/:id returns 400 on malformed JSON with a valid signature', async () => {
+  const { app } = buildIncomingApp();
+  const body = 'not-json';
+  await post(app, body, sign(SECRET, Buffer.from(body))).expect(400);
+});
+
+test('POST /incoming/:id returns 400 for an unknown event type', async () => {
+  const { app } = buildIncomingApp();
+  const body = JSON.stringify({ type: 'totally.unknown' });
+  const res = await post(app, body, sign(SECRET, Buffer.from(body))).expect(400);
+  assert.match(res.body.error, /Unsupported/);
+});
+
+test('POST /incoming/:id acknowledges a valid contribution.confirmed for an un-indexed tx', async () => {
+  // No matching contribution → handler returns 202, wrapped in a 200 envelope.
+  const { app } = buildIncomingApp({ serviceQuery: async () => ({ rows: [] }) });
+  const body = JSON.stringify({ type: 'contribution.confirmed', tx_hash: 'tx-unknown' });
+  const res = await post(app, body, sign(SECRET, Buffer.from(body))).expect(200);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.status, 202);
+  assert.equal(res.body.body.linked, false);
+});
+
+test('POST /incoming/:id links a matching contribution and returns success', async () => {
+  const { app } = buildIncomingApp({
+    serviceQuery: async (sql) => {
+      if (sql.includes('FROM contributions')) {
+        return { rows: [{ id: 'c-1', campaign_id: 'cam-1', amount: '10', asset: 'USDC', title: 'T' }] };
+      }
+      return { rows: [] };
+    },
+  });
+  const body = JSON.stringify({ type: 'contribution.confirmed', tx_hash: 'tx-1' });
+  const res = await post(app, body, sign(SECRET, Buffer.from(body))).expect(200);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.status, 200);
+  assert.equal(res.body.body.linked, true);
+  assert.equal(res.body.body.contribution_id, 'c-1');
 });

--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -1,13 +1,341 @@
+const crypto = require('crypto');
+const db = require('../config/database');
 const logger = require('../config/logger');
+const { createNotification } = require('./notifications');
 
-async function processIncomingWebhook(webhookId, payload) {
-  logger.info('Processing incoming webhook', { webhookId, eventType: payload.type });
-  // TODO: Implement state transitions here based on payload.type
-  // e.g., marking a contribution as complete, triggering a withdrawal
-  
-  return true;
+// Event types accepted on the inbound webhook endpoint (POST /api/webhooks/incoming/:id).
+// These are distinct from the OUTBOUND events in webhookDispatcher.js — inbound
+// events are state notifications pushed to us by external systems (anchors,
+// signing services, review tooling) that we reflect into local state.
+const INCOMING_WEBHOOK_EVENTS = {
+  CONTRIBUTION_CONFIRMED: 'contribution.confirmed',
+  WITHDRAWAL_COMPLETED: 'withdrawal.completed',
+  ANCHOR_DEPOSIT_UPDATED: 'anchor.deposit.updated',
+  MILESTONE_APPROVED: 'milestone.approved',
+  MILESTONE_REJECTED: 'milestone.rejected',
+};
+
+/**
+ * Error type for client-side (4xx) webhook problems — malformed payloads,
+ * unknown event types, or resources that don't belong to the webhook owner.
+ * The route maps `.status` onto the HTTP response. Anything that throws
+ * WITHOUT a status (e.g. a DB failure) surfaces as a 500 so the sender
+ * retries — inbound retry is driven by the caller reacting to non-2xx.
+ */
+class WebhookError extends Error {
+  constructor(message, status = 400) {
+    super(message);
+    this.name = 'WebhookError';
+    this.status = status;
+  }
+}
+
+/**
+ * Timing-safe HMAC-SHA256 verification for inbound webhook bodies.
+ * Accepts an optional `sha256=` prefix on the header (GitHub/Stripe style).
+ * `rawBody` must be the exact bytes that were signed (a Buffer or string).
+ *
+ * @returns {boolean} true iff the signature matches.
+ */
+function verifyWebhookSignature(secret, rawBody, headerSig) {
+  if (!secret || !headerSig) return false;
+
+  const provided = String(headerSig).replace(/^sha256=/i, '').trim();
+  const expected = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+
+  // timingSafeEqual throws on length mismatch, so guard first. Both sides are
+  // hex of a fixed-length digest, so an unequal length is already a mismatch.
+  const expectedBuf = Buffer.from(expected, 'hex');
+  let providedBuf;
+  try {
+    providedBuf = Buffer.from(provided, 'hex');
+  } catch {
+    return false;
+  }
+  if (expectedBuf.length !== providedBuf.length || providedBuf.length === 0) {
+    return false;
+  }
+  return crypto.timingSafeEqual(expectedBuf, providedBuf);
+}
+
+/**
+ * Confirmation that an on-chain contribution settled.
+ *
+ * Idempotent LINK ONLY: the authoritative record of a contribution and the
+ * campaign `raised_amount` is owned by the Horizon listener (ledgerMonitor) and
+ * the 15-minute reconciliation job. An inbound webhook must never add money —
+ * doing so would double-count the same payment. Here we only verify the
+ * contribution exists under one of the owner's campaigns and notify; if it
+ * hasn't been indexed on-chain yet we acknowledge without side effects.
+ */
+async function handleContributionConfirmed(ownerUserId, payload) {
+  const txHash = payload.tx_hash || payload.txHash;
+  if (!txHash) {
+    throw new WebhookError('contribution.confirmed requires tx_hash');
+  }
+
+  const { rows } = await db.query(
+    `SELECT c.id, c.campaign_id, c.amount, c.asset, cam.title
+     FROM contributions c
+     JOIN campaigns cam ON cam.id = c.campaign_id
+     WHERE c.tx_hash = $1 AND cam.creator_id = $2`,
+    [txHash, ownerUserId]
+  );
+
+  if (!rows.length) {
+    // Not yet indexed by the on-chain listener (or not this owner's). Acknowledge
+    // so the sender doesn't retry forever; reconciliation is the source of truth.
+    logger.info('Incoming contribution.confirmed not yet indexed', { ownerUserId, txHash });
+    return { status: 202, body: { received: true, linked: false } };
+  }
+
+  const contribution = rows[0];
+
+  // Idempotent: mark the tracked stellar_transaction indexed if it isn't already.
+  // Never mutates raised_amount.
+  await db.query(
+    `UPDATE stellar_transactions
+     SET status = 'indexed', contribution_id = $1, updated_at = NOW()
+     WHERE tx_hash = $2 AND kind = 'contribution' AND status <> 'indexed'`,
+    [contribution.id, txHash]
+  );
+
+  await createNotification(ownerUserId, {
+    type: 'contribution_confirmed',
+    title: 'Contribution confirmed',
+    body: `A contribution of ${contribution.amount} ${contribution.asset} to "${contribution.title}" was confirmed on-chain.`,
+    link: `/campaigns/${contribution.campaign_id}`,
+  }).catch((err) => logger.error('contribution.confirmed notify failed', { error: err.message }));
+
+  return { status: 200, body: { received: true, linked: true, contribution_id: contribution.id } };
+}
+
+/**
+ * External signing/broadcast service reports a withdrawal has settled on-chain.
+ * Transitions the request to `submitted` (the terminal success state) and stores
+ * the tx hash. Idempotent — a repeat delivery for an already-submitted request
+ * is a no-op that still returns 200.
+ */
+async function handleWithdrawalCompleted(ownerUserId, payload) {
+  const withdrawalId = payload.withdrawal_id || payload.withdrawalId;
+  const txHash = payload.tx_hash || payload.txHash || null;
+  if (!withdrawalId) {
+    throw new WebhookError('withdrawal.completed requires withdrawal_id');
+  }
+
+  // Scope to the owner via campaign ownership.
+  const { rows } = await db.query(
+    `UPDATE withdrawal_requests wr
+     SET status = 'submitted',
+         tx_hash = COALESCE($3, wr.tx_hash)
+     FROM campaigns c
+     WHERE wr.id = $1
+       AND wr.campaign_id = c.id
+       AND c.creator_id = $2
+       AND wr.status IN ('pending', 'submitted')
+     RETURNING wr.id, wr.campaign_id, wr.amount, wr.status, wr.tx_hash`,
+    [withdrawalId, ownerUserId, txHash]
+  );
+
+  if (!rows.length) {
+    // Either not the owner's, or in a non-completable state (failed/denied).
+    const { rows: exists } = await db.query(
+      `SELECT wr.id FROM withdrawal_requests wr
+       JOIN campaigns c ON c.id = wr.campaign_id
+       WHERE wr.id = $1 AND c.creator_id = $2`,
+      [withdrawalId, ownerUserId]
+    );
+    if (!exists.length) {
+      throw new WebhookError('Withdrawal not found', 404);
+    }
+    throw new WebhookError('Withdrawal is not in a completable state', 409);
+  }
+
+  const wr = rows[0];
+  await createNotification(ownerUserId, {
+    type: 'withdrawal_approved',
+    title: 'Withdrawal completed',
+    body: `Your withdrawal of ${wr.amount} was submitted on-chain.`,
+    link: `/campaigns/${wr.campaign_id}`,
+  }).catch((err) => logger.error('withdrawal.completed notify failed', { error: err.message }));
+
+  return { status: 200, body: { received: true, withdrawal_id: wr.id, status: wr.status } };
+}
+
+// Map a remote SEP-24 anchor transaction status onto our local anchor_deposits
+// lifecycle. Mirrors the mapping used when polling in routes/anchor.js.
+function mapAnchorStatus(remoteStatus) {
+  const s = String(remoteStatus || '').toLowerCase();
+  if (s === 'completed') return 'deposit_completed';
+  if (['error', 'expired', 'no_market', 'too_small', 'too_large', 'refunded'].includes(s)) {
+    return 'failed';
+  }
+  return null; // still pending — record last_anchor_status but don't advance local state.
+}
+
+/**
+ * SEP-24 anchor deposit status update. Records the raw remote status/payload and
+ * advances the local deposit lifecycle when the remote status is terminal.
+ * Contribution submission on top of a completed deposit remains the job of the
+ * existing anchor flow — this handler does not move funds.
+ */
+async function handleAnchorDepositUpdated(ownerUserId, payload) {
+  const anchorId = payload.anchor_id || payload.anchorId;
+  const anchorTransactionId = payload.anchor_transaction_id || payload.anchorTransactionId;
+  const remoteStatus = payload.status;
+  if (!anchorId || !anchorTransactionId) {
+    throw new WebhookError('anchor.deposit.updated requires anchor_id and anchor_transaction_id');
+  }
+
+  const localStatus = mapAnchorStatus(remoteStatus);
+
+  const { rows } = await db.query(
+    `UPDATE anchor_deposits
+     SET last_anchor_status = $3,
+         last_anchor_payload = $4::jsonb,
+         status = CASE
+           WHEN $5::text IS NOT NULL AND status NOT IN ('completed', 'failed')
+             THEN $5::text
+           ELSE status
+         END,
+         updated_at = NOW()
+     WHERE anchor_id = $1 AND anchor_transaction_id = $2 AND user_id = $6
+     RETURNING id, campaign_id, status`,
+    [
+      anchorId,
+      anchorTransactionId,
+      remoteStatus || null,
+      JSON.stringify(payload),
+      localStatus,
+      ownerUserId,
+    ]
+  );
+
+  if (!rows.length) {
+    throw new WebhookError('Anchor deposit not found', 404);
+  }
+
+  return { status: 200, body: { received: true, deposit_id: rows[0].id, status: rows[0].status } };
+}
+
+/**
+ * External review system reports a milestone approval/rejection decision.
+ *
+ * Reflects the decision into the milestone status (`pending_review` →
+ * `approved` | `rejected`) and records an audit event. It deliberately does NOT
+ * perform any on-chain release: fund release stays gated behind the platform
+ * multisig in the authenticated milestones route. This only mirrors the review
+ * outcome and notifies.
+ */
+async function handleMilestoneDecision(ownerUserId, payload, approved) {
+  const milestoneId = payload.milestone_id || payload.milestoneId;
+  if (!milestoneId) {
+    throw new WebhookError(`${payload.type} requires milestone_id`);
+  }
+  const reason = payload.reason ? String(payload.reason).trim() : null;
+  if (!approved && !reason) {
+    throw new WebhookError('milestone.rejected requires a reason');
+  }
+
+  const newStatus = approved ? 'approved' : 'rejected';
+  const { rows } = await db.query(
+    `UPDATE milestones m
+     SET status = $3,
+         review_note = $4,
+         approved_at = CASE WHEN $3 = 'approved' THEN NOW() ELSE NULL END,
+         reviewed_at = NOW()
+     FROM campaigns c
+     WHERE m.id = $1
+       AND m.campaign_id = c.id
+       AND c.creator_id = $2
+       AND m.status = 'pending_review'
+     RETURNING m.id, m.campaign_id, m.title, m.status`,
+    [milestoneId, ownerUserId, newStatus, reason]
+  );
+
+  if (!rows.length) {
+    const { rows: exists } = await db.query(
+      `SELECT m.id FROM milestones m
+       JOIN campaigns c ON c.id = m.campaign_id
+       WHERE m.id = $1 AND c.creator_id = $2`,
+      [milestoneId, ownerUserId]
+    );
+    if (!exists.length) {
+      throw new WebhookError('Milestone not found', 404);
+    }
+    throw new WebhookError('Milestone is not awaiting review', 409);
+  }
+
+  const milestone = rows[0];
+  await db.query(
+    `INSERT INTO milestone_events (milestone_id, actor_id, action, note, metadata)
+     VALUES ($1, NULL, $2, $3, $4::jsonb)`,
+    [milestone.id, newStatus, reason, JSON.stringify({ source: 'incoming_webhook' })]
+  );
+
+  await createNotification(ownerUserId, {
+    type: approved ? 'milestone_approved' : 'milestone_rejected',
+    title: approved ? 'Milestone approved' : 'Milestone rejected',
+    body: approved
+      ? `Milestone "${milestone.title}" was approved.`
+      : `Milestone "${milestone.title}" was rejected: ${reason}`,
+    link: `/campaigns/${milestone.campaign_id}`,
+  }).catch((err) => logger.error('milestone decision notify failed', { error: err.message }));
+
+  return { status: 200, body: { received: true, milestone_id: milestone.id, status: milestone.status } };
+}
+
+/**
+ * Route an inbound webhook payload to its handler based on `payload.type`.
+ * The caller (routes/webhooks.js) has already verified the HMAC signature and
+ * parsed the JSON body. All handlers are scoped to the webhook's owning user so
+ * a webhook secret can only mutate resources belonging to that user.
+ *
+ * @param {string} webhookId  the webhook whose secret authenticated this request
+ * @param {object} payload    parsed JSON body; must include a string `type`
+ * @returns {Promise<{status:number, body:object}>} HTTP status + response body
+ * @throws {WebhookError} for malformed payloads / unknown types / ownership misses
+ */
+async function processIncomingWebhook(webhookId, payload, { ownerUserId } = {}) {
+  logger.info('Processing incoming webhook', { webhookId, eventType: payload && payload.type });
+
+  if (!payload || typeof payload !== 'object' || typeof payload.type !== 'string') {
+    throw new WebhookError('Webhook payload must include a string "type"');
+  }
+
+  // The route resolves the owner from the same row it verified the signature
+  // against and passes it in. If a caller invokes this directly (e.g. tests,
+  // reprocessing) we fall back to looking it up so scoping is never skipped.
+  if (!ownerUserId) {
+    const { rows } = await db.query(
+      `SELECT user_id FROM webhooks WHERE id = $1 AND revoked_at IS NULL`,
+      [webhookId]
+    );
+    if (!rows.length) {
+      throw new WebhookError('Webhook not found', 404);
+    }
+    ownerUserId = rows[0].user_id;
+  }
+
+  switch (payload.type) {
+    case INCOMING_WEBHOOK_EVENTS.CONTRIBUTION_CONFIRMED:
+      return handleContributionConfirmed(ownerUserId, payload);
+    case INCOMING_WEBHOOK_EVENTS.WITHDRAWAL_COMPLETED:
+      return handleWithdrawalCompleted(ownerUserId, payload);
+    case INCOMING_WEBHOOK_EVENTS.ANCHOR_DEPOSIT_UPDATED:
+      return handleAnchorDepositUpdated(ownerUserId, payload);
+    case INCOMING_WEBHOOK_EVENTS.MILESTONE_APPROVED:
+      return handleMilestoneDecision(ownerUserId, payload, true);
+    case INCOMING_WEBHOOK_EVENTS.MILESTONE_REJECTED:
+      return handleMilestoneDecision(ownerUserId, payload, false);
+    default:
+      throw new WebhookError(`Unsupported webhook event type: ${payload.type}`);
+  }
 }
 
 module.exports = {
-  processIncomingWebhook
+  processIncomingWebhook,
+  verifyWebhookSignature,
+  WebhookError,
+  INCOMING_WEBHOOK_EVENTS,
 };

--- a/backend/src/services/webhookService.test.js
+++ b/backend/src/services/webhookService.test.js
@@ -1,0 +1,325 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('crypto');
+const proxyquire = require('proxyquire').noCallThru();
+
+const OWNER = 'owner-1';
+
+// Build the service with a scripted db. `handlers` is an array of
+// { match: (sql) => bool, rows: [...] } consulted in order; the first match
+// wins. Unmatched queries return { rows: [] }. Every executed query is pushed
+// to `queryLog` for assertions.
+function buildService(handlers = []) {
+  const queryLog = [];
+  const notifications = [];
+
+  const svc = proxyquire('./webhookService', {
+    '../config/database': {
+      query: async (sql, params) => {
+        queryLog.push({ sql, params });
+        for (const h of handlers) {
+          if (h.match(sql)) return { rows: h.rows };
+        }
+        return { rows: [] };
+      },
+    },
+    '../config/logger': {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+    './notifications': {
+      createNotification: async (userId, msg) => {
+        notifications.push({ userId, msg });
+      },
+    },
+  });
+
+  return { svc, queryLog, notifications };
+}
+
+// The webhook-owner lookup every processIncomingWebhook call performs.
+const ownerLookup = { match: (s) => s.includes('SELECT user_id FROM webhooks'), rows: [{ user_id: OWNER }] };
+
+// --- verifyWebhookSignature -------------------------------------------------
+
+test('verifyWebhookSignature accepts a valid HMAC-SHA256 signature', () => {
+  const { svc } = buildService();
+  const secret = 'whsec_abc';
+  const body = Buffer.from(JSON.stringify({ type: 'x' }));
+  const sig = crypto.createHmac('sha256', secret).update(body).digest('hex');
+  assert.equal(svc.verifyWebhookSignature(secret, body, sig), true);
+});
+
+test('verifyWebhookSignature tolerates a sha256= prefix', () => {
+  const { svc } = buildService();
+  const secret = 'whsec_abc';
+  const body = Buffer.from('{}');
+  const sig = crypto.createHmac('sha256', secret).update(body).digest('hex');
+  assert.equal(svc.verifyWebhookSignature(secret, body, `sha256=${sig}`), true);
+});
+
+test('verifyWebhookSignature rejects a wrong signature', () => {
+  const { svc } = buildService();
+  const body = Buffer.from('{}');
+  assert.equal(svc.verifyWebhookSignature('secret', body, 'deadbeef'), false);
+});
+
+test('verifyWebhookSignature rejects non-hex / empty / missing input', () => {
+  const { svc } = buildService();
+  const body = Buffer.from('{}');
+  assert.equal(svc.verifyWebhookSignature('secret', body, 'not-hex-zz'), false);
+  assert.equal(svc.verifyWebhookSignature('secret', body, ''), false);
+  assert.equal(svc.verifyWebhookSignature('', body, 'aa'), false);
+});
+
+// --- routing / validation ---------------------------------------------------
+
+test('processIncomingWebhook rejects a payload without a string type', async () => {
+  const { svc } = buildService([ownerLookup]);
+  await assert.rejects(() => svc.processIncomingWebhook('wh-1', {}, { ownerUserId: OWNER }), (e) => {
+    assert.equal(e.name, 'WebhookError');
+    assert.equal(e.status, 400);
+    return true;
+  });
+});
+
+test('processIncomingWebhook rejects an unknown event type', async () => {
+  const { svc } = buildService([ownerLookup]);
+  await assert.rejects(
+    () => svc.processIncomingWebhook('wh-1', { type: 'nope.unknown' }, { ownerUserId: OWNER }),
+    (e) => e.status === 400 && /Unsupported/.test(e.message)
+  );
+});
+
+test('processIncomingWebhook looks up the owner when not supplied', async () => {
+  const { svc, queryLog } = buildService([
+    ownerLookup,
+    { match: (s) => s.includes('FROM contributions'), rows: [] },
+  ]);
+  await svc.processIncomingWebhook('wh-1', { type: 'contribution.confirmed', tx_hash: 't1' });
+  assert.ok(queryLog.some((q) => q.sql.includes('SELECT user_id FROM webhooks')));
+});
+
+test('processIncomingWebhook throws 404 when the webhook owner cannot be resolved', async () => {
+  const { svc } = buildService([{ match: (s) => s.includes('SELECT user_id FROM webhooks'), rows: [] }]);
+  await assert.rejects(
+    () => svc.processIncomingWebhook('missing', { type: 'contribution.confirmed', tx_hash: 't' }),
+    (e) => e.status === 404
+  );
+});
+
+// --- contribution.confirmed -------------------------------------------------
+
+test('contribution.confirmed links an indexed contribution without touching raised_amount', async () => {
+  const { svc, queryLog, notifications } = buildService([
+    {
+      match: (s) => s.includes('FROM contributions'),
+      rows: [{ id: 'c-1', campaign_id: 'cam-1', amount: '50', asset: 'USDC', title: 'Save Bees' }],
+    },
+  ]);
+  const res = await svc.processIncomingWebhook(
+    'wh-1',
+    { type: 'contribution.confirmed', tx_hash: 'tx-1' },
+    { ownerUserId: OWNER }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(res.body.linked, true);
+  assert.equal(res.body.contribution_id, 'c-1');
+  assert.equal(notifications.length, 1);
+  // Must never mutate campaign raised_amount from an inbound webhook.
+  assert.ok(!queryLog.some((q) => /UPDATE campaigns[\s\S]*raised_amount/.test(q.sql)));
+});
+
+test('contribution.confirmed acknowledges (202) when not yet indexed', async () => {
+  const { svc, notifications } = buildService([
+    { match: (s) => s.includes('FROM contributions'), rows: [] },
+  ]);
+  const res = await svc.processIncomingWebhook(
+    'wh-1',
+    { type: 'contribution.confirmed', tx_hash: 'tx-unknown' },
+    { ownerUserId: OWNER }
+  );
+  assert.equal(res.status, 202);
+  assert.equal(res.body.linked, false);
+  assert.equal(notifications.length, 0);
+});
+
+test('contribution.confirmed requires tx_hash', async () => {
+  const { svc } = buildService([ownerLookup]);
+  await assert.rejects(
+    () => svc.processIncomingWebhook('wh-1', { type: 'contribution.confirmed' }, { ownerUserId: OWNER }),
+    (e) => e.status === 400
+  );
+});
+
+// --- withdrawal.completed ---------------------------------------------------
+
+test('withdrawal.completed transitions a pending request to submitted', async () => {
+  const { svc, notifications } = buildService([
+    {
+      match: (s) => s.includes('UPDATE withdrawal_requests'),
+      rows: [{ id: 'w-1', campaign_id: 'cam-1', amount: '100', status: 'submitted', tx_hash: 'h1' }],
+    },
+  ]);
+  const res = await svc.processIncomingWebhook(
+    'wh-1',
+    { type: 'withdrawal.completed', withdrawal_id: 'w-1', tx_hash: 'h1' },
+    { ownerUserId: OWNER }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(res.body.status, 'submitted');
+  assert.equal(notifications.length, 1);
+});
+
+test('withdrawal.completed returns 404 for a withdrawal the owner does not own', async () => {
+  const { svc } = buildService([
+    { match: (s) => s.includes('UPDATE withdrawal_requests'), rows: [] },
+    { match: (s) => s.includes('SELECT wr.id FROM withdrawal_requests'), rows: [] },
+  ]);
+  await assert.rejects(
+    () =>
+      svc.processIncomingWebhook(
+        'wh-1',
+        { type: 'withdrawal.completed', withdrawal_id: 'w-x' },
+        { ownerUserId: OWNER }
+      ),
+    (e) => e.status === 404
+  );
+});
+
+test('withdrawal.completed returns 409 when the request is in a non-completable state', async () => {
+  const { svc } = buildService([
+    { match: (s) => s.includes('UPDATE withdrawal_requests'), rows: [] },
+    { match: (s) => s.includes('SELECT wr.id FROM withdrawal_requests'), rows: [{ id: 'w-1' }] },
+  ]);
+  await assert.rejects(
+    () =>
+      svc.processIncomingWebhook(
+        'wh-1',
+        { type: 'withdrawal.completed', withdrawal_id: 'w-1' },
+        { ownerUserId: OWNER }
+      ),
+    (e) => e.status === 409
+  );
+});
+
+// --- anchor.deposit.updated -------------------------------------------------
+
+test('anchor.deposit.updated records remote status and advances local lifecycle', async () => {
+  const { svc, queryLog } = buildService([
+    {
+      match: (s) => s.includes('UPDATE anchor_deposits'),
+      rows: [{ id: 'a-1', campaign_id: 'cam-1', status: 'deposit_completed' }],
+    },
+  ]);
+  const res = await svc.processIncomingWebhook(
+    'wh-1',
+    {
+      type: 'anchor.deposit.updated',
+      anchor_id: 'anchor-x',
+      anchor_transaction_id: 'atx-1',
+      status: 'completed',
+    },
+    { ownerUserId: OWNER }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(res.body.status, 'deposit_completed');
+  // Owner scoping: the update must be constrained by user_id.
+  const upd = queryLog.find((q) => q.sql.includes('UPDATE anchor_deposits'));
+  assert.ok(upd.sql.includes('user_id'));
+  assert.ok(upd.params.includes(OWNER));
+});
+
+test('anchor.deposit.updated returns 404 when no matching deposit for the owner', async () => {
+  const { svc } = buildService([
+    { match: (s) => s.includes('UPDATE anchor_deposits'), rows: [] },
+  ]);
+  await assert.rejects(
+    () =>
+      svc.processIncomingWebhook(
+        'wh-1',
+        { type: 'anchor.deposit.updated', anchor_id: 'x', anchor_transaction_id: 'y', status: 'pending' },
+        { ownerUserId: OWNER }
+      ),
+    (e) => e.status === 404
+  );
+});
+
+test('anchor.deposit.updated requires anchor_id and anchor_transaction_id', async () => {
+  const { svc } = buildService([ownerLookup]);
+  await assert.rejects(
+    () =>
+      svc.processIncomingWebhook(
+        'wh-1',
+        { type: 'anchor.deposit.updated', anchor_id: 'x' },
+        { ownerUserId: OWNER }
+      ),
+    (e) => e.status === 400
+  );
+});
+
+// --- milestone.approved / milestone.rejected --------------------------------
+
+test('milestone.approved transitions pending_review to approved and records an event', async () => {
+  const { svc, queryLog, notifications } = buildService([
+    {
+      match: (s) => s.includes('UPDATE milestones'),
+      rows: [{ id: 'm-1', campaign_id: 'cam-1', title: 'Beta', status: 'approved' }],
+    },
+  ]);
+  const res = await svc.processIncomingWebhook(
+    'wh-1',
+    { type: 'milestone.approved', milestone_id: 'm-1' },
+    { ownerUserId: OWNER }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(res.body.status, 'approved');
+  assert.ok(queryLog.some((q) => q.sql.includes('INSERT INTO milestone_events')));
+  assert.equal(notifications.length, 1);
+});
+
+test('milestone.rejected requires a reason', async () => {
+  const { svc } = buildService([ownerLookup]);
+  await assert.rejects(
+    () =>
+      svc.processIncomingWebhook(
+        'wh-1',
+        { type: 'milestone.rejected', milestone_id: 'm-1' },
+        { ownerUserId: OWNER }
+      ),
+    (e) => e.status === 400
+  );
+});
+
+test('milestone decision returns 409 when the milestone is not awaiting review', async () => {
+  const { svc } = buildService([
+    { match: (s) => s.includes('UPDATE milestones'), rows: [] },
+    { match: (s) => s.includes('SELECT m.id FROM milestones'), rows: [{ id: 'm-1' }] },
+  ]);
+  await assert.rejects(
+    () =>
+      svc.processIncomingWebhook(
+        'wh-1',
+        { type: 'milestone.approved', milestone_id: 'm-1' },
+        { ownerUserId: OWNER }
+      ),
+    (e) => e.status === 409
+  );
+});
+
+test('milestone decision returns 404 when the milestone does not belong to the owner', async () => {
+  const { svc } = buildService([
+    { match: (s) => s.includes('UPDATE milestones'), rows: [] },
+    { match: (s) => s.includes('SELECT m.id FROM milestones'), rows: [] },
+  ]);
+  await assert.rejects(
+    () =>
+      svc.processIncomingWebhook(
+        'wh-1',
+        { type: 'milestone.rejected', milestone_id: 'm-1', reason: 'insufficient evidence' },
+        { ownerUserId: OWNER }
+      ),
+    (e) => e.status === 404
+  );
+});


### PR DESCRIPTION
Implement processIncomingWebhook with HMAC-SHA256 signature verification, payload type routing, and owner-scoped state transitions.

- Add timing-safe verifyWebhookSignature helper (crypto.timingSafeEqual), harden the /incoming/:id route to use it, and honor handler status/body.
- Route payload.type to handlers for contribution confirmations, withdrawal completions, SEP-24 anchor deposit updates, and milestone approve/reject.
- Scope every mutation to the webhook owner so a secret cannot touch other users' resources; malformed/unknown/unauthorized payloads return 4xx.
- Contribution confirmation links/verifies idempotently only (never mutates raised_amount, which stays owned by ledgerMonitor + reconciliation).
- Emit notifications for each event; add unit + integration tests.
closes #462