### PR TITLE
feat: add platform-wide announcements

### DIFF
--- a/backend/db/migrations/20260725_platform_announcements.sql
+++ b/backend/db/migrations/20260725_platform_announcements.sql
@@ -1,0 +1,38 @@
+CREATE TABLE IF NOT EXISTS platform_announcements (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  message TEXT NOT NULL CHECK (length(trim(message)) > 0),
+  severity VARCHAR(20) NOT NULL DEFAULT 'info'
+    CHECK (severity IN ('info', 'warning', 'critical')),
+
+  details_url TEXT,
+  active_from TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  active_until TIMESTAMPTZ,
+  deactivated_at TIMESTAMPTZ,
+  created_by UUID NOT NULL
+    REFERENCES users(id)
+    ON DELETE RESTRICT,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CHECK (
+    active_until IS NULL
+    OR active_until > active_from
+  ),
+
+  CHECK (
+    deactivated_at IS NULL
+    OR deactivated_at >= active_from
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_announcements_active_period
+  ON platform_announcements (active_from, active_until);
+
+CREATE INDEX IF NOT EXISTS idx_announcements_created_by
+  ON platform_announcements (created_by);
+
+CREATE INDEX IF NOT EXISTS idx_announcements_current
+  ON platform_announcements (active_from DESC)
+  WHERE deactivated_at IS NULL;

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -129,7 +129,42 @@ CREATE TABLE withdrawal_approval_events (
   created_at              TIMESTAMPTZ DEFAULT NOW()
 );
 
+CREATE TABLE platform_announcements (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+ 
+  message TEXT NOT NULL CHECK (length(trim(message)) > 0),
+  severity                VARCHAR(20) NOT NULL DEFAULT 'info'
+                            CHECK (severity IN ('info', 'warning', 'critical')),
+
+  details_url             TEXT,
+  active_from             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  active_until            TIMESTAMPTZ,
+  deactivated_at          TIMESTAMPTZ,
+  created_by              UUID NOT NULL
+                            REFERENCES users(id)
+                            ON DELETE RESTRICT,
+
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    
+  CHECK (
+    active_until IS NULL
+    OR active_until > active_from
+  ),
+  
+  CHECK (
+    deactivated_at IS NULL
+    OR deactivated_at >= active_from
+  )
+);
+
 -- Indexes
+
+CREATE INDEX idx_announcements_active_period ON platform_announcements (active_from, active_until);
+CREATE INDEX idx_announcements_created_by ON platform_announcements (created_by);
+CREATE INDEX idx_announcements_current ON platform_announcements (active_from DESC)
+  WHERE deactivated_at IS NULL;
+
 CREATE INDEX ON contributions (campaign_id);
 CREATE INDEX idx_contributions_campaign_unrefunded
   ON contributions (campaign_id)

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -166,7 +166,12 @@ const openApiSpec = swaggerJsdoc({
   },
   apis: ["./src/routes/*.js"],
 });
-app.use("/api/docs", swaggerUi.serve, swaggerUi.setup(openApiSpec));
+app.get("/api/docs/openapi.json", (_req, res) => res.json(openApiSpec));
+app.use(
+  "/api/docs",
+  swaggerUi.serveFiles(openApiSpec),
+  swaggerUi.setup(openApiSpec),
+);
 
 const v1OpenApiSpec = swaggerJsdoc({
   definition: {
@@ -224,8 +229,16 @@ app.use("/api/v1/dev", require("./routes/dev"));
 app.use("/v1/dev", require("./routes/dev"));
 app.get("/api/v1/docs/openapi.json", (_req, res) => res.json(v1OpenApiSpec));
 app.get("/v1/docs/openapi.json", (_req, res) => res.json(v1OpenApiSpec));
-app.use("/api/v1/docs", swaggerUi.serve, swaggerUi.setup(v1OpenApiSpec));
-app.use("/v1/docs", swaggerUi.serve, swaggerUi.setup(v1OpenApiSpec));
+app.use(
+  "/api/v1/docs",
+  swaggerUi.serveFiles(v1OpenApiSpec),
+  swaggerUi.setup(v1OpenApiSpec),
+);
+app.use(
+  "/v1/docs",
+  swaggerUi.serveFiles(v1OpenApiSpec),
+  swaggerUi.setup(v1OpenApiSpec),
+);
 
 app.use("/api/auth", require("./routes/auth"));
 // Backwards/alternate compatibility for docs + clients expecting /api/users/register|login.
@@ -253,6 +266,7 @@ app.use("/api/notifications", require("./routes/notifications"));
 app.use("/api/emails", require("./routes/emails"));
 app.use("/api/campaigns", require("./routes/thankYou"));
 app.use("/api/contributions", require("./routes/thankYou"));
+app.use("/api", require("./routes/announcement"));
 
 app.get("/health", async (_, res) => {
   try {

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -1,4 +1,4 @@
-const { body, query, validationResult } = require('express-validator');
+const { body, param, query, validationResult } = require('express-validator');
 const { Keypair } = require('@stellar/stellar-sdk');
 const { getSupportedAssetCodes } = require('../services/stellarService');
 const { stripHtml, sanitizeRichText } = require('../lib/sanitize');
@@ -14,6 +14,10 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{
 
 function isUuid(value) {
   return typeof value === 'string' && UUID_PATTERN.test(value);
+}
+
+function blankToNull(value) {
+  return typeof value === 'string' && value.trim() === '' ? null : value;
 }
 
 const passwordValidation = [
@@ -297,6 +301,52 @@ const withdrawalValidation = [
     }),
 ];
 
+const createAnnouncementValidation = [
+  body('message')
+    .customSanitizer(stripHtml)
+    .trim()
+    .notEmpty()
+    .withMessage('message is required')
+    .isLength({ max: 500 })
+    .withMessage('message must be at most 500 characters'),
+  body('severity')
+    .customSanitizer(blankToNull)
+    .optional({ nullable: true })
+    .isIn(['info', 'warning', 'critical'])
+    .withMessage('severity must be info, warning, or critical'),
+  body('details_url')
+    .customSanitizer(blankToNull)
+    .optional({ nullable: true })
+    .isURL({ require_protocol: true })
+    .withMessage('details_url must be a valid URL'),
+  body('active_from')
+    .customSanitizer(blankToNull)
+    .optional({ nullable: true })
+    .isISO8601()
+    .withMessage('active_from must be a valid ISO 8601 date-time'),
+  body('active_until')
+    .customSanitizer(blankToNull)
+    .optional({ nullable: true })
+    .isISO8601()
+    .withMessage('active_until must be a valid ISO 8601 date-time')
+    .custom((value, { req }) => {
+      const activeFrom = req.body.active_from;
+      const startsAt = activeFrom ? new Date(activeFrom) : new Date();
+      if (new Date(value).getTime() <= startsAt.getTime()) {
+        throw new Error(activeFrom ? 'active_until must be after active_from' : 'active_until must be in the future');
+      }
+      return true;
+    }),
+];
+
+const announcementIdValidation = [
+  param('id')
+    .custom((value) => {
+      if (!isUuid(value)) throw new Error('id must be a valid UUID');
+      return true;
+    }),
+];
+
 const getCampaignsValidation = [
   query('search').optional().customSanitizer(stripHtml),
   query('category').optional().customSanitizer(stripHtml),
@@ -377,6 +427,8 @@ module.exports = {
   contributionValidation,
   contributionQuoteValidation,
   withdrawalValidation,
+  createAnnouncementValidation,
+  announcementIdValidation,
   getCampaignsValidation,
   validateRequest,
 };

--- a/backend/src/middleware/validation.test.js
+++ b/backend/src/middleware/validation.test.js
@@ -1,18 +1,25 @@
-process.env.USDC_ISSUER = process.env.USDC_ISSUER || 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
-process.env.STELLAR_NETWORK = process.env.STELLAR_NETWORK || 'testnet';
+process.env.USDC_ISSUER =
+  process.env.USDC_ISSUER ||
+  "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+process.env.STELLAR_NETWORK = process.env.STELLAR_NETWORK || "testnet";
+process.env.PLATFORM_SECRET_KEY =
+  process.env.PLATFORM_SECRET_KEY ||
+  "SCVMQUS5EMTHWBLJTE5XCSCMHB2ZOVKRR4ATVTRPUNRCOGKRENIL3LHR";
 
-const test = require('node:test');
-const assert = require('node:assert/strict');
-const { validationResult } = require('express-validator');
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { validationResult } = require("express-validator");
 const {
   registerValidation,
   createCampaignValidation,
   contributionValidation,
   withdrawalValidation,
-} = require('../middleware/validation');
+  createAnnouncementValidation,
+  announcementIdValidation,
+} = require("../middleware/validation");
 
-async function runValidation(validations, body = {}, query = {}) {
-  const req = { body, query };
+async function runValidation(validations, body = {}, query = {}, params = {}) {
+  const req = { body, query, params };
   for (const fn of validations) {
     await fn(req, {}, () => {});
   }
@@ -23,202 +30,293 @@ async function runValidation(validations, body = {}, query = {}) {
   return { ok: true, req };
 }
 
-test('register validation rejects invalid email and short password', async () => {
+test("register validation rejects invalid email and short password", async () => {
   const result = await runValidation(registerValidation, {
-    email: 'not-an-email',
-    password: 'short',
-    name: '',
+    email: "not-an-email",
+    password: "short",
+    name: "",
   });
   assert.equal(result.ok, false);
   assert.ok(result.errors.length >= 2);
 });
 
-test('createCampaign validation rejects title longer than 100 characters', async () => {
+test("createCampaign validation rejects title longer than 100 characters", async () => {
   const result = await runValidation(createCampaignValidation, {
-    title: 'x'.repeat(101),
-    target_amount: '10',
-    asset_type: 'USDC',
+    title: "x".repeat(101),
+    target_amount: "10",
+    asset_type: "USDC",
   });
   assert.equal(result.ok, false);
-  assert.ok(result.errors.some((e) => e.path === 'title'));
+  assert.ok(result.errors.some((e) => e.path === "title"));
 });
 
-test('contribution validation rejects non-UUID campaign_id', async () => {
+test("contribution validation rejects non-UUID campaign_id", async () => {
   const result = await runValidation(contributionValidation, {
-    campaign_id: 'not-a-uuid',
-    amount: '5',
-    send_asset: 'XLM',
+    campaign_id: "not-a-uuid",
+    amount: "5",
+    send_asset: "XLM",
   });
   assert.equal(result.ok, false);
-  assert.ok(result.errors.some((e) => e.path === 'campaign_id'));
+  assert.ok(result.errors.some((e) => e.path === "campaign_id"));
 });
 
-test('withdrawal validation rejects invalid Stellar destination key', async () => {
+test("withdrawal validation rejects invalid Stellar destination key", async () => {
   const result = await runValidation(withdrawalValidation, {
-    campaign_id: '11111111-1111-1111-1111-111111111111',
-    amount: '10',
-    destination_key: 'invalid-key',
+    campaign_id: "11111111-1111-1111-1111-111111111111",
+    amount: "10",
+    destination_key: "invalid-key",
   });
   assert.equal(result.ok, false);
-  assert.ok(result.errors.some((e) => e.path === 'destination_key'));
+  assert.ok(result.errors.some((e) => e.path === "destination_key"));
 });
 
-test('register validation passes for valid payload', async () => {
+test("createAnnouncement validation rejects invalid announcement fields", async () => {
+  const result = await runValidation(createAnnouncementValidation, {
+    message: "",
+    severity: "urgent",
+    details_url: "not-a-url",
+    active_from: "2026-07-25T12:00:00.000Z",
+    active_until: "2026-07-25T11:00:00.000Z",
+  });
+
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => e.path === "message"));
+  assert.ok(result.errors.some((e) => e.path === "severity"));
+  assert.ok(result.errors.some((e) => e.path === "details_url"));
+  assert.ok(result.errors.some((e) => e.path === "active_until"));
+});
+
+test("createAnnouncement validation accepts a minimal valid payload", async () => {
+  const result = await runValidation(createAnnouncementValidation, {
+    message: "Scheduled maintenance",
+  });
+
+  assert.equal(result.ok, true);
+});
+
+test("createAnnouncement validation normalizes blank optional fields", async () => {
+  const body = {
+    message: "Scheduled maintenance",
+    severity: "",
+    details_url: "",
+    active_from: "",
+    active_until: "",
+  };
+  const result = await runValidation(createAnnouncementValidation, body);
+
+  assert.equal(result.ok, true);
+  assert.equal(body.severity, null);
+  assert.equal(body.details_url, null);
+  assert.equal(body.active_from, null);
+  assert.equal(body.active_until, null);
+});
+
+test("createAnnouncement validation rejects active_until in the past without active_from", async () => {
+  const result = await runValidation(createAnnouncementValidation, {
+    message: "Expired announcement",
+    active_until: "2000-01-01T00:00:00.000Z",
+  });
+
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.errors.some(
+      (e) => e.path === "active_until" && /future/.test(e.msg),
+    ),
+  );
+});
+
+test("announcementId validation rejects non-UUID ids", async () => {
+  const result = await runValidation(
+    announcementIdValidation,
+    {},
+    {},
+    {
+      id: "not-a-uuid",
+    },
+  );
+
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => e.path === "id"));
+});
+
+test("register validation passes for valid payload", async () => {
   const result = await runValidation(registerValidation, {
-    email: 'user@example.com',
-    password: 'Password1',
-    name: 'Test User',
+    email: "user@example.com",
+    password: "Password1",
+    name: "Test User",
   });
   assert.equal(result.ok, true);
 });
 
-test('createCampaign validation rejects negative max_per_user', async () => {
+test("createCampaign validation rejects negative max_per_user", async () => {
   const result = await runValidation(createCampaignValidation, {
-    title: 'Valid Title',
-    target_amount: '10',
-    asset_type: 'USDC',
-    max_per_user: '-5',
+    title: "Valid Title",
+    target_amount: "10",
+    asset_type: "USDC",
+    max_per_user: "-5",
   });
   assert.equal(result.ok, false);
-  assert.ok(result.errors.some((e) => e.path === 'max_per_user'));
+  assert.ok(result.errors.some((e) => e.path === "max_per_user"));
 });
 
-test('createCampaign validation rejects max_per_user less than or equal to min_contribution', async () => {
+test("createCampaign validation rejects max_per_user less than or equal to min_contribution", async () => {
   const result = await runValidation(createCampaignValidation, {
-    title: 'Valid Title',
-    target_amount: '100',
-    asset_type: 'USDC',
-    min_contribution: '10',
-    max_per_user: '10',
+    title: "Valid Title",
+    target_amount: "100",
+    asset_type: "USDC",
+    min_contribution: "10",
+    max_per_user: "10",
   });
   assert.equal(result.ok, false);
-  assert.ok(result.errors.some((e) => e.path === 'max_per_user' && e.msg === 'Per-contributor cap must be greater than minimum contribution'));
+  assert.ok(
+    result.errors.some(
+      (e) =>
+        e.path === "max_per_user" &&
+        e.msg ===
+          "Per-contributor cap must be greater than minimum contribution",
+    ),
+  );
 });
 
-test('createCampaign validation passes with valid limit parameters', async () => {
+test("createCampaign validation passes with valid limit parameters", async () => {
   const result = await runValidation(createCampaignValidation, {
-    title: 'Valid Title',
-    target_amount: '100',
-    asset_type: 'USDC',
-    min_contribution: '10',
-    max_contribution: '50',
-    max_per_user: '80',
+    title: "Valid Title",
+    target_amount: "100",
+    asset_type: "USDC",
+    min_contribution: "10",
+    max_contribution: "50",
+    max_per_user: "80",
   });
   assert.equal(result.ok, true);
 });
-
 
 // Milestone percentage total validation tests
-test('createCampaign validation rejects milestone percentages exceeding 100%', async () => {
+test("createCampaign validation rejects milestone percentages exceeding 100%", async () => {
   const result = await runValidation(createCampaignValidation, {
-    title: 'Test Campaign',
-    target_amount: '100',
-    asset_type: 'USDC',
+    title: "Test Campaign",
+    target_amount: "100",
+    asset_type: "USDC",
     milestones: [
-      { title: 'Milestone 1', release_percentage: 80 },
-      { title: 'Milestone 2', release_percentage: 80 }
-    ]
+      { title: "Milestone 1", release_percentage: 80 },
+      { title: "Milestone 2", release_percentage: 80 },
+    ],
   });
   assert.equal(result.ok, false);
-  assert.ok(result.errors.some((e) => e.msg === 'Milestone percentages must not exceed 100%'));
+  assert.ok(
+    result.errors.some(
+      (e) => e.msg === "Milestone percentages must not exceed 100%",
+    ),
+  );
 });
 
-test('createCampaign validation accepts milestone percentages totalling exactly 100%', async () => {
+test("createCampaign validation accepts milestone percentages totalling exactly 100%", async () => {
   const result = await runValidation(createCampaignValidation, {
-    title: 'Test Campaign',
-    target_amount: '100',
-    asset_type: 'USDC',
+    title: "Test Campaign",
+    target_amount: "100",
+    asset_type: "USDC",
     milestones: [
-      { title: 'Milestone 1', release_percentage: 40 },
-      { title: 'Milestone 2', release_percentage: 60 }
-    ]
+      { title: "Milestone 1", release_percentage: 40 },
+      { title: "Milestone 2", release_percentage: 60 },
+    ],
   });
   assert.equal(result.ok, true);
 });
 
-test('createCampaign validation accepts milestone percentages totalling less than 100%', async () => {
+test("createCampaign validation accepts milestone percentages totalling less than 100%", async () => {
   const result = await runValidation(createCampaignValidation, {
-    title: 'Test Campaign',
-    target_amount: '100',
-    asset_type: 'USDC',
+    title: "Test Campaign",
+    target_amount: "100",
+    asset_type: "USDC",
     milestones: [
-      { title: 'Milestone 1', release_percentage: 40 },
-      { title: 'Milestone 2', release_percentage: 30 }
-    ]
+      { title: "Milestone 1", release_percentage: 40 },
+      { title: "Milestone 2", release_percentage: 30 },
+    ],
   });
   assert.equal(result.ok, true);
 });
 
-test('createCampaign validation accepts single milestone with 100%', async () => {
+test("createCampaign validation accepts single milestone with 100%", async () => {
   const result = await runValidation(createCampaignValidation, {
-    title: 'Test Campaign',
-    target_amount: '100',
-    asset_type: 'USDC',
-    milestones: [
-      { title: 'Milestone 1', release_percentage: 100 }
-    ]
+    title: "Test Campaign",
+    target_amount: "100",
+    asset_type: "USDC",
+    milestones: [{ title: "Milestone 1", release_percentage: 100 }],
   });
   assert.equal(result.ok, true);
 });
 
-test('createCampaign validation accepts four milestones with 25% each', async () => {
+test("createCampaign validation accepts four milestones with 25% each", async () => {
   const result = await runValidation(createCampaignValidation, {
-    title: 'Test Campaign',
-    target_amount: '100',
-    asset_type: 'USDC',
+    title: "Test Campaign",
+    target_amount: "100",
+    asset_type: "USDC",
     milestones: [
-      { title: 'Milestone 1', release_percentage: 25 },
-      { title: 'Milestone 2', release_percentage: 25 },
-      { title: 'Milestone 3', release_percentage: 25 },
-      { title: 'Milestone 4', release_percentage: 25 }
-    ]
+      { title: "Milestone 1", release_percentage: 25 },
+      { title: "Milestone 2", release_percentage: 25 },
+      { title: "Milestone 3", release_percentage: 25 },
+      { title: "Milestone 4", release_percentage: 25 },
+    ],
   });
   assert.equal(result.ok, true);
 });
 
-test('createCampaign validation rejects milestone percentages with floating point exceeding 100%', async () => {
+test("createCampaign validation rejects milestone percentages with floating point exceeding 100%", async () => {
   const result = await runValidation(createCampaignValidation, {
-    title: 'Test Campaign',
-    target_amount: '100',
-    asset_type: 'USDC',
+    title: "Test Campaign",
+    target_amount: "100",
+    asset_type: "USDC",
     milestones: [
-      { title: 'Milestone 1', release_percentage: 50.1 },
-      { title: 'Milestone 2', release_percentage: 50.1 }
-    ]
+      { title: "Milestone 1", release_percentage: 50.1 },
+      { title: "Milestone 2", release_percentage: 50.1 },
+    ],
   });
   assert.equal(result.ok, false);
-  assert.ok(result.errors.some((e) => e.msg === 'Milestone percentages must not exceed 100%'));
+  assert.ok(
+    result.errors.some(
+      (e) => e.msg === "Milestone percentages must not exceed 100%",
+    ),
+  );
 });
 
-test('contribution validation rejects display_name longer than 50 characters', async () => {
+test("contribution validation rejects display_name longer than 50 characters", async () => {
   const result = await runValidation(contributionValidation, {
-    campaign_id: '123e4567-e89b-12d3-a456-426614174000',
-    amount: '10',
-    send_asset: 'XLM',
-    display_name: 'a'.repeat(51),
+    campaign_id: "123e4567-e89b-12d3-a456-426614174000",
+    amount: "10",
+    send_asset: "XLM",
+    display_name: "a".repeat(51),
   });
   assert.equal(result.ok, false);
-  assert.ok(result.errors.some((e) => e.msg === 'Display name must be at most 50 characters'));
+  assert.ok(
+    result.errors.some(
+      (e) => e.msg === "Display name must be at most 50 characters",
+    ),
+  );
 });
 
-test('contribution validation rejects display_name with null bytes or control characters', async () => {
+test("contribution validation rejects display_name with null bytes or control characters", async () => {
   const result = await runValidation(contributionValidation, {
-    campaign_id: '123e4567-e89b-12d3-a456-426614174000',
-    amount: '10',
-    send_asset: 'XLM',
-    display_name: 'Bad\0User',
+    campaign_id: "123e4567-e89b-12d3-a456-426614174000",
+    amount: "10",
+    send_asset: "XLM",
+    display_name: "Bad\0User",
   });
   assert.equal(result.ok, false);
-  assert.ok(result.errors.some((e) => e.msg === 'Display name contains invalid control characters or null bytes'));
+  assert.ok(
+    result.errors.some(
+      (e) =>
+        e.msg ===
+        "Display name contains invalid control characters or null bytes",
+    ),
+  );
 });
 
-test('contribution validation trims whitespace on valid display_name', async () => {
+test("contribution validation trims whitespace on valid display_name", async () => {
   const result = await runValidation(contributionValidation, {
-    campaign_id: '123e4567-e89b-12d3-a456-426614174000',
-    amount: '10',
-    send_asset: 'XLM',
-    display_name: '   Alice   ',
+    campaign_id: "123e4567-e89b-12d3-a456-426614174000",
+    amount: "10",
+    send_asset: "XLM",
+    display_name: "   Alice   ",
   });
   assert.equal(result.ok, true);
-  assert.equal(result.req.body.display_name, 'Alice');
+  assert.equal(result.req.body.display_name, "Alice");
 });

--- a/backend/src/routes/announcement.js
+++ b/backend/src/routes/announcement.js
@@ -1,0 +1,235 @@
+const router = require("express").Router();
+const db = require("../config/database");
+const { requireAuth, requireRole } = require("../middleware/auth");
+const {
+  announcementIdValidation,
+  createAnnouncementValidation,
+  validateRequest,
+} = require("../middleware/validation");
+const asyncHandler = require("../utils/asyncHandler");
+
+/**
+ * @openapi
+ * components:
+ *   schemas:
+ *     Announcement:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *           format: uuid
+ *         message:
+ *           type: string
+ *         severity:
+ *           type: string
+ *           enum: [info, warning, critical]
+ *         details_url:
+ *           type: string
+ *           nullable: true
+ *         active_from:
+ *           type: string
+ *           format: date-time
+ *         active_until:
+ *           type: string
+ *           format: date-time
+ *           nullable: true
+ *         deactivated_at:
+ *           type: string
+ *           format: date-time
+ *           nullable: true
+ *         created_by:
+ *           type: string
+ *           format: uuid
+ *         created_at:
+ *           type: string
+ *           format: date-time
+ *         updated_at:
+ *           type: string
+ *           format: date-time
+ *       required:
+ *         - id
+ *         - message
+ *         - severity
+ *         - active_from
+ *         - created_by
+ *         - created_at
+ *         - updated_at
+ *     AnnouncementCreateRequest:
+ *       type: object
+ *       required:
+ *         - message
+ *       properties:
+ *         message:
+ *           type: string
+ *         severity:
+ *           type: string
+ *           enum: [info, warning, critical]
+ *           default: info
+ *         details_url:
+ *           type: string
+ *           format: uri
+ *           nullable: true
+ *         active_from:
+ *           type: string
+ *           format: date-time
+ *           nullable: true
+ *         active_until:
+ *           type: string
+ *           format: date-time
+ *           nullable: true
+ */
+
+/**
+ * @openapi
+ * /api/announcements/active:
+ *   get:
+ *     tags: [Announcements]
+ *     summary: List active platform announcements
+ *     responses:
+ *       200:
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Announcement'
+ */
+router.get("/announcements/active", async (req, res, next) => {
+  try {
+    const { rows } = await db.query(`
+      SELECT *
+      FROM platform_announcements
+      WHERE active_from <= NOW()
+        AND deactivated_at IS NULL
+        AND (
+          active_until IS NULL
+          OR active_until > NOW()
+        )
+      ORDER BY active_from DESC
+    `);
+
+    res.json(rows);
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
+ * @openapi
+ * /api/announcements/create:
+ *   post:
+ *     tags: [Announcements]
+ *     summary: Create a platform announcement
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AnnouncementCreateRequest'
+ *     responses:
+ *       201:
+ *         description: Announcement created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Announcement'
+ *       401:
+ *         description: Authentication required
+ *       403:
+ *         description: Admin access required
+ */
+
+router.post(
+  "/announcements/create",
+  requireAuth,
+  requireRole("admin"),
+  createAnnouncementValidation,
+  validateRequest,
+  asyncHandler(async (req, res) => {
+    const { message, severity, details_url, active_from, active_until } =
+      req.body;
+    const createdBy = req.user.userId || req.user.id;
+
+    const { rows } = await db.query(
+      `
+        INSERT INTO platform_announcements (
+            message,
+            severity,
+            details_url,
+            active_from,
+            active_until,
+            created_by
+        )
+        VALUES ($1, COALESCE($2, 'info'), $3, COALESCE($4, NOW()), $5, $6)
+        RETURNING *;
+        `,
+      [message, severity, details_url, active_from, active_until, createdBy],
+    );
+
+    res.status(201).json(rows[0]);
+  }),
+);
+
+/**
+ * @openapi
+ * /api/announcements/{id}/deactivate:
+ *   patch:
+ *     tags: [Announcements]
+ *     summary: Deactivate a platform announcement
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Announcement deactivated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Announcement'
+ *       401:
+ *         description: Authentication required
+ *       403:
+ *         description: Admin access required
+ *       404:
+ *         description: Announcement not found or already deactivated
+ */
+router.patch(
+  "/announcements/:id/deactivate",
+  requireAuth,
+  requireRole("admin"),
+  announcementIdValidation,
+  validateRequest,
+  asyncHandler(async (req, res) => {
+    const { rows } = await db.query(
+      `
+      UPDATE platform_announcements
+      SET
+        deactivated_at = NOW(),
+        updated_at = NOW()
+      WHERE id = $1
+        AND deactivated_at IS NULL
+      RETURNING *;
+      `,
+      [req.params.id],
+    );
+
+    if (rows.length === 0) {
+      return res.status(404).json({
+        error: "Announcement not found or already deactivated",
+      });
+    }
+
+    res.json(rows[0]);
+  }),
+);
+
+module.exports = router;

--- a/backend/src/routes/announcement.test.js
+++ b/backend/src/routes/announcement.test.js
@@ -1,0 +1,247 @@
+process.env.USDC_ISSUER = process.env.USDC_ISSUER || 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+process.env.STELLAR_NETWORK = process.env.STELLAR_NETWORK || 'testnet';
+process.env.PLATFORM_SECRET_KEY = process.env.PLATFORM_SECRET_KEY || 'SCVMQUS5EMTHWBLJTE5XCSCMHB2ZOVKRR4ATVTRPUNRCOGKRENIL3LHR';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const proxyquire = require('proxyquire').noCallThru();
+
+const ANNOUNCEMENT_ID = '11111111-1111-1111-1111-111111111111';
+const ADMIN_ID = 'admin-1';
+
+function buildApp({ queryImpl, user = { userId: ADMIN_ID, role: 'admin' } } = {}) {
+  const calls = [];
+  const router = proxyquire('./announcement', {
+    '../config/database': {
+      query: async (text, params) => {
+        calls.push({ text, params });
+        if (queryImpl) return queryImpl(text, params);
+        return { rows: [] };
+      },
+    },
+    '../middleware/auth': {
+      requireAuth: (req, _res, next) => {
+        if (user) req.user = user;
+        next();
+      },
+      requireRole: (...roles) => (req, res, next) => {
+        if (!req.user || !roles.includes(req.user.role)) {
+          return res.status(403).json({ error: 'Insufficient role for this action' });
+        }
+        next();
+      },
+    },
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api', router);
+  return { app, calls };
+}
+
+test('GET /api/announcements/active returns active platform announcements', async () => {
+  const activeAnnouncements = [
+    {
+      id: ANNOUNCEMENT_ID,
+      message: 'Scheduled maintenance tonight',
+      severity: 'warning',
+      details_url: 'https://status.example.com',
+    },
+  ];
+  const { app, calls } = buildApp({
+    queryImpl: async () => ({ rows: activeAnnouncements }),
+  });
+
+  const res = await request(app).get('/api/announcements/active');
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body, activeAnnouncements);
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].text, /FROM platform_announcements/);
+  assert.match(calls[0].text, /active_from <= NOW\(\)/);
+  assert.match(calls[0].text, /deactivated_at IS NULL/);
+  assert.match(calls[0].text, /active_until > NOW\(\)/);
+  assert.match(calls[0].text, /ORDER BY active_from DESC/);
+});
+
+test('POST /api/announcements/create inserts an admin announcement', async () => {
+  const created = {
+    id: ANNOUNCEMENT_ID,
+    message: 'Payments are temporarily delayed',
+    severity: 'critical',
+    details_url: 'https://status.example.com/incidents/1',
+    active_from: '2026-07-25T10:00:00.000Z',
+    active_until: '2026-07-25T12:00:00.000Z',
+    created_by: ADMIN_ID,
+  };
+  const { app, calls } = buildApp({
+    queryImpl: async () => ({ rows: [created] }),
+  });
+
+  const payload = {
+    message: created.message,
+    severity: created.severity,
+    details_url: created.details_url,
+    active_from: created.active_from,
+    active_until: created.active_until,
+  };
+  const res = await request(app)
+    .post('/api/announcements/create')
+    .send(payload);
+
+  assert.equal(res.status, 201);
+  assert.deepEqual(res.body, created);
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].text, /INSERT INTO platform_announcements/);
+  assert.deepEqual(calls[0].params, [
+    payload.message,
+    payload.severity,
+    payload.details_url,
+    payload.active_from,
+    payload.active_until,
+    ADMIN_ID,
+  ]);
+});
+
+test('POST /api/announcements/create rejects non-admin users', async () => {
+  const { app, calls } = buildApp({
+    user: { id: 'user-1', role: 'contributor' },
+  });
+
+  const res = await request(app)
+    .post('/api/announcements/create')
+    .send({ message: 'Hello' });
+
+  assert.equal(res.status, 403);
+  assert.deepEqual(res.body, { error: 'Insufficient role for this action' });
+  assert.equal(calls.length, 0);
+});
+
+test('POST /api/announcements/create rejects invalid announcement payloads', async () => {
+  const { app, calls } = buildApp();
+
+  const missingMessage = await request(app)
+    .post('/api/announcements/create')
+    .send({ severity: 'info' });
+  assert.equal(missingMessage.status, 400);
+  assert.equal(missingMessage.body.error.code, 'VALIDATION_ERROR');
+  assert.match(missingMessage.body.error.message, /message/i);
+
+  const badSeverity = await request(app)
+    .post('/api/announcements/create')
+    .send({ message: 'Hello', severity: 'urgent' });
+  assert.equal(badSeverity.status, 400);
+  assert.match(badSeverity.body.error.message, /severity/);
+
+  const badDateRange = await request(app)
+    .post('/api/announcements/create')
+    .send({
+      message: 'Hello',
+      active_from: '2026-07-25T12:00:00.000Z',
+      active_until: '2026-07-25T11:00:00.000Z',
+    });
+  assert.equal(badDateRange.status, 400);
+  assert.match(badDateRange.body.error.message, /active_until/);
+  assert.equal(calls.length, 0);
+});
+
+test('POST /api/announcements/create treats blank optional fields as defaults', async () => {
+  const created = {
+    id: ANNOUNCEMENT_ID,
+    message: 'Maintenance window',
+    severity: 'info',
+    details_url: null,
+    active_from: '2026-07-25T10:00:00.000Z',
+    active_until: null,
+    created_by: ADMIN_ID,
+  };
+  const { app, calls } = buildApp({
+    queryImpl: async () => ({ rows: [created] }),
+  });
+
+  const res = await request(app)
+    .post('/api/announcements/create')
+    .send({
+      message: 'Maintenance window',
+      severity: '',
+      details_url: '',
+      active_from: '',
+      active_until: '',
+    });
+
+  assert.equal(res.status, 201);
+  assert.deepEqual(res.body, created);
+  assert.deepEqual(calls[0].params, [
+    'Maintenance window',
+    null,
+    null,
+    null,
+    null,
+    ADMIN_ID,
+  ]);
+});
+
+test('POST /api/announcements/create rejects active_until in the past when active_from is omitted', async () => {
+  const { app, calls } = buildApp();
+
+  const res = await request(app)
+    .post('/api/announcements/create')
+    .send({
+      message: 'Expired announcement',
+      active_until: '2000-01-01T00:00:00.000Z',
+    });
+
+  assert.equal(res.status, 400);
+  assert.equal(res.body.error.code, 'VALIDATION_ERROR');
+  assert.match(res.body.error.message, /active_until must be in the future/);
+  assert.equal(calls.length, 0);
+});
+
+test('PATCH /api/announcements/:id/deactivate deactivates an active announcement', async () => {
+  const deactivated = {
+    id: ANNOUNCEMENT_ID,
+    message: 'Resolved incident',
+    deactivated_at: '2026-07-25T11:00:00.000Z',
+  };
+  const { app, calls } = buildApp({
+    queryImpl: async () => ({ rows: [deactivated] }),
+  });
+
+  const res = await request(app)
+    .patch(`/api/announcements/${ANNOUNCEMENT_ID}/deactivate`);
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body, deactivated);
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].text, /UPDATE platform_announcements/);
+  assert.match(calls[0].text, /deactivated_at = NOW\(\)/);
+  assert.deepEqual(calls[0].params, [ANNOUNCEMENT_ID]);
+});
+
+test('PATCH /api/announcements/:id/deactivate returns 404 when no announcement is updated', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({ rows: [] }),
+  });
+
+  const res = await request(app)
+    .patch(`/api/announcements/${ANNOUNCEMENT_ID}/deactivate`);
+
+  assert.equal(res.status, 404);
+  assert.deepEqual(res.body, {
+    error: 'Announcement not found or already deactivated',
+  });
+});
+
+test('PATCH /api/announcements/:id/deactivate rejects invalid ids', async () => {
+  const { app, calls } = buildApp();
+
+  const res = await request(app)
+    .patch('/api/announcements/not-a-uuid/deactivate');
+
+  assert.equal(res.status, 400);
+  assert.equal(res.body.error.code, 'VALIDATION_ERROR');
+  assert.match(res.body.error.message, /id must be a valid UUID/);
+  assert.equal(calls.length, 0);
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -29,6 +29,7 @@ import { ToastProvider } from './context/ToastContext';
 import { NetworkStatusProvider } from './context/NetworkStatusContext';
 import { OfflineBanner } from './components/OfflineBanner';
 import ImpersonationBanner from './components/ImpersonationBanner';
+import AnnouncementBanner from './components/AnnouncementBanner';
 import { useAuth } from './context/AuthContext';
 
 export default function App() {
@@ -48,6 +49,7 @@ export default function App() {
           <NetworkStatusProvider>
             <OfflineBanner />
             {!hideNavbar && <ImpersonationBanner />}
+            {!hideNavbar && <AnnouncementBanner />}
             {!hideNavbar && <Navbar />}
             <Routes>
               <Route path="/" element={<Landing />} />

--- a/frontend/src/components/AnnouncementBanner.jsx
+++ b/frontend/src/components/AnnouncementBanner.jsx
@@ -1,0 +1,103 @@
+import { useEffect, useMemo, useState } from 'react';
+import { api } from '../services/api';
+
+const POLL_INTERVAL_MS = 60_000;
+const STORAGE_KEY = 'crowdpay.dismissedAnnouncements';
+const SEVERITY_RANK = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+};
+
+function readDismissed() {
+  try {
+    const value = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+    return Array.isArray(value) ? new Set(value) : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function announcementKey(announcement) {
+  return `${announcement.id}:${announcement.message}`;
+}
+
+function sortAnnouncements(announcements) {
+  return [...announcements].sort((a, b) => {
+    const severityDiff =
+      (SEVERITY_RANK[a.severity] ?? SEVERITY_RANK.info) -
+      (SEVERITY_RANK[b.severity] ?? SEVERITY_RANK.info);
+    if (severityDiff !== 0) return severityDiff;
+    return new Date(b.active_from || 0).getTime() - new Date(a.active_from || 0).getTime();
+  });
+}
+
+export default function AnnouncementBanner() {
+  const [announcements, setAnnouncements] = useState([]);
+  const [dismissed, setDismissed] = useState(() => readDismissed());
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadAnnouncements() {
+      try {
+        const data = await api.getActiveAnnouncements();
+        if (!cancelled) setAnnouncements(Array.isArray(data) ? data : []);
+      } catch {
+        if (!cancelled) setAnnouncements([]);
+      }
+    }
+
+    loadAnnouncements();
+    const timer = setInterval(loadAnnouncements, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, []);
+
+  const visibleAnnouncement = useMemo(() => {
+    return sortAnnouncements(announcements).find((item) => !dismissed.has(announcementKey(item)));
+  }, [announcements, dismissed]);
+
+  if (!visibleAnnouncement) return null;
+
+  function dismiss() {
+    const next = new Set(dismissed);
+    next.add(announcementKey(visibleAnnouncement));
+    setDismissed(next);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...next]));
+  }
+
+  const severity = visibleAnnouncement.severity || 'info';
+
+  return (
+    <div
+      role="status"
+      className={`announcement-banner announcement-banner--${severity}`}
+    >
+      <div className="announcement-banner__content">
+        <span className="announcement-banner__message">{visibleAnnouncement.message}</span>
+        {visibleAnnouncement.details_url && (
+          <a
+            className="announcement-banner__link"
+            href={visibleAnnouncement.details_url}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Details
+          </a>
+        )}
+      </div>
+      <button
+        type="button"
+        className="announcement-banner__dismiss"
+        onClick={dismiss}
+        aria-label="Dismiss announcement"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/AnnouncementBanner.test.jsx
+++ b/frontend/src/components/AnnouncementBanner.test.jsx
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AnnouncementBanner from './AnnouncementBanner';
+import { api } from '../services/api';
+
+vi.mock('../services/api', () => ({
+  api: {
+    getActiveAnnouncements: vi.fn(),
+  },
+}));
+
+describe('AnnouncementBanner', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('renders the highest severity active announcement with details link', async () => {
+    api.getActiveAnnouncements.mockResolvedValue([
+      {
+        id: 'info-1',
+        message: 'General maintenance',
+        severity: 'info',
+        active_from: '2026-07-25T10:00:00.000Z',
+      },
+      {
+        id: 'critical-1',
+        message: 'Payments are temporarily delayed',
+        severity: 'critical',
+        details_url: 'https://status.example.com/incidents/1',
+        active_from: '2026-07-25T09:00:00.000Z',
+      },
+    ]);
+
+    render(<AnnouncementBanner />);
+
+    expect(await screen.findByText('Payments are temporarily delayed')).toBeInTheDocument();
+    expect(screen.queryByText('General maintenance')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /details/i })).toHaveAttribute(
+      'href',
+      'https://status.example.com/incidents/1'
+    );
+    expect(screen.getByRole('status')).toHaveClass('announcement-banner--critical');
+  });
+
+  it('persists dismissal until the message changes', async () => {
+    api.getActiveAnnouncements.mockResolvedValue([
+      {
+        id: 'ann-1',
+        message: 'Scheduled maintenance',
+        severity: 'warning',
+      },
+    ]);
+
+    const user = userEvent.setup();
+    const { unmount } = render(<AnnouncementBanner />);
+
+    expect(await screen.findByText('Scheduled maintenance')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /dismiss announcement/i }));
+    expect(screen.queryByText('Scheduled maintenance')).not.toBeInTheDocument();
+
+    unmount();
+    api.getActiveAnnouncements.mockResolvedValue([
+      {
+        id: 'ann-1',
+        message: 'Scheduled maintenance',
+        severity: 'warning',
+      },
+    ]);
+    render(<AnnouncementBanner />);
+    await waitFor(() => expect(api.getActiveAnnouncements).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText('Scheduled maintenance')).not.toBeInTheDocument();
+
+    unmount();
+    api.getActiveAnnouncements.mockResolvedValue([
+      {
+        id: 'ann-1',
+        message: 'Scheduled maintenance updated',
+        severity: 'warning',
+      },
+    ]);
+    render(<AnnouncementBanner />);
+    expect(await screen.findByText('Scheduled maintenance updated')).toBeInTheDocument();
+  });
+
+  it('polls for active announcements every 60 seconds', async () => {
+    vi.useFakeTimers();
+    api.getActiveAnnouncements.mockResolvedValue([]);
+
+    render(<AnnouncementBanner />);
+    await act(async () => {});
+    expect(api.getActiveAnnouncements).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(api.getActiveAnnouncements).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -147,6 +147,73 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
   .container { padding: 0 2rem; }
 }
 
+.announcement-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 0.7rem 1rem;
+  border-bottom: 1px solid var(--color-info-border);
+  background: var(--color-info-bg);
+  color: var(--color-info-text);
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+.announcement-banner--warning {
+  border-bottom-color: var(--color-warning-border);
+  background: var(--color-warning-bg);
+  color: var(--color-warning-text);
+}
+.announcement-banner--critical {
+  border-bottom-color: var(--color-error-border);
+  background: var(--color-error-bg);
+  color: var(--color-error-text);
+}
+.announcement-banner__content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex: 1;
+  min-width: 0;
+}
+.announcement-banner__message {
+  overflow-wrap: anywhere;
+  text-align: center;
+}
+.announcement-banner__link {
+  flex: 0 0 auto;
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+.announcement-banner__dismiss {
+  flex: 0 0 auto;
+  width: 2rem;
+  height: 2rem;
+  min-height: 2rem;
+  padding: 0;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+@media (max-width: 520px) {
+  .announcement-banner {
+    align-items: flex-start;
+  }
+  .announcement-banner__content {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .announcement-banner__message {
+    text-align: left;
+  }
+}
+
 .btn-primary {
   background: var(--color-text-primary);
   color: #fff;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -305,6 +305,7 @@ async function logout() {
 
 export const api = {
   getPlatformConfig: () => request('GET', '/config'),
+  getActiveAnnouncements: () => request('GET', '/announcements/active'),
 
   register: (body) => request('POST', '/auth/register', body),
   login: (body) => request('POST', '/auth/login', body),


### PR DESCRIPTION
## What I built

Adds platform-wide announcements across the backend and frontend.

Backend:
- GET /api/announcements/active returns currently active announcements.
- POST /api/announcements/create lets admins create announcements.
- PATCH /api/announcements/:id/deactivate lets admins deactivate announcements.
- Adds platform_announcements table, migration, validation, and route tests.

Frontend:
- Adds a global announcement banner above the navbar.
- Polls active announcements every 60 seconds.
- Shows the highest-priority announcement first: critical, then warning, then info.
- Supports optional details links.
- Lets users dismiss announcements locally.
- Dismissal is keyed by id:message, so if the message changes, the banner appears again.

Manual testing:
- Created an admin test user locally.
- Logged in through /api/auth/login.
- Created an announcement through POST /api/announcements/create.
- Verified it appeared from GET /api/announcements/active and in the frontend.
- Deactivated it through PATCH /api/announcements/:id/deactivate.
- Verified it no longer appeared in active announcements.

Checks:
- npm test -- src/components/AnnouncementBanner.test.jsx passes.
- npm run build passes.
- npm run lint passes with existing warnings.
- Backend announcement route tests pass during backend suite.
- Full frontend/backend suites still have unrelated pre-existing failures noted locally.

Closes #404