### PR TITLE
fix(#399): track contract deployment status and add retry mechanism

### DIFF
--- a/backend/db/migrations/20260725_contract_deployment_status.sql
+++ b/backend/db/migrations/20260725_contract_deployment_status.sql
@@ -1,0 +1,26 @@
+-- Track contract deployment lifecycle per campaign
+-- Values: 'deploying', 'deployed', 'failed'
+-- NULL means legacy campaign created before this tracking was added
+ALTER TABLE campaigns
+  ADD COLUMN IF NOT EXISTS contract_deployment_status TEXT
+    CHECK (contract_deployment_status IN ('deploying', 'deployed', 'failed'))
+    DEFAULT NULL;
+
+-- Store the last deployment error so admins can diagnose failures
+ALTER TABLE campaigns
+  ADD COLUMN IF NOT EXISTS contract_deployment_error TEXT;
+
+-- Timestamp of last deployment attempt (for retry backoff)
+ALTER TABLE campaigns
+  ADD COLUMN IF NOT EXISTS last_deployment_attempt_at TIMESTAMPTZ;
+
+-- Index for the cron retry query
+CREATE INDEX IF NOT EXISTS idx_campaigns_deployment_retry
+  ON campaigns (contract_deployment_status, last_deployment_attempt_at)
+  WHERE contract_deployment_status = 'failed';
+
+-- Backfill existing campaigns that have a deployed contract
+UPDATE campaigns
+SET contract_deployment_status = 'deployed'
+WHERE escrow_contract_id IS NOT NULL
+  AND contract_deployment_status IS NULL;

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -30,6 +30,9 @@ const {
   refreshActiveCampaignStatuses,
 } = require("./services/campaignStatusService");
 const {
+  retryFailedContractDeployments,
+} = require("./services/contractDeploymentRetryService");
+const {
   sendWeeklyContributorDigests,
 } = require("./services/weeklyDigestService");
 const { flushQuietHours } = require("./services/notifications");
@@ -394,6 +397,17 @@ function startNotificationDigestCron() {
   logger.info("Notification digest cron scheduled", { schedule });
 }
 
+function startContractDeploymentRetryCron() {
+  if (!ff.isEnabled("contract-deployment-retry-cron")) return;
+  const cron = require("node-cron");
+  cron.schedule("*/10 * * * *", () => {
+    retryFailedContractDeployments().catch((err) => {
+      logger.error("Contract deployment retry cron failed", { error: err.message });
+    });
+  });
+  logger.info("Contract deployment retry cron scheduled (every 10 minutes)");
+}
+
 async function bootstrap() {
   if (process.env.NODE_ENV === "production") {
     await assertNoLegacyPlaintextUserWalletSecrets();
@@ -410,6 +424,7 @@ async function bootstrap() {
     startReconciliationCron();
     startWeeklyDigestCron();
     startNotificationDigestCron();
+    startContractDeploymentRetryCron();
   });
 }
 

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -9,6 +9,7 @@ const {
 } = require('../middleware/auth');
 const { reconcileSingleCampaign, getRecentReconciliationRuns } = require('../services/reconciliation');
 const { server } = require('../config/stellar');
+const { deployCampaignContracts } = require('../services/sorobanService');
 const {
   processDelivery,
   processCampaignWebhookDelivery,
@@ -161,7 +162,7 @@ router.get('/stats', async (req, res) => {
  */
 router.get('/campaigns', async (req, res) => {
   try {
-    const { status, include_deleted, flagged_only } = req.query;
+    const { status, include_deleted, flagged_only, contract_deployment_status } = req.query;
     const params = [];
     let where = 'WHERE 1=1';
 
@@ -178,9 +179,16 @@ router.get('/campaigns', async (req, res) => {
       where += ` AND c.status = $${params.length}`;
     }
 
+    if (contract_deployment_status) {
+      params.push(contract_deployment_status);
+      where += ` AND c.contract_deployment_status = $${params.length}`;
+    }
+
     const { rows } = await db.query(
       `SELECT c.id, c.title, c.status, c.raised_amount, c.target_amount, 
               c.asset_type, c.created_at, c.deleted_at, c.is_flagged_duplicate,
+              c.contract_deployment_status, c.contract_deployment_error,
+              c.escrow_contract_id,
               u.id as creator_id, u.name as creator_name, u.email as creator_email,
               (SELECT COUNT(*) FROM contributions WHERE campaign_id = c.id) as contribution_count
        FROM campaigns c 
@@ -1122,6 +1130,137 @@ router.get('/campaigns/:id/contributions', async (req, res) => {
   } catch (err) {
     logger.error('Error fetching campaign contributions for admin', { error: err.message });
     res.status(500).json({ error: 'Failed to fetch contributions' });
+  }
+});
+
+/**
+ * POST /api/admin/campaigns/:id/redeploy-contract
+ * Retry contract deployment for a campaign with a failed or missing contract.
+ * Accepts campaigns with contract_deployment_status = 'failed' or NULL (legacy).
+ */
+router.post('/campaigns/:id/redeploy-contract', async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    const { rows: campaignRows } = await db.query(
+      `SELECT c.id, c.title, c.status, c.creator_id, c.escrow_contract_id,
+              c.contract_deployment_status, c.deadline, c.target_amount,
+              c.asset_type, c.platform_fee_bps, c.wallet_public_key,
+              u.wallet_public_key AS creator_public_key
+       FROM campaigns c
+       JOIN users u ON u.id = c.creator_id
+       WHERE c.id = $1 AND c.deleted_at IS NULL`,
+      [id]
+    );
+
+    if (!campaignRows.length) {
+      return res.status(404).json({ error: 'Campaign not found' });
+    }
+
+    const campaign = campaignRows[0];
+
+    if (campaign.escrow_contract_id && campaign.contract_deployment_status === 'deployed') {
+      return res.status(400).json({ error: 'Campaign already has a deployed contract' });
+    }
+
+    if (!process.env.PLATFORM_SECRET_KEY) {
+      return res.status(500).json({ error: 'PLATFORM_SECRET_KEY not configured' });
+    }
+
+    const platformPublicKey = require('@stellar/stellar-sdk').Keypair.fromSecret(
+      process.env.PLATFORM_SECRET_KEY
+    ).publicKey();
+
+    const deadlineUnix = campaign.deadline
+      ? Math.floor(new Date(campaign.deadline).getTime() / 1000)
+      : 0;
+    const assetContractAddress = process.env.USDC_CONTRACT_ADDRESS || process.env.USDC_ISSUER;
+
+    // Mark as deploying
+    await db.query(
+      `UPDATE campaigns
+       SET contract_deployment_status = 'deploying',
+           contract_deployment_error = NULL,
+           last_deployment_attempt_at = NOW()
+       WHERE id = $1`,
+      [id]
+    );
+
+    let escrowContractId;
+    let milestonesContractId;
+    try {
+      ({ escrowContractId, milestonesContractId } = await deployCampaignContracts({
+        creatorPublicKey: campaign.creator_public_key,
+        platformPublicKey,
+        campaignId: campaign.title + Date.now(),
+        targetAmount: Math.floor(Number(campaign.target_amount) * 10_000_000),
+        deadlineUnix,
+        assetContractAddress,
+        platformFeeBps: campaign.platform_fee_bps || 0,
+        milestones: [],
+        signerSecret: process.env.PLATFORM_SECRET_KEY,
+      }));
+    } catch (err) {
+      logger.error('Contract redeploy failed', {
+        campaignId: id,
+        adminId: req.user.userId,
+        error: err.message,
+      });
+
+      await db.query(
+        `UPDATE campaigns
+         SET contract_deployment_status = 'failed',
+             contract_deployment_error = $1,
+             last_deployment_attempt_at = NOW()
+         WHERE id = $2`,
+        [err.message, id]
+      );
+
+      Sentry.withScope((scope) => {
+        scope.setLevel('error');
+        scope.setTag('admin_redeploy', 'contract_deployment');
+        scope.setContext('deployment', { campaignId: id, adminId: req.user.userId });
+        Sentry.captureMessage(`Admin contract redeploy failed for campaign ${id}: ${err.message}`);
+      });
+
+      return res.status(502).json({
+        error: 'Contract deployment failed',
+        detail: err.message,
+      });
+    }
+
+    await db.query(
+      `UPDATE campaigns
+       SET escrow_contract_id = $1,
+           milestones_contract_id = $2,
+           contract_address = $1,
+           contract_deployed_at = NOW(),
+           contract_deployment_status = 'deployed',
+           contract_deployment_error = NULL,
+           last_deployment_attempt_at = NOW()
+       WHERE id = $3`,
+      [escrowContractId, milestonesContractId, id]
+    );
+
+    await logAdminAction(req.user.userId, 'redeploy_contract', 'campaign', id, {
+      escrow_contract_id: escrowContractId,
+      milestones_contract_id: milestonesContractId,
+    });
+
+    logger.info('Contract redeployed', {
+      campaignId: id,
+      adminId: req.user.userId,
+      escrowContractId,
+    });
+
+    res.json({
+      message: 'Contract deployed successfully',
+      escrow_contract_id: escrowContractId,
+      milestones_contract_id: milestonesContractId,
+    });
+  } catch (err) {
+    logger.error('Error in redeploy-contract', { error: err.message, campaignId: req.params.id });
+    res.status(500).json({ error: 'Failed to redeploy contract' });
   }
 });
 

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -1,5 +1,6 @@
 const router = require('express').Router();
 const multer = require('multer');
+const Sentry = require('@sentry/node');
 const db = require('../config/database');
 const logger = require('../config/logger');
 const { requireAuth, requireRole } = require('../middleware/auth');
@@ -463,7 +464,8 @@ router.get('/categories', asyncHandler(async (req, res) => {
 router.get('/:id/contract-status', asyncHandler(async (req, res) => {
   const { rows } = await db.query(
     `SELECT id, contract_address, escrow_contract_id, milestones_contract_id,
-            target_amount, deadline, status
+            target_amount, deadline, status,
+            contract_deployment_status, contract_deployment_error
      FROM campaigns
      WHERE id = $1`,
     [req.params.id]
@@ -479,6 +481,8 @@ router.get('/:id/contract-status', asyncHandler(async (req, res) => {
   if (!escrowContractId && !campaign.milestones_contract_id) {
     return res.json({
       has_contract: false,
+      contract_deployment_status: campaign.contract_deployment_status,
+      contract_deployment_error: campaign.contract_deployment_error,
       status: campaign.status,
       totalRaised: 0,
       milestones: [],
@@ -503,6 +507,7 @@ router.get('/:id/contract-status', asyncHandler(async (req, res) => {
       contract_address: campaign.contract_address || escrowContractId,
       escrow_contract_id: escrowContractId,
       milestones_contract_id: campaign.milestones_contract_id,
+      contract_deployment_status: campaign.contract_deployment_status,
       ...onChain,
     });
   } catch (err) {
@@ -1013,6 +1018,8 @@ router.post('/', requireAuth, requireRole('creator', 'admin'), createCampaignVal
 
   let escrowContractId;
   let milestonesContractId;
+  let contractDeploymentStatus;
+  let contractDeploymentError = null;
   try {
     ({ escrowContractId, milestonesContractId } = await deployCampaignContracts({
       creatorPublicKey,
@@ -1025,17 +1032,26 @@ router.post('/', requireAuth, requireRole('creator', 'admin'), createCampaignVal
       milestones: normalizedMilestones,
       signerSecret: process.env.PLATFORM_SECRET_KEY,
     }));
+    contractDeploymentStatus = 'deployed';
   } catch (err) {
     logger.error('Soroban contract deployment failed during campaign creation', {
       error: err.message,
       creatorUserId: req.user.userId,
     });
-    return res.status(502).json({
-      error: 'Soroban contract deployment failed',
-      detail: err.message,
+    contractDeploymentStatus = 'failed';
+    contractDeploymentError = err.message;
+
+    Sentry.withScope((scope) => {
+      scope.setLevel('error');
+      scope.setTag('campaign_creation', 'contract_deployment');
+      scope.setContext('deployment', {
+        creatorUserId: req.user.userId,
+        error: err.message,
+      });
+      Sentry.captureMessage(`Contract deployment failed during campaign creation: ${err.message}`);
     });
   }
-  const contractAddress = escrowContractId;
+  const contractAddress = escrowContractId || null;
 
   const client = await db.connect();
   let campaign;
@@ -1045,12 +1061,15 @@ router.post('/', requireAuth, requireRole('creator', 'admin'), createCampaignVal
       `INSERT INTO campaigns
          (title, description, target_amount, asset_type, wallet_public_key, creator_id, deadline, 
           min_contribution, max_contribution, escrow_contract_id, milestones_contract_id, platform_fee_bps,
-          contract_address, contract_deployed_at, content_fingerprint, is_flagged_duplicate)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW(), $14, $15)
+          contract_address, contract_deployed_at, content_fingerprint, is_flagged_duplicate,
+          contract_deployment_status, contract_deployment_error, last_deployment_attempt_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
        RETURNING *`,
       [title, description, target_amount, asset_type, wallet.publicKey, req.user.userId, deadline, 
        min_contribution || null, max_contribution || null, escrowContractId, milestonesContractId, platformFeeBps,
-       contractAddress, contentFingerprint, isFlaggedDuplicate]
+       contractAddress, contractDeploymentStatus === 'deployed' ? new Date() : null,
+       contentFingerprint, isFlaggedDuplicate,
+       contractDeploymentStatus, contractDeploymentError, new Date()]
     );
     campaign = rows[0];
 

--- a/backend/src/services/contractDeploymentRetryService.js
+++ b/backend/src/services/contractDeploymentRetryService.js
@@ -1,0 +1,155 @@
+const db = require('../config/database');
+const logger = require('../config/logger');
+const Sentry = require('@sentry/node');
+const { deployCampaignContracts } = require('./sorobanService');
+const { Keypair } = require('@stellar/stellar-sdk');
+
+const RETRY_LOCK_KEY = 323002;
+const MAX_RETRIES_PER_RUN = 10;
+const MIN_BACKOFF_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Retry failed contract deployments for campaigns stuck in 'failed' status.
+ * Guarded by a Postgres advisory lock so overlapping cron ticks do not run in parallel.
+ */
+async function retryFailedContractDeployments() {
+  const client = await db.connect();
+  let lockAcquired = false;
+
+  try {
+    const { rows: lockRows } = await client.query(
+      'SELECT pg_try_advisory_lock($1) AS acquired',
+      [RETRY_LOCK_KEY]
+    );
+    lockAcquired = lockRows[0]?.acquired === true;
+    if (!lockAcquired) {
+      logger.info('Contract deployment retry skipped — another instance holds the advisory lock');
+      return { retried: 0, succeeded: 0, failed: 0, skipped: true };
+    }
+
+    // Find campaigns with failed deployment, waiting at least MIN_BACKOFF_MS since last attempt
+    const { rows: campaigns } = await client.query(
+      `SELECT c.id, c.title, c.creator_id, c.deadline, c.target_amount,
+              c.asset_type, c.platform_fee_bps, c.contract_deployment_error,
+              c.last_deployment_attempt_at,
+              u.wallet_public_key AS creator_public_key
+       FROM campaigns c
+       JOIN users u ON u.id = c.creator_id
+       WHERE c.contract_deployment_status = 'failed'
+         AND c.deleted_at IS NULL
+         AND c.last_deployment_attempt_at < NOW() - INTERVAL '5 minutes'
+       ORDER BY c.last_deployment_attempt_at ASC
+       LIMIT $1`,
+      [MAX_RETRIES_PER_RUN]
+    );
+
+    if (!campaigns.length) {
+      return { retried: 0, succeeded: 0, failed: 0, skipped: false };
+    }
+
+    const platformSecret = process.env.PLATFORM_SECRET_KEY;
+    if (!platformSecret) {
+      logger.warn('Skipping contract deployment retry — PLATFORM_SECRET_KEY not configured');
+      return { retried: 0, succeeded: 0, failed: 0, skipped: false };
+    }
+
+    const platformPublicKey = Keypair.fromSecret(platformSecret).publicKey();
+    const assetContractAddress = process.env.USDC_CONTRACT_ADDRESS || process.env.USDC_ISSUER;
+
+    let succeeded = 0;
+    let failed = 0;
+
+    for (const campaign of campaigns) {
+      // Mark as deploying
+      await client.query(
+        `UPDATE campaigns
+         SET contract_deployment_status = 'deploying',
+             last_deployment_attempt_at = NOW()
+         WHERE id = $1`,
+        [campaign.id]
+      );
+
+      const deadlineUnix = campaign.deadline
+        ? Math.floor(new Date(campaign.deadline).getTime() / 1000)
+        : 0;
+
+      try {
+        const { escrowContractId, milestonesContractId } = await deployCampaignContracts({
+          creatorPublicKey: campaign.creator_public_key,
+          platformPublicKey,
+          campaignId: campaign.title + Date.now(),
+          targetAmount: Math.floor(Number(campaign.target_amount) * 10_000_000),
+          deadlineUnix,
+          assetContractAddress,
+          platformFeeBps: campaign.platform_fee_bps || 0,
+          milestones: [],
+          signerSecret: platformSecret,
+        });
+
+        await client.query(
+          `UPDATE campaigns
+           SET escrow_contract_id = COALESCE(escrow_contract_id, $1),
+               milestones_contract_id = COALESCE(milestones_contract_id, $2),
+               contract_address = COALESCE(contract_address, $1),
+               contract_deployed_at = COALESCE(contract_deployed_at, NOW()),
+               contract_deployment_status = 'deployed',
+               contract_deployment_error = NULL,
+               last_deployment_attempt_at = NOW()
+           WHERE id = $3`,
+          [escrowContractId, milestonesContractId, campaign.id]
+        );
+
+        logger.info('Contract deployment retry succeeded', {
+          campaignId: campaign.id,
+          escrowContractId,
+        });
+        succeeded++;
+      } catch (err) {
+        await client.query(
+          `UPDATE campaigns
+           SET contract_deployment_status = 'failed',
+               contract_deployment_error = $1,
+               last_deployment_attempt_at = NOW()
+           WHERE id = $2`,
+          [err.message, campaign.id]
+        );
+
+        logger.error('Contract deployment retry failed', {
+          campaignId: campaign.id,
+          error: err.message,
+          previousError: campaign.contract_deployment_error,
+        });
+
+        Sentry.withScope((scope) => {
+          scope.setLevel('warning');
+          scope.setTag('cron_redeploy', 'contract_deployment');
+          scope.setContext('deployment', {
+            campaignId: campaign.id,
+            error: err.message,
+            previousError: campaign.contract_deployment_error,
+          });
+          Sentry.captureMessage(
+            `Contract deployment retry failed for campaign ${campaign.id}: ${err.message}`
+          );
+        });
+
+        failed++;
+      }
+    }
+
+    logger.info('Contract deployment retry batch completed', {
+      retried: campaigns.length,
+      succeeded,
+      failed,
+    });
+
+    return { retried: campaigns.length, succeeded, failed, skipped: false };
+  } finally {
+    if (lockAcquired) {
+      await client.query('SELECT pg_advisory_unlock($1)', [RETRY_LOCK_KEY]);
+    }
+    client.release();
+  }
+}
+
+module.exports = { retryFailedContractDeployments };

--- a/backend/src/services/featureFlags.js
+++ b/backend/src/services/featureFlags.js
@@ -63,6 +63,14 @@ const FLAGS = {
     allowedRoles: null,
     allowedUserIds: null,
   },
+  'contract-deployment-retry-cron': {
+    description: 'Enable the cron that retries failed Soroban contract deployments',
+    envVar: 'ENABLE_CONTRACT_DEPLOYMENT_RETRY_CRON',
+    defaultValue: true,
+    rolloutPct: null,
+    allowedRoles: null,
+    allowedUserIds: null,
+  },
   'kyc-required-for-campaigns': {
     description: 'Require KYC verification before a user can create a campaign',
     envVar: 'KYC_REQUIRED_FOR_CAMPAIGNS',


### PR DESCRIPTION
## Summary

Fixes #399 — Failed Soroban contract deployment leaves campaign in inconsistent state.

## Problem

When `deployCampaignContracts()` fails in `backend/src/routes/campaigns.js`, the route returns a 502 and the campaign is never persisted. If the Stellar wallet was already created, it becomes orphaned. The campaign is stuck in a broken state with no retry mechanism.

## Changes

### 1. Database migration (`20260725_contract_deployment_status.sql`)
- Add `contract_deployment_status` column (`deploying` | `deployed` | `failed` | NULL)
- Add `contract_deployment_error` column for the last error message
- Add `last_deployment_attempt_at` timestamp for retry backoff
- Add partial index on `failed` status for the cron retry query
- Backfill existing campaigns that already have a deployed contract

### 2. Campaign creation persists on failure (`campaigns.js`)
- Instead of returning 502 and aborting, the campaign is created with `contract_deployment_status = 'failed'` and the error is stored
- Campaign exists in a degraded but recoverable state
- Sentry alert fires immediately on deployment failure

### 3. Admin retry endpoint (`admin.js`)
- `POST /api/admin/campaigns/:id/redeploy-contract` for manual retry
- Accepts campaigns with `failed` status or NULL (legacy)
- Updates contract IDs on success, logs error + Sentry on failure
- Admin action is audit-logged

### 4. Automatic retry cron (`contractDeploymentRetryService.js`)
- Runs every 10 minutes, guarded by Postgres advisory lock
- Picks up campaigns with `failed` status where last attempt was >5 min ago
- Retries up to 10 campaigns per run
- Fires Sentry on each failure
- Feature-flagged via `contract-deployment-retry-cron`

### 5. Admin dashboard visibility (`admin.js`)
- Campaign listing returns `contract_deployment_status`, `contract_deployment_error`
- Supports filtering by `?contract_deployment_status=failed`

### 6. Public contract-status endpoint (`campaigns.js`)
- `GET /api/campaigns/:id/contract-status` includes `contract_deployment_status`

## Acceptance Criteria

- [x] Contract deployment status tracked in DB
- [x] Failed deployments trigger Sentry alert
- [x] Admin can retry contract deployment via API
- [x] Campaign clearly shows degraded state in admin dashboard when contract is missing
