### PR TITLE
feat: full-text campaign search with ts_rank relevance (#468)

### DIFF
--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -5,7 +5,7 @@ const { stripHtml, sanitizeRichText } = require('../lib/sanitize');
 
 const SUPPORTED_ASSETS = getSupportedAssetCodes();
 const VALID_CAMPAIGN_STATUSES = ['active', 'funded', 'closed', 'failed'];
-const VALID_ORDER_BY = ['newest', 'ending_soon', 'most_funded', 'most_backed', 'closest_to_goal', 'trending'];
+const VALID_ORDER_BY = ['newest', 'ending_soon', 'most_funded', 'most_backed', 'closest_to_goal', 'trending', 'relevance'];
 const VALID_CATEGORIES = [
   'technology', 'community', 'arts', 'education',
   'environment', 'health', 'business', 'open_source', 'other',

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -250,8 +250,10 @@ router.get('/', getCampaignsValidation, validateRequest, asyncHandler(async (req
     // Progress is (raised_amount / target_amount) * 100
     filters.push(`(c.raised_amount / c.target_amount) * 100 >= $${params.length}`);
   }
+  let searchParamIdx = null;
   if (search) {
     params.push(search);
+    searchParamIdx = params.length;
     filters.push(`c.search_vector @@ websearch_to_tsquery('english', $${params.length})`);
   }
 
@@ -268,7 +270,13 @@ router.get('/', getCampaignsValidation, validateRequest, asyncHandler(async (req
     most_backed: '(SELECT COUNT(*) FROM contributions ctr WHERE ctr.campaign_id = c.id) DESC',
     closest_to_goal: '(c.raised_amount / NULLIF(c.target_amount, 0)) DESC NULLS LAST, c.raised_amount DESC',
   };
-  const orderBy = sortExpressions[sort] || sortExpressions.newest;
+  if (searchParamIdx !== null) {
+    sortExpressions.relevance = `ts_rank(c.search_vector, websearch_to_tsquery('english', $${searchParamIdx})) DESC, c.created_at DESC`;
+  }
+  // A search without an explicit sort ranks by relevance; explicit sorts always win.
+  const effectiveSort =
+    searchParamIdx !== null && req.query.sort === undefined ? 'relevance' : sort;
+  const orderBy = sortExpressions[effectiveSort] || sortExpressions.newest;
 
   const query = `
     SELECT c.*,

--- a/backend/src/routes/campaigns.test.js
+++ b/backend/src/routes/campaigns.test.js
@@ -463,3 +463,49 @@ test('GET /api/campaigns/mine parses page and limit parameters', async () => {
   assert.equal(response.body.pagination.page, 2);
   assert.equal(response.body.pagination.limit, 10);
 });
+
+function buildListingApp(queries) {
+  return buildApp({
+    queryImpl: async (text, params) => {
+      queries.push({ text, params });
+      if (text.includes('COUNT(*)')) return { rows: [{ total: 1 }] };
+      return { rows: [{ id: 'camp-1', title: 'Solar panels', status: 'active' }] };
+    },
+  });
+}
+
+test('GET /api/campaigns search without sort ranks by relevance', async () => {
+  const queries = [];
+  const app = buildListingApp(queries);
+
+  const response = await request(app).get('/api/campaigns?search=solar');
+  assert.equal(response.status, 200);
+
+  const listQuery = queries.find((q) => q.text.includes('ORDER BY'));
+  assert.ok(listQuery);
+  assert.match(listQuery.text, /ORDER BY ts_rank\(c\.search_vector/);
+});
+
+test('GET /api/campaigns explicit sort wins over relevance when searching', async () => {
+  const queries = [];
+  const app = buildListingApp(queries);
+
+  const response = await request(app).get('/api/campaigns?search=solar&sort=newest');
+  assert.equal(response.status, 200);
+
+  const listQuery = queries.find((q) => q.text.includes('ORDER BY'));
+  assert.match(listQuery.text, /ORDER BY c\.created_at DESC/);
+  assert.doesNotMatch(listQuery.text, /ts_rank/);
+});
+
+test('GET /api/campaigns sort=relevance without search falls back to newest', async () => {
+  const queries = [];
+  const app = buildListingApp(queries);
+
+  const response = await request(app).get('/api/campaigns?sort=relevance');
+  assert.equal(response.status, 200);
+
+  const listQuery = queries.find((q) => q.text.includes('ORDER BY'));
+  assert.match(listQuery.text, /ORDER BY c\.created_at DESC/);
+  assert.doesNotMatch(listQuery.text, /ts_rank/);
+});

--- a/backend/src/routes/v1.js
+++ b/backend/src/routes/v1.js
@@ -81,12 +81,11 @@ router.get('/campaigns', getCampaignsValidation, validateRequest, asyncHandler(a
     params.push(asset);
     filters.push(`c.asset_type = $${params.length}`);
   }
+  let searchParamIdx = null;
   if (search) {
-    const escaped = String(search).replace(/[%_\\]/g, '\\$&');
-    params.push(`%${escaped}%`);
-    filters.push(
-      `(c.title ILIKE $${params.length} OR COALESCE(c.description, '') ILIKE $${params.length})`
-    );
+    params.push(search);
+    searchParamIdx = params.length;
+    filters.push(`c.search_vector @@ websearch_to_tsquery('english', $${params.length})`);
   }
 
   const whereClause = `WHERE ${filters.join(' AND ')}`;
@@ -103,7 +102,13 @@ router.get('/campaigns', getCampaignsValidation, validateRequest, asyncHandler(a
     most_backed:
       '(SELECT COUNT(*) FROM contributions ctr WHERE ctr.campaign_id = c.id) DESC',
   };
-  const orderBy = sortExpressions[sort] || sortExpressions.newest;
+  if (searchParamIdx !== null) {
+    sortExpressions.relevance = `ts_rank(c.search_vector, websearch_to_tsquery('english', $${searchParamIdx})) DESC, c.created_at DESC`;
+  }
+  // A search without an explicit sort ranks by relevance; explicit sorts always win.
+  const effectiveSort =
+    searchParamIdx !== null && req.query.sort === undefined ? 'relevance' : sort;
+  const orderBy = sortExpressions[effectiveSort] || sortExpressions.newest;
 
   const { rows } = await db.query(
     `SELECT c.id, c.title, c.description, c.target_amount, c.raised_amount,

--- a/backend/src/routes/v1.test.js
+++ b/backend/src/routes/v1.test.js
@@ -117,3 +117,67 @@ test('POST /api/v1/campaigns/:id/contributions records contribution from tx hash
   assert.equal(recorded.campaignId, 'camp-1');
   assert.equal(recorded.txHash, 'stellar-tx-hash');
 });
+
+function buildSearchApp(queries) {
+  return buildApp({
+    queryImpl: async (sql, params) => {
+      queries.push({ text: sql, params });
+      if (sql.includes('COUNT')) return { rows: [{ total: 1 }] };
+      return { rows: [{ id: 'camp-1', title: 'Solar panels', status: 'active' }] };
+    },
+    authError: 'Missing token',
+  });
+}
+
+test('GET /api/v1/campaigns search uses full-text search, not ILIKE', async () => {
+  const queries = [];
+  const app = buildSearchApp(queries);
+
+  const res = await request(app).get('/api/v1/campaigns?search=solar%20panels');
+  assert.equal(res.status, 200);
+
+  const listQuery = queries.find((q) => q.text.includes('ORDER BY'));
+  assert.ok(listQuery);
+  assert.match(listQuery.text, /websearch_to_tsquery/);
+  assert.doesNotMatch(listQuery.text, /ILIKE/);
+  // The raw search term is bound, not a %-wrapped pattern
+  assert.ok(listQuery.params.includes('solar panels'));
+  // Count query filters identically
+  const countQuery = queries.find((q) => q.text.includes('COUNT'));
+  assert.match(countQuery.text, /websearch_to_tsquery/);
+});
+
+test('GET /api/v1/campaigns search without sort ranks by relevance', async () => {
+  const queries = [];
+  const app = buildSearchApp(queries);
+
+  const res = await request(app).get('/api/v1/campaigns?search=solar');
+  assert.equal(res.status, 200);
+
+  const listQuery = queries.find((q) => q.text.includes('ORDER BY'));
+  assert.match(listQuery.text, /ORDER BY ts_rank\(c\.search_vector/);
+});
+
+test('GET /api/v1/campaigns explicit sort wins over relevance', async () => {
+  const queries = [];
+  const app = buildSearchApp(queries);
+
+  const res = await request(app).get('/api/v1/campaigns?search=solar&sort=newest');
+  assert.equal(res.status, 200);
+
+  const listQuery = queries.find((q) => q.text.includes('ORDER BY'));
+  assert.match(listQuery.text, /ORDER BY c\.created_at DESC/);
+  assert.doesNotMatch(listQuery.text, /ts_rank/);
+});
+
+test('GET /api/v1/campaigns sort=relevance without search falls back to newest', async () => {
+  const queries = [];
+  const app = buildSearchApp(queries);
+
+  const res = await request(app).get('/api/v1/campaigns?sort=relevance');
+  assert.equal(res.status, 200);
+
+  const listQuery = queries.find((q) => q.text.includes('ORDER BY'));
+  assert.match(listQuery.text, /ORDER BY c\.created_at DESC/);
+  assert.doesNotMatch(listQuery.text, /ts_rank/);
+});


### PR DESCRIPTION
Closes #468.

- Replaces the remaining ILIKE search in the public v1 API with `search_vector @@ websearch_to_tsquery`
- Adds `ts_rank` relevance ordering to both `/campaigns` and `/api/v1/campaigns` — default only when searching without an explicit sort, so the frontend contract is unchanged
- No migration needed: the existing 20260602 generated tsvector column + GIN index already cover storage/backfill
- 7 new mocked route tests; verified on real postgres:14 (ranking order, stemming, GIN index usage via EXPLAIN)
- The 8 failing suite tests are pre-existing on main (stash-verified)


