### PR TITLE
Notification setting page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,6 +17,7 @@ import Developer from './pages/Developer';
 import Dashboard from './pages/Dashboard';
 import MyContributions from './pages/MyContributions';
 import Profile from './pages/Profile';
+import NotificationSettings from './pages/NotificationSettings';
 import HowItWorks from './pages/HowItWorks';
 import Pricing from './pages/Pricing';
 import About from './pages/About';
@@ -100,6 +101,14 @@ export default function App() {
                 element={
                   <PrivateRoute>
                     <Profile />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/settings/notifications"
+                element={
+                  <PrivateRoute>
+                    <NotificationSettings />
                   </PrivateRoute>
                 }
               />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -824,3 +824,223 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
 @media (max-width: 720px) {
   .nav-search { display: none; }
 }
+
+/* ── Toggle Switch ───────────────────────────────────────────────────────── */
+.notif-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  user-select: none;
+  flex-shrink: 0;
+}
+.notif-toggle__input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+.notif-toggle__label {
+  font-size: 0.8rem;
+  color: var(--color-text-hint);
+  font-weight: 500;
+  white-space: nowrap;
+}
+.notif-toggle__track {
+  position: relative;
+  display: inline-block;
+  width: 38px;
+  height: 22px;
+  background: var(--color-border);
+  border-radius: 99px;
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+}
+.notif-toggle__track--on {
+  background: var(--color-accent);
+}
+.notif-toggle__thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  background: #fff;
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  transition: transform 0.2s ease;
+}
+.notif-toggle__track--on .notif-toggle__thumb {
+  transform: translateX(16px);
+}
+.notif-toggle__input:focus-visible + .notif-toggle__track {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
+}
+.notif-toggle__input:disabled + .notif-toggle__track {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ── Notification Settings Page ───────────────────────────────────────────── */
+.notif-settings__card {
+  margin-bottom: 1.5rem;
+  min-height: auto;
+}
+.notif-settings__channel-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.notif-settings__channel-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--color-border-lighter);
+}
+.notif-settings__channel-row:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+.notif-settings__channel-row:first-child {
+  padding-top: 0;
+}
+.notif-settings__channel-info {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  flex: 1;
+  min-width: 0;
+}
+.notif-settings__channel-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: var(--color-surface);
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+.notif-settings__quiet-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border-lighter);
+}
+.notif-settings__time-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.notif-settings__types-table {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.notif-settings__types-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 0.75rem;
+  margin-bottom: 0.5rem;
+  border-bottom: 2px solid var(--color-border-lighter);
+}
+.notif-settings__types-label {
+  font-weight: 700;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.notif-settings__types-channels {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex-shrink: 0;
+}
+.notif-settings__types-ch-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  font-size: 1.1rem;
+}
+.notif-settings__types-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--color-border-lighter);
+}
+.notif-settings__types-row:last-child {
+  border-bottom: none;
+}
+.notif-settings__types-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  flex: 1;
+  min-width: 0;
+}
+.notif-settings__campaign-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.notif-settings__campaign-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  background: var(--color-surface);
+  border-radius: 10px;
+  border: 1px solid var(--color-border-lighter);
+  flex-wrap: wrap;
+}
+.notif-settings__campaign-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  flex: 1;
+  min-width: 0;
+}
+.notif-settings__campaign-toggles {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+@media (max-width: 640px) {
+  .notif-settings__types-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+  .notif-settings__types-channels {
+    gap: 1rem;
+  }
+  .notif-settings__channel-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+  .notif-settings__campaign-item {
+    flex-direction: column;
+  }
+  .notif-settings__types-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+}

--- a/frontend/src/pages/NotificationSettings.jsx
+++ b/frontend/src/pages/NotificationSettings.jsx
@@ -1,0 +1,497 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { useToast } from '../context/ToastContext';
+import { api } from '../services/api';
+
+const CHANNELS = [
+  { id: 'email', label: 'Email', icon: '✉' },
+  { id: 'push', label: 'Push', icon: '🔔' },
+  { id: 'in_app', label: 'In-app', icon: '💬' },
+];
+
+const EVENT_TYPES = [
+  { id: 'campaign_update', label: 'Campaign updates', description: 'New updates posted on campaigns you support' },
+  { id: 'milestone_completion', label: 'Milestone completions', description: 'Milestones reached or approved' },
+  { id: 'withdrawal', label: 'Withdrawal notifications', description: 'Withdrawal requests, approvals, and rejections' },
+  { id: 'dispute', label: 'Dispute notifications', description: 'Disputes opened, updated, or resolved' },
+  { id: 'referral_reward', label: 'Referral rewards', description: 'When a referral contribution is confirmed' },
+  { id: 'weekly_digest', label: 'Weekly digest', description: 'A summary of activity delivered once a week' },
+];
+
+function formatHour(h) {
+  if (h === null || h === undefined) return '';
+  const hour = Number(h);
+  if (isNaN(hour)) return '';
+  const period = hour >= 12 ? 'PM' : 'AM';
+  const display = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+  return `${display}:00 ${period}`;
+}
+
+function Toggle({ checked, onChange, disabled, label, id }) {
+  return (
+    <label className="notif-toggle" htmlFor={id}>
+      <span className="notif-toggle__label">{label}</span>
+      <span
+        className={`notif-toggle__track${checked ? ' notif-toggle__track--on' : ''}`}
+        aria-hidden="true"
+      >
+        <span className="notif-toggle__thumb" />
+      </span>
+      <input
+        id={id}
+        type="checkbox"
+        checked={!!checked}
+        onChange={(e) => onChange(e.target.checked)}
+        disabled={disabled}
+        className="notif-toggle__input"
+      />
+    </label>
+  );
+}
+
+function SectionCard({ title, description, children }) {
+  return (
+    <div className="campaign-card notif-settings__card">
+      <div style={{ marginBottom: '1rem' }}>
+        <h2 style={{ fontSize: '1.15rem', fontWeight: 700, marginBottom: '0.25rem' }}>{title}</h2>
+        {description && (
+          <p style={{ color: 'var(--color-text-hint)', fontSize: '0.875rem', margin: 0 }}>
+            {description}
+          </p>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export default function NotificationSettings() {
+  const { user, ready } = useAuth();
+  const toast = useToast();
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  // Channel-level enabled flags (derived from preferences)
+  const [channelEnabled, setChannelEnabled] = useState({ email: true, push: true, in_app: true });
+
+  // Quiet hours
+  const [quietStart, setQuietStart] = useState('');
+  const [quietEnd, setQuietEnd] = useState('');
+  const [quietEnabled, setQuietEnabled] = useState(false);
+
+  // Per-event-type per-channel preferences: { [eventType]: { [channel]: boolean } }
+  const [prefs, setPrefs] = useState({});
+
+  // Per-campaign overrides
+  const [campaigns, setCampaigns] = useState([]);
+  const [campaignOverrides, setCampaignOverrides] = useState({});
+  const [showCampaignSection, setShowCampaignSection] = useState(false);
+
+  const loadPreferences = useCallback(async () => {
+    try {
+      const [prefRows, channelSettings, myCampaigns] = await Promise.all([
+        api.getNotificationPreferences().catch(() => []),
+        api.getChannelSettings().catch(() => ({})),
+        api.getMyCampaigns({ limit: 50 }).catch(() => ({ campaigns: [] })),
+      ]);
+
+      // Build preference map from rows
+      const prefMap = {};
+      if (Array.isArray(prefRows)) {
+        for (const row of prefRows) {
+          if (!prefMap[row.event_type]) prefMap[row.event_type] = {};
+          prefMap[row.event_type][row.channel] = row.enabled;
+        }
+      }
+      setPrefs(prefMap);
+
+      // Derive channel-level enabled from the "campaign_update" event as a proxy,
+      // or default to true if no preferences exist yet
+      const chEnabled = {};
+      for (const ch of CHANNELS) {
+        const proxyEvent = prefMap['campaign_update'];
+        if (proxyEvent && proxyEvent[ch.id] !== undefined) {
+          chEnabled[ch.id] = proxyEvent[ch.id];
+        } else {
+          chEnabled[ch.id] = true;
+        }
+      }
+      setChannelEnabled(chEnabled);
+
+      // Quiet hours from channel settings
+      const qs = channelSettings?.quiet_hours_start;
+      const qe = channelSettings?.quiet_hours_end;
+      if (qs !== null && qs !== undefined && qe !== null && qe !== undefined) {
+        setQuietEnabled(true);
+        setQuietStart(String(qs));
+        setQuietEnd(String(qe));
+      }
+
+      // Campaigns for per-campaign overrides
+      const campList = (myCampaigns?.campaigns || []).filter(
+        (c) => c.status === 'active' || c.status === 'funded'
+      );
+      setCampaigns(campList);
+
+      // Build campaign override map from preferences
+      const overrides = {};
+      if (Array.isArray(prefRows)) {
+        for (const row of prefRows) {
+          if (row.event_type?.startsWith('campaign_') && row.event_type.includes(':')) {
+            const campId = row.event_type.split(':').pop();
+            if (!overrides[campId]) overrides[campId] = {};
+            overrides[campId][row.channel] = row.enabled;
+          }
+        }
+      }
+      setCampaignOverrides(overrides);
+    } catch (err) {
+      toast(err.message || 'Failed to load notification settings', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    loadPreferences();
+  }, [loadPreferences]);
+
+  const handleChannelToggle = useCallback(
+    async (channelId, enabled) => {
+      setChannelEnabled((prev) => ({ ...prev, [channelId]: enabled }));
+
+      // Also toggle all event types for this channel
+      setPrefs((prev) => {
+        const next = { ...prev };
+        for (const evt of EVENT_TYPES) {
+          if (!next[evt.id]) next[evt.id] = {};
+          next[evt.id] = { ...next[evt.id], [channelId]: enabled };
+        }
+        return next;
+      });
+
+      try {
+        // Save each event type preference for this channel
+        const promises = EVENT_TYPES.map((evt) =>
+          api.updateNotificationPreference({
+            event_type: evt.id,
+            channel: channelId,
+            enabled,
+          })
+        );
+        await Promise.all(promises);
+        toast(
+          `${channelId === 'in_app' ? 'In-app' : channelId.charAt(0).toUpperCase() + channelId.slice(1)} notifications ${enabled ? 'enabled' : 'disabled'}`,
+          'success'
+        );
+      } catch (err) {
+        toast(err.message || 'Failed to update channel settings', 'error');
+      }
+    },
+    [toast]
+  );
+
+  const handleEventTypeToggle = useCallback(
+    async (eventTypeId, channelId, enabled) => {
+      setPrefs((prev) => {
+        const next = { ...prev };
+        if (!next[eventTypeId]) next[eventTypeId] = {};
+        next[eventTypeId] = { ...next[eventTypeId], [channelId]: enabled };
+        return next;
+      });
+
+      try {
+        await api.updateNotificationPreference({
+          event_type: eventTypeId,
+          channel: channelId,
+          enabled,
+        });
+      } catch (err) {
+        toast(err.message || 'Failed to save preference', 'error');
+      }
+    },
+    [toast]
+  );
+
+  const handleQuietHoursSave = useCallback(async () => {
+    if (quietEnabled && (quietStart === '' || quietEnd === '')) {
+      toast('Please set both start and end times for quiet hours', 'error');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await api.updateChannelSettings({
+        quiet_hours_start: quietEnabled ? Number(quietStart) : null,
+        quiet_hours_end: quietEnabled ? Number(quietEnd) : null,
+      });
+      toast('Quiet hours updated', 'success');
+    } catch (err) {
+      toast(err.message || 'Failed to save quiet hours', 'error');
+    } finally {
+      setSaving(false);
+    }
+  }, [quietEnabled, quietStart, quietEnd, toast]);
+
+  const handleCampaignOverride = useCallback(
+    async (campaignId, channelId, enabled) => {
+      setCampaignOverrides((prev) => {
+        const next = { ...prev };
+        if (!next[campaignId]) next[campaignId] = {};
+        next[campaignId] = { ...next[campaignId], [channelId]: enabled };
+        return next;
+      });
+
+      try {
+        await api.updateNotificationPreference({
+          event_type: `campaign_override:${campaignId}`,
+          channel: channelId,
+          enabled,
+        });
+      } catch (err) {
+        toast(err.message || 'Failed to save campaign override', 'error');
+      }
+    },
+    [toast]
+  );
+
+  if (!ready) {
+    return (
+      <main className="container page-narrow" style={{ paddingTop: '3rem' }}>
+        <p className="alert alert--info">Loading session…</p>
+      </main>
+    );
+  }
+
+  if (!user) {
+    return (
+      <main className="container page-narrow" style={{ paddingTop: '3rem' }}>
+        <p className="alert alert--error">
+          Please <Link to="/login" style={{ color: 'var(--color-accent)', fontWeight: 600 }}>log in</Link> to manage notification settings.
+        </p>
+      </main>
+    );
+  }
+
+  if (loading) {
+    return (
+      <main className="container page-narrow notif-settings" style={{ paddingTop: '3rem' }}>
+        <h1 style={{ fontSize: '1.75rem', fontWeight: 800, marginBottom: '1.5rem' }}>Notification Settings</h1>
+        <div className="campaign-card">
+          <p style={{ color: 'var(--color-text-hint)' }}>Loading your preferences…</p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="container page-narrow notif-settings" style={{ paddingTop: '3rem', paddingBottom: '4rem' }}>
+      <div style={{ marginBottom: '1.5rem' }}>
+        <Link
+          to="/profile"
+          style={{ color: 'var(--color-text-hint)', fontSize: '0.875rem', fontWeight: 500 }}
+        >
+          ← Back to profile
+        </Link>
+      </div>
+
+      <h1 style={{ fontSize: '1.75rem', fontWeight: 800, marginBottom: '0.5rem' }}>
+        Notification Settings
+      </h1>
+      <p style={{ color: 'var(--color-text-hint)', fontSize: '0.9rem', marginBottom: '2rem' }}>
+        Control how and when you receive notifications from CrowdPay.
+      </p>
+
+      {/* ── Channel Toggles ─────────────────────────────────── */}
+      <SectionCard
+        title="Notification channels"
+        description="Turn entire channels on or off. Disabling a channel silences all notifications delivered through it."
+      >
+        <div className="notif-settings__channel-list">
+          {CHANNELS.map((ch) => (
+            <div key={ch.id} className="notif-settings__channel-row">
+              <div className="notif-settings__channel-info">
+                <span className="notif-settings__channel-icon" aria-hidden="true">{ch.icon}</span>
+                <div>
+                  <div style={{ fontWeight: 600, fontSize: '0.95rem' }}>{ch.label}</div>
+                  <div style={{ color: 'var(--color-text-hint)', fontSize: '0.8rem' }}>
+                    {ch.id === 'email'
+                      ? 'Delivered to your email address'
+                      : ch.id === 'push'
+                        ? 'Browser and mobile push alerts'
+                        : 'Shown in the CrowdPay notification center'}
+                  </div>
+                </div>
+              </div>
+              <Toggle
+                id={`channel-${ch.id}`}
+                checked={channelEnabled[ch.id]}
+                onChange={(enabled) => handleChannelToggle(ch.id, enabled)}
+                label={`Toggle ${ch.label}`}
+              />
+            </div>
+          ))}
+        </div>
+      </SectionCard>
+
+      {/* ── Quiet Hours ─────────────────────────────────────── */}
+      <SectionCard
+        title="Quiet hours"
+        description="Pause non-critical notifications during specific hours. Critical alerts (disputes, withdrawals) are always delivered."
+      >
+        <Toggle
+          id="quiet-hours-toggle"
+          checked={quietEnabled}
+          onChange={setQuietEnabled}
+          label="Enable quiet hours"
+        />
+        {quietEnabled && (
+          <div className="notif-settings__quiet-form">
+            <div className="notif-settings__time-group">
+              <label htmlFor="quiet-start" className="label-strong" style={{ fontSize: '0.875rem' }}>
+                Start time
+              </label>
+              <select
+                id="quiet-start"
+                value={quietStart}
+                onChange={(e) => setQuietStart(e.target.value)}
+                style={{ maxWidth: '160px' }}
+              >
+                <option value="">Select…</option>
+                {Array.from({ length: 24 }, (_, i) => (
+                  <option key={i} value={i}>
+                    {formatHour(i)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="notif-settings__time-group">
+              <label htmlFor="quiet-end" className="label-strong" style={{ fontSize: '0.875rem' }}>
+                End time
+              </label>
+              <select
+                id="quiet-end"
+                value={quietEnd}
+                onChange={(e) => setQuietEnd(e.target.value)}
+                style={{ maxWidth: '160px' }}
+              >
+                <option value="">Select…</option>
+                {Array.from({ length: 24 }, (_, i) => (
+                  <option key={i} value={i}>
+                    {formatHour(i)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={handleQuietHoursSave}
+              disabled={saving}
+              style={{ marginTop: '0.5rem', alignSelf: 'flex-start' }}
+            >
+              {saving ? 'Saving…' : 'Save quiet hours'}
+            </button>
+          </div>
+        )}
+      </SectionCard>
+
+      {/* ── Notification Types ──────────────────────────────── */}
+      <SectionCard
+        title="Notification types"
+        description="Choose which events trigger notifications and on which channels."
+      >
+        <div className="notif-settings__types-table">
+          <div className="notif-settings__types-header">
+            <span className="notif-settings__types-label">Event</span>
+            <div className="notif-settings__types-channels">
+              {CHANNELS.filter((ch) => channelEnabled[ch.id]).map((ch) => (
+                <span key={ch.id} className="notif-settings__types-ch-label" title={ch.label}>
+                  {ch.icon}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {EVENT_TYPES.map((evt) => {
+            const evtPrefs = prefs[evt.id] || {};
+            return (
+              <div key={evt.id} className="notif-settings__types-row">
+                <div className="notif-settings__types-info">
+                  <span style={{ fontWeight: 600, fontSize: '0.9rem' }}>{evt.label}</span>
+                  <span style={{ color: 'var(--color-text-hint)', fontSize: '0.8rem' }}>
+                    {evt.description}
+                  </span>
+                </div>
+                <div className="notif-settings__types-channels">
+                  {CHANNELS.filter((ch) => channelEnabled[ch.id]).map((ch) => (
+                    <Toggle
+                      key={ch.id}
+                      id={`pref-${evt.id}-${ch.id}`}
+                      checked={evtPrefs[ch.id] !== false}
+                      onChange={(enabled) => handleEventTypeToggle(evt.id, ch.id, enabled)}
+                      label={`${evt.label} via ${ch.label}`}
+                    />
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </SectionCard>
+
+      {/* ── Per-Campaign Overrides ──────────────────────────── */}
+      {campaigns.length > 0 && (
+        <SectionCard
+          title="Campaign overrides"
+          description="Override notification settings for individual campaigns you manage."
+        >
+          {!showCampaignSection ? (
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={() => setShowCampaignSection(true)}
+              style={{ alignSelf: 'flex-start' }}
+            >
+              Configure campaign overrides
+            </button>
+          ) : (
+            <div className="notif-settings__campaign-list">
+              {campaigns.map((camp) => {
+                const overrides = campaignOverrides[camp.id] || {};
+                return (
+                  <div key={camp.id} className="notif-settings__campaign-item">
+                    <div className="notif-settings__campaign-info">
+                      <Link
+                        to={`/campaigns/${camp.id}`}
+                        style={{ fontWeight: 600, fontSize: '0.9rem', color: 'var(--color-accent)' }}
+                      >
+                        {camp.title}
+                      </Link>
+                      <span style={{ color: 'var(--color-text-hint)', fontSize: '0.8rem' }}>
+                        {camp.status} · ${Number(camp.raised_amount || 0).toLocaleString()} raised
+                      </span>
+                    </div>
+                    <div className="notif-settings__campaign-toggles">
+                      {CHANNELS.filter((ch) => channelEnabled[ch.id]).map((ch) => (
+                        <Toggle
+                          key={ch.id}
+                          id={`camp-${camp.id}-${ch.id}`}
+                          checked={overrides[ch.id] !== false}
+                          onChange={(enabled) => handleCampaignOverride(camp.id, ch.id, enabled)}
+                          label={`${ch.label} for ${camp.title}`}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </SectionCard>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { stellarExpertAccountUrl } from '../config/stellar';
 import VerificationBadge from '../components/VerificationBadge';
@@ -334,6 +334,32 @@ export default function Profile() {
           )}
         </div>
       )}
+
+      <div className="campaign-card" style={{ marginTop: '2rem' }}>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: '0.75rem',
+            flexWrap: 'wrap',
+          }}
+        >
+          <div>
+            <h2 style={{ fontSize: '1.15rem', fontWeight: 700, marginBottom: '0.25rem' }}>
+              Notification Settings
+            </h2>
+            <p style={{ color: 'var(--color-text-secondary)', fontSize: '0.9rem', margin: 0 }}>
+              Control how and when you receive email, push, and in-app notifications.
+            </p>
+          </div>
+          <Link to="/settings/notifications">
+            <button type="button" className="btn-secondary">
+              Manage →
+            </button>
+          </Link>
+        </div>
+      </div>
     </main>
   );
 }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -497,6 +497,10 @@ export const api = {
   getNotifications: () => request('GET', '/notifications'),
   markNotificationRead: (id) => request('PATCH', `/notifications/${id}/read`, {}),
   markAllNotificationsRead: () => request('PATCH', '/notifications/read-all', {}),
+  getNotificationPreferences: () => request('GET', '/notifications/preferences'),
+  updateNotificationPreference: (body) => request('PUT', '/notifications/preferences', body),
+  getChannelSettings: () => request('GET', '/notifications/channel-settings'),
+  updateChannelSettings: (body) => request('PUT', '/notifications/channel-settings', body),
 
   getReferralCode: (campaignId) => request('GET', `/campaigns/${campaignId}/referral`),
   getReferralLeaderboard: (campaignId) => request('GET', `/campaigns/${campaignId}/referrals`),


### PR DESCRIPTION

**Here's my plan:**
- **`api.js`**: Add methods for `getNotificationPreferences`, `getChannelSettings`, `updateChannelSettings`, and `updateNotificationPreference`
- **`NotificationSettings.jsx`**: New page with channel toggles, quiet hours, event-type toggles, and per-campaign overrides
- **`App.jsx`**: Add route at `/settings/notifications`
- **`index.css`**: Add toggle switch and settings page styles
- **`Profile.jsx`**: Add a link to the notification settings page


**Step 1: Add API methods to `api.js`**

The existing `api.js` already has `getNotifications`, `markNotificationRead`, and `markAllNotificationsRead`. I'll add 4 new methods for preferences and channel settings, connecting to the existing backend endpoints at `/api/notifications/preferences` and `/api/notifications/channel-settings`.


**Step 2: Create `NotificationSettings.jsx`**

This is the main page component. It will have:
- Channel toggles (Email, Push, In-app)
- Quiet Hours configuration (start/end time pickers)
- Per-event-type toggles for each channel
- Per-campaign notification overrides
- Auto-save with toast feedback


**Step 3: Add route in `App.jsx`**

I'll add the notification settings route as a protected route (requires login), following the same pattern as other private routes.


Now let me add a navigation link from the Profile page. I'll add a "Notification settings" card that links to the new page.


**Step 4: Add CSS styles**

I'll add toggle switch styles and settings-specific layout styles to `index.css`, following the existing CSS variable system and responsive patterns.


The backend already has all the needed endpoints (`/api/notifications/preferences` and `/api/notifications/channel-settings`), so no backend stubs needed. Let me verify the build.


Build succeeded with no errors. Let me also run lint to check for any issues:


The build compiles cleanly with zero errors. Here's a summary of everything implemented:

---

## Summary — Notification Settings Page (Issue #472)

### Files Modified

**1. [`frontend/src/services/api.js`](file:///c:\Users\ABUBAKAR\crowdpay\frontend\src\services\api.js)** — 4 new API methods added
- `getNotificationPreferences()` → `GET /api/notifications/preferences`
- `updateNotificationPreference(body)` → `PUT /api/notifications/preferences`
- `getChannelSettings()` → `GET /api/notifications/channel-settings`
- `updateChannelSettings(body)` → `PUT /api/notifications/channel-settings`

All reuse the existing `request()` helper with token refresh and error handling.

**2. [`frontend/src/App.jsx`](file:///c:\Users\ABUBAKAR\crowdpay\frontend\src\App.jsx)** — New protected route added
- Route: `/settings/notifications` wrapped in `PrivateRoute` (redirects to login if unauthenticated)

**3. [`frontend/src/pages/Profile.jsx`](file:///c:\Users\ABUBAKAR\crowdpay\frontend\src\pages\Profile.jsx)** — Navigation card added
- Added a "Notification Settings" card at the bottom of the profile page with a "Manage →" button linking to `/settings/notifications`

**4. [`frontend/src/index.css`](file:///c:\Users\ABUBAKAR\crowdpay\frontend\src\index.css)** — Toggle switch + settings layout styles
- `.notif-toggle` — Accessible toggle switch (track + thumb) using CSS variables, with focus-visible and disabled states
- `.notif-settings__*` — Card layout, channel rows, quiet hours form, event-type table, campaign override cards
- Responsive breakpoint at 640px for mobile stacking

### File Created

**5. [`frontend/src/pages/NotificationSettings.jsx`](file:///c:\Users\ABUBAKAR\crowdpay\frontend\src\pages\NotificationSettings.jsx)** — The new page (498 lines)

Features implemented per acceptance criteria:

| Feature | Implementation |
|---|---|
| **Email / Push / In-app toggles** | Channel-level toggles that bulk-save all event-type preferences for that channel |
| **Quiet Hours** | Start/end time selectors (0–23h) with enable/disable toggle, saved via `PUT /channel-settings` |
| **Notification types** | 6 event types × 3 channels matrix; each cell is an independent toggle |
| **Per-campaign overrides** | Lists user's active/funded campaigns with per-channel toggles, saved as `campaign_override:{id}` event types |
| **Persistence** | All changes auto-save to the backend API; reload restores from server |
| **Responsive** | Stacks vertically on mobile (< 640px), table layout on desktop |
| **Existing design** | Uses `campaign-card`, `btn-primary`, `btn-secondary`, `alert`, CSS variables, `useToast` for feedback |

### Backend (no changes needed)
All required endpoints already exist in [`backend/src/routes/notifications.js`](file:///c:\Users\ABUBAKAR\crowdpay\backend\src\routes\notifications.js) — `GET/PUT /preferences` and `GET/PUT /channel-settings`.

closes #472 