### PR TITLE
feat(#403): admin endpoint to retry failed Soroban contract deployments

### DIFF
--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1188,8 +1188,9 @@ router.post('/campaigns/:id/redeploy-contract', async (req, res) => {
 
     let escrowContractId;
     let milestonesContractId;
+    let deploymentTxHash;
     try {
-      ({ escrowContractId, milestonesContractId } = await deployCampaignContracts({
+      ({ escrowContractId, milestonesContractId, deploymentTxHash } = await deployCampaignContracts({
         creatorPublicKey: campaign.creator_public_key,
         platformPublicKey,
         campaignId: campaign.title + Date.now(),
@@ -1245,18 +1246,21 @@ router.post('/campaigns/:id/redeploy-contract', async (req, res) => {
     await logAdminAction(req.user.userId, 'redeploy_contract', 'campaign', id, {
       escrow_contract_id: escrowContractId,
       milestones_contract_id: milestonesContractId,
+      deployment_tx_hash: deploymentTxHash,
     });
 
     logger.info('Contract redeployed', {
       campaignId: id,
       adminId: req.user.userId,
       escrowContractId,
+      deploymentTxHash,
     });
 
     res.json({
       message: 'Contract deployed successfully',
       escrow_contract_id: escrowContractId,
       milestones_contract_id: milestonesContractId,
+      deployment_tx_hash: deploymentTxHash,
     });
   } catch (err) {
     logger.error('Error in redeploy-contract', { error: err.message, campaignId: req.params.id });

--- a/backend/src/services/sorobanService.js
+++ b/backend/src/services/sorobanService.js
@@ -227,7 +227,10 @@ async function createContractFromWasmHash({ wasmHash, signerSecret }) {
       const meta = xdr.TransactionMeta.fromXDR(result.resultMetaXdr, 'base64');
       const created = meta.v3().sorobanMeta().createdContracts();
       if (created && created.length > 0) {
-        return created[0].contractId().toString('hex');
+        return {
+          contractId: created[0].contractId().toString('hex'),
+          txHash: result.hash || null,
+        };
       }
     }
   }
@@ -339,21 +342,21 @@ async function deployCampaignContracts({
 
   try {
     logger.info('Deploying escrow contract instance...');
-    const escrowContractId = await createContractFromWasmHash({
+    const escrow = await createContractFromWasmHash({
       wasmHash: escrowWasmHash,
       signerSecret,
     });
 
     logger.info('Deploying milestones contract instance...');
-    const milestonesContractId = await createContractFromWasmHash({
+    const milestones = await createContractFromWasmHash({
       wasmHash: milestonesWasmHash,
       signerSecret,
     });
 
     logger.info('Initializing escrow contract...');
     await initializeEscrow({
-      contractId: escrowContractId,
-      adminAddress: milestonesContractId,
+      contractId: escrow.contractId,
+      adminAddress: milestones.contractId,
       campaignId: parseInt(campaignId.replace(/-/g, '').slice(0, 8), 16) || 1,
       target: targetAmount,
       deadline: deadlineUnix,
@@ -365,15 +368,19 @@ async function deployCampaignContracts({
 
     logger.info('Initializing milestones contract...');
     await initializeMilestones({
-      contractId: milestonesContractId,
+      contractId: milestones.contractId,
       creatorAddress: creatorPublicKey,
       platformAddress: platformPublicKey,
-      escrowContractId,
+      escrowContractId: escrow.contractId,
       milestones,
       signerSecret,
     });
 
-    return { escrowContractId, milestonesContractId };
+    return {
+      escrowContractId: escrow.contractId,
+      milestonesContractId: milestones.contractId,
+      deploymentTxHash: escrow.txHash,
+    };
   } catch (err) {
     logger.error('Soroban contract deployment failed', { error: err.message });
     throw new Error(`Soroban contract deployment failed: ${err.message}`);


### PR DESCRIPTION
## Summary

Fixes #403 — Add admin endpoint to retry failed Soroban contract deployments.

## Problem

When a campaign's Soroban contract deployment fails (network error, fee spike, sequence mismatch), there is currently no way to retry it without developer intervention in the database. Admins need a self-service endpoint to unblock stuck campaigns.

## Changes

### 1. `POST /api/admin/campaigns/:id/redeploy-contract` (`admin.js`)
- Protected by admin auth middleware (`requireAuth` + `requireAdmin` at router level)
- Validates campaign exists and is not soft-deleted
- Rejects campaigns that already have a successfully deployed contract (`contract_deployment_status = 'deployed'`)
- Accepts campaigns with `failed` status or `NULL` (legacy pre-tracking campaigns)
- Marks campaign as `deploying` before attempt, updates to `deployed` or `failed` after
- Returns deployment result details: `escrow_contract_id`, `milestones_contract_id`, `deployment_tx_hash`
- All results logged with campaign ID, admin ID, and tx hash via structured logger
- Admin action audit-logged to `admin_actions` table with full context

### 2. Contract deployment status tracking (`campaigns.js`, migration)
- New `contract_deployment_status` column (`deploying` | `deployed` | `failed` | NULL)
- New `contract_deployment_error` column stores the last failure message
- New `last_deployment_attempt_at` timestamp for retry backoff
- Campaign creation no longer aborts on deployment failure — persists in degraded state with `failed` status
- Partial index on `failed` status for efficient cron retry queries
- Backfill existing campaigns that already have a deployed contract

### 3. Deployment tx hash in audit trail (`sorobanService.js`)
- `createContractFromWasmHash` now returns `{ contractId, txHash }` instead of just the contract ID
- `deployCampaignContracts` bubbles up `deploymentTxHash` in its return value
- Admin redeploy endpoint captures and logs the tx hash in structured logs, Sentry context, and admin audit table

### 4. Sentry alerting on failure (`campaigns.js`, `admin.js`)
- Campaign creation fires Sentry alert when contract deployment fails
- Admin redeploy fires Sentry alert on failure with campaign ID and admin ID context

### 5. Automatic retry cron (`contractDeploymentRetryService.js`, `featureFlags.js`, `index.js`)
- New service retries failed contract deployments every 10 minutes
- Guarded by Postgres advisory lock (no duplicate runs across instances)
- Retries up to 10 campaigns per run, with 5-minute backoff between attempts
- Feature-flagged via `contract-deployment-retry-cron` (enabled by default)

### 6. Admin dashboard visibility (`admin.js`)
- `GET /api/admin/campaigns` now returns `contract_deployment_status`, `contract_deployment_error`, and `escrow_contract_id`
- Supports filtering by `?contract_deployment_status=failed` to surface broken campaigns
- `GET /api/campaigns/:id/contract-status` includes `contract_deployment_status` for frontend degraded-state display

## Acceptance Criteria

- [x] Endpoint protected by admin auth middleware
- [x] Cannot re-deploy to a campaign that already has a deployed contract
- [x] Deployment result (success/failure) logged with campaign ID and tx hash
- [x] Admin UI surfaces campaigns awaiting contract deployment via filtered listing

## Testing

All modified files pass `node --check` syntax validation.
