### PR TITLE
fix(backend): validate contribution display_name length, trim whitesp…

### DIFF
--- a/backend/db/migrations/20260725_display_name_length_limit.sql
+++ b/backend/db/migrations/20260725_display_name_length_limit.sql
@@ -1,0 +1,2 @@
+-- Alter display_name column in contributions table to VARCHAR(50)
+ALTER TABLE contributions ALTER COLUMN display_name TYPE VARCHAR(50);

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -88,7 +88,7 @@ CREATE TABLE contributions (
   conversion_rate     NUMERIC(30, 15),
   path                JSONB,
   tx_hash             TEXT UNIQUE NOT NULL,  -- deduplicate by Stellar transaction hash
-  display_name        TEXT,
+  display_name        VARCHAR(50),
   refunded            BOOLEAN NOT NULL DEFAULT FALSE,
   platform_fee_amount NUMERIC(20, 7),
   ip_address          TEXT,

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -260,7 +260,13 @@ const contributionValidation = [
     .withMessage(`send_asset must be one of: ${SUPPORTED_ASSETS.join(', ')}`),
   body('display_name')
     .optional({ nullable: true })
-    .customSanitizer(stripHtml)
+    .customSanitizer((val) => (typeof val === 'string' ? stripHtml(val).trim() : val))
+    .custom((value) => {
+      if (typeof value === 'string' && /[\u0000-\u001F\u007F-\u009F]/.test(value)) {
+        throw new Error('Display name contains invalid control characters or null bytes');
+      }
+      return true;
+    })
     .isLength({ max: 50 })
     .withMessage('Display name must be at most 50 characters'),
 ];
@@ -335,7 +341,14 @@ function validateRequest(req, res, next) {
     message: e.msg,
   }));
 
-  return res.status(400).json({
+  const isContributionsPath = Boolean(
+    (req.originalUrl && req.originalUrl.includes('/contributions')) ||
+    (req.baseUrl && req.baseUrl.includes('/contributions')) ||
+    (req.path && req.path.includes('/contributions'))
+  );
+  const statusCode = isContributionsPath ? 422 : 400;
+
+  return res.status(statusCode).json({
     error: {
       code: 'VALIDATION_ERROR',
       message: fields[0]?.message || 'Validation failed',

--- a/backend/src/middleware/validation.test.js
+++ b/backend/src/middleware/validation.test.js
@@ -18,9 +18,9 @@ async function runValidation(validations, body = {}, query = {}) {
   }
   const result = validationResult(req);
   if (!result.isEmpty()) {
-    return { ok: false, errors: result.array() };
+    return { ok: false, errors: result.array(), req };
   }
-  return { ok: true };
+  return { ok: true, req };
 }
 
 test('register validation rejects invalid email and short password', async () => {
@@ -188,4 +188,37 @@ test('createCampaign validation rejects milestone percentages with floating poin
   });
   assert.equal(result.ok, false);
   assert.ok(result.errors.some((e) => e.msg === 'Milestone percentages must not exceed 100%'));
+});
+
+test('contribution validation rejects display_name longer than 50 characters', async () => {
+  const result = await runValidation(contributionValidation, {
+    campaign_id: '123e4567-e89b-12d3-a456-426614174000',
+    amount: '10',
+    send_asset: 'XLM',
+    display_name: 'a'.repeat(51),
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => e.msg === 'Display name must be at most 50 characters'));
+});
+
+test('contribution validation rejects display_name with null bytes or control characters', async () => {
+  const result = await runValidation(contributionValidation, {
+    campaign_id: '123e4567-e89b-12d3-a456-426614174000',
+    amount: '10',
+    send_asset: 'XLM',
+    display_name: 'Bad\0User',
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => e.msg === 'Display name contains invalid control characters or null bytes'));
+});
+
+test('contribution validation trims whitespace on valid display_name', async () => {
+  const result = await runValidation(contributionValidation, {
+    campaign_id: '123e4567-e89b-12d3-a456-426614174000',
+    amount: '10',
+    send_asset: 'XLM',
+    display_name: '   Alice   ',
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.req.body.display_name, 'Alice');
 });


### PR DESCRIPTION
…ace, reject control chars, and constrain DB column to VARCHAR(50)## 📌 Summary

Adds input validation, control character sanitization, whitespace trimming, and PostgreSQL database schema constraints (`VARCHAR(50)`) for the `display_name` parameter on contribution endpoints.

## 🐛 Root Cause

The contribution API previously accepted `display_name` without length restrictions, control character rejection, or database constraints (`TEXT` type in PostgreSQL). This allowed unvalidated or malformed strings to be saved and displayed publicly on campaign backer walls.

## 🛠️ Changes Made

1. **Backend Validation & Moderation (`backend/src/middleware/validation.js`)**:
   - Added whitespace trimming (`.trim()`).
   - Capped `display_name` max length to 50 characters.
   - Added custom validation rejecting null bytes (`\0`) and control characters (`\u0000-\u001F`, `\u007F-\u009F`).
   - Updated `validateRequest` to return HTTP `422 Unprocessable Entity` for contribution route validation failures.

2. **Database Schema & Migration**:
   - Created migration `20260725_display_name_length_limit.sql`:
     ```sql
     ALTER TABLE contributions ALTER COLUMN display_name TYPE VARCHAR(50);
     ```
   - Updated `backend/db/schema.sql` definition to `display_name VARCHAR(50)`.

3. **Automated Unit Tests (`backend/src/middleware/validation.test.js`)**:
   - Added unit tests for 50-character limit enforcement, control character/null byte rejection, and whitespace trimming.

## ✅ Acceptance Criteria & Verification

-  `display_name` capped at 50 characters; longer values rejected with HTTP `422`.
-  Leading and trailing whitespace stripped.
- Database column updated to `VARCHAR(50)`.
-  Null bytes and control characters rejected.
- All 17 backend validation unit tests passing (`17/17 pass`).
Closes #402 