### PR TITLE
feat: complete TOTP/2FA infrastructure

### DIFF
--- a/backend/db/migrations/20260725_2fa_infrastructure.sql
+++ b/backend/db/migrations/20260725_2fa_infrastructure.sql
@@ -1,0 +1,27 @@
+CREATE TABLE trusted_devices (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  device_fingerprint TEXT NOT NULL,
+  device_name TEXT,
+  ip_address INET,
+  trusted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  UNIQUE(user_id, device_fingerprint)
+);
+
+CREATE TABLE security_audit_log (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  event_type TEXT NOT NULL,
+  ip_address INET,
+  user_agent TEXT,
+  metadata JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE users ADD COLUMN enforce_2fa BOOLEAN DEFAULT FALSE;
+
+CREATE INDEX idx_trusted_devices_user ON trusted_devices(user_id);
+CREATE INDEX idx_trusted_devices_fingerprint ON trusted_devices(user_id, device_fingerprint);
+CREATE INDEX idx_security_audit_log_user ON security_audit_log(user_id);
+CREATE INDEX idx_security_audit_log_created ON security_audit_log(created_at);

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -2,9 +2,8 @@ const router = require('express').Router();
 const crypto = require('crypto');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
-const { authenticator } = require('otplib');
-const qrcode = require('qrcode');
 const rateLimit = require('express-rate-limit');
+const totpService = require('../services/totpService');
 const { Keypair } = require('@stellar/stellar-sdk');
 const db = require('../config/database');
 const logger = require('../config/logger');
@@ -461,8 +460,19 @@ router.post('/login', loginLimiter, loginValidation, validateRequest, async (req
 
   const user = rows[0];
 
+  const enforceResult = await totpService.enforce2faCheck(user);
+  if (enforceResult.enforced) {
+    return res.status(403).json({ error: enforceResult.message });
+  }
+
   if (user.totp_enabled) {
-    return res.json({ requires_2fa: true });
+    const fingerprint = totpService.generateFingerprint(req);
+    const trusted = await totpService.isDeviceTrusted(user.id, fingerprint);
+    if (trusted) {
+      // Skip 2FA for trusted device
+    } else {
+      return res.json({ requires_2fa: true });
+    }
   }
 
   const { accessToken } = generateTokens(user);
@@ -538,16 +548,12 @@ router.post('/2fa/challenge', totpChallengeLimiter, totpChallengeEmailLimiter, v
   let codeValid = false;
 
   if (code.length === 6) {
-    codeValid = authenticator.verify({ token: code, secret: user.totp_secret });
+    codeValid = totpService.verifyTotp(user.totp_secret, code);
   } else if (user.backup_codes && user.backup_codes.length > 0) {
-    for (let i = 0; i < user.backup_codes.length; i++) {
-      if (await bcrypt.compare(code, user.backup_codes[i])) {
-        codeValid = true;
-        // remove used backup code
-        user.backup_codes.splice(i, 1);
-        await db.query('UPDATE users SET backup_codes = $1 WHERE id = $2', [user.backup_codes, user.id]);
-        break;
-      }
+    const result = await totpService.verifyBackupCode(user.backup_codes, code);
+    if (result.valid) {
+      codeValid = true;
+      await totpService.removeBackupCode(user.id, user.backup_codes, result.index);
     }
   }
 
@@ -562,6 +568,10 @@ router.post('/2fa/challenge', totpChallengeLimiter, totpChallengeEmailLimiter, v
         user.id,
       ]
     );
+    await totpService.logAuditEvent(user.id, 'totp_challenge_failed', req, {
+      consecutiveFailures: failedAttempts,
+      lockedOut: lockingOut,
+    });
     logger.warn('Failed 2FA attempt', {
       event: 'totp_failed_attempt',
       userId: user.id,
@@ -579,6 +589,12 @@ router.post('/2fa/challenge', totpChallengeLimiter, totpChallengeEmailLimiter, v
     );
   }
 
+  const fingerprint = totpService.generateFingerprint(req);
+  const wasBackupCode = code.length !== 6;
+  await totpService.logAuditEvent(user.id, 'totp_challenge_success', req, {
+    method: wasBackupCode ? 'backup_code' : 'totp',
+  });
+
   const { accessToken } = generateTokens(user);
   const { token: refreshToken, expiresAt } = await createRefreshToken(user.id);
 
@@ -587,6 +603,7 @@ router.post('/2fa/challenge', totpChallengeLimiter, totpChallengeEmailLimiter, v
 
   res.json({
     token: accessToken,
+    device_trusted: await totpService.isDeviceTrusted(user.id, fingerprint),
     user: {
       id: user.id,
       email: user.email,
@@ -612,11 +629,12 @@ router.post('/2fa/setup', requireAuth, async (req, res) => {
     return res.status(400).json({ error: '2FA is already enabled' });
   }
 
-  const secret = authenticator.generateSecret();
-  const otpauth = authenticator.keyuri(user.email, 'CrowdPay', secret);
-  const qrCodeDataUrl = await qrcode.toDataURL(otpauth);
+  const secret = totpService.generateSecret();
+  const otpauth = totpService.buildOtpauthUri(user.email, secret);
+  const qrCodeDataUrl = await totpService.generateQrCode(otpauth);
 
   await db.query('UPDATE users SET totp_secret = $1 WHERE id = $2', [secret, user.id]);
+  await totpService.logAuditEvent(user.id, 'totp_setup_initiated', req);
 
   res.json({
     secret,
@@ -637,21 +655,151 @@ router.post('/2fa/verify', requireAuth, async (req, res) => {
     return res.status(400).json({ error: '2FA setup not initiated' });
   }
 
-  const isValid = authenticator.verify({ token: code, secret: user.totp_secret });
+  const isValid = totpService.verifyTotp(user.totp_secret, code);
   if (!isValid) {
     return res.status(401).json({ error: 'Invalid 2FA code' });
   }
 
-  // Generate 8 backup codes
-  const rawBackupCodes = Array.from({ length: 8 }, () => crypto.randomBytes(4).toString('hex'));
-  const hashedBackupCodes = await Promise.all(rawBackupCodes.map(bc => bcrypt.hash(bc, 10)));
+  const { raw: rawBackupCodes, hashed: hashedBackupCodes } = await totpService.generateBackupCodes();
 
   await db.query('UPDATE users SET totp_enabled = true, backup_codes = $1 WHERE id = $2', [hashedBackupCodes, user.id]);
+  await totpService.logAuditEvent(user.id, 'totp_enabled', req);
 
   res.json({
     message: '2FA enabled successfully',
     backupCodes: rawBackupCodes
   });
+});
+
+router.post('/2fa/disable', requireAuth, async (req, res) => {
+  const { code } = req.body;
+  if (!code) {
+    return res.status(400).json({ error: 'Current 2FA code is required to disable' });
+  }
+
+  const { rows } = await db.query('SELECT * FROM users WHERE id = $1', [req.user.userId]);
+  const user = rows[0];
+
+  if (!user.totp_enabled) {
+    return res.status(400).json({ error: '2FA is not enabled' });
+  }
+
+  let codeValid = false;
+  if (code.length === 6) {
+    codeValid = totpService.verifyTotp(user.totp_secret, code);
+  } else if (user.backup_codes && user.backup_codes.length > 0) {
+    const result = await totpService.verifyBackupCode(user.backup_codes, code);
+    if (result.valid) {
+      codeValid = true;
+      await totpService.removeBackupCode(user.id, user.backup_codes, result.index);
+    }
+  }
+
+  if (!codeValid) {
+    return res.status(401).json({ error: 'Invalid 2FA code' });
+  }
+
+  await db.query(
+    'UPDATE users SET totp_enabled = false, totp_secret = NULL, backup_codes = NULL WHERE id = $1',
+    [user.id]
+  );
+  await totpService.revokeAllDevices(user.id);
+  await totpService.logAuditEvent(user.id, 'totp_disabled', req);
+
+  res.json({ message: '2FA disabled successfully' });
+});
+
+router.get('/2fa/backup-codes', requireAuth, async (req, res) => {
+  const { rows } = await db.query('SELECT * FROM users WHERE id = $1', [req.user.userId]);
+  const user = rows[0];
+
+  if (!user.totp_enabled) {
+    return res.status(400).json({ error: '2FA is not enabled' });
+  }
+
+  const { raw, hashed } = await totpService.generateBackupCodes();
+  await db.query('UPDATE users SET backup_codes = $1 WHERE id = $2', [hashed, user.id]);
+  await totpService.logAuditEvent(user.id, 'backup_codes_regenerated', req);
+
+  res.json({ backupCodes: raw });
+});
+
+router.post('/2fa/trust-device', requireAuth, async (req, res) => {
+  const { code } = req.body;
+  if (!code) {
+    return res.status(400).json({ error: '2FA code is required to trust device' });
+  }
+
+  const { rows } = await db.query('SELECT * FROM users WHERE id = $1', [req.user.userId]);
+  const user = rows[0];
+
+  if (!user.totp_enabled) {
+    return res.status(400).json({ error: '2FA is not enabled' });
+  }
+
+  const isValid = totpService.verifyTotp(user.totp_secret, code);
+  if (!isValid) {
+    return res.status(401).json({ error: 'Invalid 2FA code' });
+  }
+
+  const fingerprint = totpService.generateFingerprint(req);
+  await totpService.trustDevice(user.id, fingerprint, req);
+  await totpService.logAuditEvent(user.id, 'device_trusted', req);
+
+  res.json({ message: 'Device trusted successfully' });
+});
+
+router.get('/2fa/devices', requireAuth, async (req, res) => {
+  const { rows } = await db.query('SELECT * FROM users WHERE id = $1', [req.user.userId]);
+  const user = rows[0];
+
+  if (!user.totp_enabled) {
+    return res.status(400).json({ error: '2FA is not enabled' });
+  }
+
+  const devices = await totpService.getUserDevices(user.id);
+  res.json({ devices });
+});
+
+router.delete('/2fa/devices/:deviceId', requireAuth, async (req, res) => {
+  const { rows } = await db.query('SELECT * FROM users WHERE id = $1', [req.user.userId]);
+  const user = rows[0];
+
+  if (!user.totp_enabled) {
+    return res.status(400).json({ error: '2FA is not enabled' });
+  }
+
+  const removed = await totpService.revokeDevice(user.id, parseInt(req.params.deviceId, 10));
+  if (!removed) {
+    return res.status(404).json({ error: 'Device not found' });
+  }
+
+  await totpService.logAuditEvent(user.id, 'device_revoked', req, {
+    deviceId: parseInt(req.params.deviceId, 10),
+  });
+
+  res.json({ message: 'Device removed' });
+});
+
+router.get('/2fa/audit-log', requireAuth, async (req, res) => {
+  const { rows } = await db.query('SELECT * FROM users WHERE id = $1', [req.user.userId]);
+  const user = rows[0];
+
+  if (!user.totp_enabled && user.role !== 'admin') {
+    return res.status(403).json({ error: '2FA is not enabled' });
+  }
+
+  const limit = Math.min(parseInt(req.query.limit, 10) || 50, 200);
+  const { rows: events } = await db.query(
+    `SELECT id, event_type, ip_address, user_agent, metadata, created_at
+     FROM security_audit_log
+     WHERE user_id = $1
+     ORDER BY created_at DESC
+     LIMIT $2`,
+    [user.id, limit]
+  );
+
+  res.json({ events });
 });
 
 router.post('/refresh', async (req, res) => {

--- a/backend/src/routes/totp.test.js
+++ b/backend/src/routes/totp.test.js
@@ -1,0 +1,586 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const proxyquire = require('proxyquire').noCallThru();
+
+function buildApp({
+  queryImpl,
+  totpServiceImpl,
+  bcryptImpl,
+  userOverrides = {},
+} = {}) {
+  const bcryptStub = {
+    hash: async () => 'hashed',
+    compare: async () => false,
+    ...bcryptImpl,
+  };
+
+  const defaultTotp = {
+    generateFingerprint: () => 'fp-abc123',
+    verifyTotp: () => true,
+    generateSecret: () => 'JBSWY3DPEHPK3PXP',
+    buildOtpauthUri: () => 'otpauth://totp/test',
+    generateQrCode: () => 'data:image/png;base64,abc',
+    generateBackupCodes: async () => ({
+      raw: ['code1', 'code2'],
+      hashed: ['hashed1', 'hashed2'],
+    }),
+    verifyBackupCode: async () => ({ valid: true, index: 0 }),
+    removeBackupCode: async () => {},
+    logAuditEvent: async () => {},
+    isDeviceTrusted: async () => false,
+    trustDevice: async () => {},
+    revokeDevice: async () => true,
+    revokeAllDevices: async () => {},
+    getUserDevices: async () => [],
+    enforce2faCheck: async () => ({ enforced: false }),
+    ...totpServiceImpl,
+  };
+
+  const router = proxyquire('./auth', {
+    '@stellar/stellar-sdk': {
+      Keypair: {
+        random: () => ({
+          publicKey: () => 'GUSER',
+          secret: () => 'SA3D5',
+        }),
+      },
+    },
+    '../config/database': { query: queryImpl },
+    '../services/stellarService': {
+      ensureCustodialAccountFundedAndTrusted: async () => {},
+    },
+    '../services/walletSecrets': {
+      encryptWalletSecret: async (secret) => `cpws:v1:${secret.slice(0, 8)}`,
+    },
+    '../services/emailService': {
+      sendEmail: () => {},
+      sendWelcomeEmail: async () => {},
+    },
+    '../middleware/auth': {
+      requireAuth: (req, _res, next) => {
+        req.user = { userId: userOverrides.userId || 1, role: userOverrides.role || 'creator' };
+        next();
+      },
+    },
+    '../services/totpService': defaultTotp,
+    jsonwebtoken: {
+      sign: () => 'jwt-token',
+    },
+    bcryptjs: bcryptStub,
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/auth', router);
+  return { app };
+}
+
+const creatorUser = {
+  id: 1,
+  email: 'creator@example.com',
+  name: 'Creator',
+  role: 'creator',
+  wallet_public_key: 'GUSER',
+  totp_enabled: false,
+  totp_secret: null,
+  backup_codes: null,
+};
+
+const totpEnabledUser = {
+  ...creatorUser,
+  totp_enabled: true,
+  totp_secret: 'JBSWY3DPEHPK3PXP',
+  backup_codes: ['hashed1', 'hashed2'],
+};
+
+test('POST /2fa/setup generates secret and QR code', async () => {
+  let updatedSecret = false;
+  const { app } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('SELECT * FROM users')) {
+        return { rows: [creatorUser] };
+      }
+      if (text.includes('UPDATE users SET totp_secret')) {
+        updatedSecret = true;
+      }
+      return { rows: [] };
+    },
+  });
+
+  const res = await request(app).post('/api/auth/2fa/setup');
+  assert.equal(res.status, 200);
+  assert.ok(res.body.secret);
+  assert.ok(res.body.qrCodeDataUrl);
+  assert.equal(updatedSecret, true);
+});
+
+test('POST /2fa/setup rejects contributor role', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({
+      rows: [{ ...creatorUser, role: 'contributor' }],
+    }),
+  });
+
+  const res = await request(app).post('/api/auth/2fa/setup');
+  assert.equal(res.status, 403);
+  assert.match(res.body.error, /creator and admin/);
+});
+
+test('POST /2fa/setup rejects already-enabled account', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({
+      rows: [{ ...creatorUser, totp_enabled: true }],
+    }),
+  });
+
+  const res = await request(app).post('/api/auth/2fa/setup');
+  assert.equal(res.status, 400);
+  assert.match(res.body.error, /already enabled/);
+});
+
+test('POST /2fa/verify activates 2FA and returns backup codes', async () => {
+  let updated = false;
+  const { app } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('SELECT * FROM users')) {
+        return { rows: [{ ...creatorUser, totp_secret: 'JBSWY3DPEHPK3PXP' }] };
+      }
+      if (text.includes('UPDATE users SET totp_enabled')) {
+        updated = true;
+      }
+      return { rows: [] };
+    },
+  });
+
+  const res = await request(app)
+    .post('/api/auth/2fa/verify')
+    .send({ code: '123456' });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.message, '2FA enabled successfully');
+  assert.ok(Array.isArray(res.body.backupCodes));
+  assert.equal(updated, true);
+});
+
+test('POST /2fa/verify rejects invalid code', async () => {
+  const { app } = buildApp({
+    totpServiceImpl: { verifyTotp: () => false },
+    queryImpl: async () => ({
+      rows: [{ ...creatorUser, totp_secret: 'JBSWY3DPEHPK3PXP' }],
+    }),
+  });
+
+  const res = await request(app)
+    .post('/api/auth/2fa/verify')
+    .send({ code: '000000' });
+
+  assert.equal(res.status, 401);
+  assert.match(res.body.error, /Invalid 2FA code/);
+});
+
+test('POST /2fa/verify rejects missing secret', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({
+      rows: [{ ...creatorUser, totp_secret: null }],
+    }),
+  });
+
+  const res = await request(app)
+    .post('/api/auth/2fa/verify')
+    .send({ code: '123456' });
+
+  assert.equal(res.status, 400);
+  assert.match(res.body.error, /not initiated/);
+});
+
+test('POST /2fa/disable clears TOTP and revokes devices', async () => {
+  let cleared = false;
+  let revoked = false;
+  const { app } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('SELECT * FROM users')) {
+        return { rows: [totpEnabledUser] };
+      }
+      if (text.includes('UPDATE users SET totp_enabled = false')) {
+        cleared = true;
+      }
+      return { rows: [] };
+    },
+    totpServiceImpl: {
+      revokeAllDevices: async () => { revoked = true; },
+    },
+  });
+
+  const res = await request(app)
+    .post('/api/auth/2fa/disable')
+    .send({ code: '123456' });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.message, '2FA disabled successfully');
+  assert.equal(cleared, true);
+  assert.equal(revoked, true);
+});
+
+test('POST /2fa/disable rejects when 2FA not enabled', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({
+      rows: [{ ...creatorUser, totp_enabled: false }],
+    }),
+  });
+
+  const res = await request(app)
+    .post('/api/auth/2fa/disable')
+    .send({ code: '123456' });
+
+  assert.equal(res.status, 400);
+  assert.match(res.body.error, /not enabled/);
+});
+
+test('POST /2fa/disable rejects invalid code', async () => {
+  const { app } = buildApp({
+    totpServiceImpl: { verifyTotp: () => false },
+    queryImpl: async () => ({
+      rows: [{ ...totpEnabledUser, backup_codes: [] }],
+    }),
+  });
+
+  const res = await request(app)
+    .post('/api/auth/2fa/disable')
+    .send({ code: '000000' });
+
+  assert.equal(res.status, 401);
+  assert.match(res.body.error, /Invalid 2FA code/);
+});
+
+test('GET /2fa/backup-codes regenerates and returns codes', async () => {
+  let updated = false;
+  const { app } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('SELECT * FROM users')) {
+        return { rows: [totpEnabledUser] };
+      }
+      if (text.includes('UPDATE users SET backup_codes')) {
+        updated = true;
+      }
+      return { rows: [] };
+    },
+  });
+
+  const res = await request(app).get('/api/auth/2fa/backup-codes');
+  assert.equal(res.status, 200);
+  assert.ok(Array.isArray(res.body.backupCodes));
+  assert.equal(updated, true);
+});
+
+test('GET /2fa/backup-codes rejects when 2FA not enabled', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({
+      rows: [{ ...creatorUser, totp_enabled: false }],
+    }),
+  });
+
+  const res = await request(app).get('/api/auth/2fa/backup-codes');
+  assert.equal(res.status, 400);
+  assert.match(res.body.error, /not enabled/);
+});
+
+test('POST /2fa/trust-device trusts device after code verification', async () => {
+  let trusted = false;
+  const { app } = buildApp({
+    queryImpl: async () => ({
+      rows: [totpEnabledUser],
+    }),
+    totpServiceImpl: {
+      trustDevice: async () => { trusted = true; },
+    },
+  });
+
+  const res = await request(app)
+    .post('/api/auth/2fa/trust-device')
+    .send({ code: '123456' });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.message, 'Device trusted successfully');
+  assert.equal(trusted, true);
+});
+
+test('POST /2fa/trust-device rejects invalid code', async () => {
+  const { app } = buildApp({
+    totpServiceImpl: { verifyTotp: () => false },
+    queryImpl: async () => ({
+      rows: [{ ...totpEnabledUser, backup_codes: [] }],
+    }),
+  });
+
+  const res = await request(app)
+    .post('/api/auth/2fa/trust-device')
+    .send({ code: '000000' });
+
+  assert.equal(res.status, 401);
+});
+
+test('GET /2fa/devices returns device list', async () => {
+  const devices = [{ id: 1, device_name: 'Test', trusted_at: '2026-01-01T00:00:00.000Z' }];
+  const { app } = buildApp({
+    queryImpl: async () => ({
+      rows: [totpEnabledUser],
+    }),
+    totpServiceImpl: {
+      getUserDevices: async () => devices,
+    },
+  });
+
+  const res = await request(app).get('/api/auth/2fa/devices');
+  assert.equal(res.status, 200);
+  assert.equal(res.body.devices.length, 1);
+  assert.equal(res.body.devices[0].id, 1);
+  assert.equal(res.body.devices[0].device_name, 'Test');
+});
+
+test('DELETE /2fa/devices/:id removes device', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({
+      rows: [totpEnabledUser],
+    }),
+  });
+
+  const res = await request(app).delete('/api/auth/2fa/devices/42');
+  assert.equal(res.status, 200);
+  assert.equal(res.body.message, 'Device removed');
+});
+
+test('DELETE /2fa/devices/:id returns 404 for unknown device', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({
+      rows: [totpEnabledUser],
+    }),
+    totpServiceImpl: {
+      revokeDevice: async () => false,
+    },
+  });
+
+  const res = await request(app).delete('/api/auth/2fa/devices/999');
+  assert.equal(res.status, 404);
+});
+
+test('GET /2fa/audit-log returns events', async () => {
+  const events = [{ id: 1, event_type: 'totp_enabled' }];
+  const { app } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('SELECT * FROM users')) {
+        return { rows: [totpEnabledUser] };
+      }
+      if (text.includes('FROM security_audit_log')) {
+        return { rows: events };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const res = await request(app).get('/api/auth/2fa/audit-log');
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body.events, events);
+});
+
+test('POST /2fa/challenge uses clock skew via totpService.verifyTotp', async () => {
+  let verifyCalledWith = null;
+  const { app } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('SELECT * FROM users')) {
+        return {
+          rows: [{
+            ...totpEnabledUser,
+            totp_failed_attempts: 0,
+            totp_locked_until: null,
+          }],
+        };
+      }
+      return { rows: [] };
+    },
+    bcryptImpl: {
+      compare: async () => true,
+    },
+    totpServiceImpl: {
+      verifyTotp: (secret, token) => {
+        verifyCalledWith = { secret, token };
+        return true;
+      },
+      isDeviceTrusted: async () => false,
+    },
+  });
+
+  const res = await request(app)
+    .post('/api/auth/2fa/challenge')
+    .send({ email: 'creator@example.com', password: 'pass', code: '123456' });
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(verifyCalledWith, { secret: 'JBSWY3DPEHPK3PXP', token: '123456' });
+});
+
+test('POST /2fa/challenge skips 2FA for trusted device', async () => {
+  const { app } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('SELECT * FROM users')) {
+        return {
+          rows: [{
+            ...totpEnabledUser,
+            totp_failed_attempts: 0,
+            totp_locked_until: null,
+          }],
+        };
+      }
+      return { rows: [] };
+    },
+    bcryptImpl: {
+      compare: async () => true,
+    },
+    totpServiceImpl: {
+      isDeviceTrusted: async () => true,
+    },
+  });
+
+  const res = await request(app)
+    .post('/api/auth/2fa/challenge')
+    .send({ email: 'creator@example.com', password: 'pass', code: '123456' });
+
+  assert.equal(res.status, 200);
+  assert.ok(res.body.token);
+  assert.equal(res.body.device_trusted, true);
+});
+
+test('POST /2fa/setup logs audit event', async () => {
+  let auditLogged = false;
+  const { app } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('SELECT * FROM users')) {
+        return { rows: [creatorUser] };
+      }
+      return { rows: [] };
+    },
+    totpServiceImpl: {
+      logAuditEvent: async (userId, eventType) => {
+        if (eventType === 'totp_setup_initiated') auditLogged = true;
+      },
+    },
+  });
+
+  await request(app).post('/api/auth/2fa/setup');
+  assert.equal(auditLogged, true);
+});
+
+test('POST /2fa/verify generates 10 backup codes', async () => {
+  const { app } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('SELECT * FROM users')) {
+        return { rows: [{ ...creatorUser, totp_secret: 'JBSWY3DPEHPK3PXP' }] };
+      }
+      return { rows: [] };
+    },
+    totpServiceImpl: {
+      generateBackupCodes: async () => {
+        return {
+          raw: Array.from({ length: 10 }, (_, i) => `code${i}`),
+          hashed: Array.from({ length: 10 }, (_, i) => `hashed${i}`),
+        };
+      },
+    },
+  });
+
+  const res = await request(app)
+    .post('/api/auth/2fa/verify')
+    .send({ code: '123456' });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.backupCodes.length, 10);
+});
+
+test('POST /2fa/disable requires code parameter', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({
+      rows: [totpEnabledUser],
+    }),
+  });
+
+  const res = await request(app).post('/api/auth/2fa/disable');
+  assert.equal(res.status, 400);
+  assert.match(res.body.error, /required/);
+});
+
+test('POST /2fa/challenge rejects locked account', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({
+      rows: [{
+        ...totpEnabledUser,
+        totp_locked_until: new Date(Date.now() + 60000),
+      }],
+    }),
+    bcryptImpl: {
+      compare: async () => true,
+    },
+  });
+
+  const res = await request(app)
+    .post('/api/auth/2fa/challenge')
+    .send({ email: 'creator@example.com', password: 'pass', code: '123456' });
+
+  assert.equal(res.status, 423);
+  assert.match(res.body.error, /Too many/);
+});
+
+test('Login returns requires_2fa for untrusted device with 2FA enabled', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({
+      rows: [{
+        ...totpEnabledUser,
+        password_hash: 'hashed',
+        kyc_status: 'verified',
+      }],
+    }),
+    bcryptImpl: {
+      compare: async () => true,
+    },
+    totpServiceImpl: {
+      isDeviceTrusted: async () => false,
+    },
+  });
+
+  const res = await request(app)
+    .post('/api/auth/login')
+    .send({ email: 'creator@example.com', password: 'pass' });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.requires_2fa, true);
+});
+
+test('Login enforces 2FA policy for accounts that must enable it', async () => {
+  const { app } = buildApp({
+    queryImpl: async () => ({
+      rows: [{
+        ...creatorUser,
+        enforce_2fa: true,
+        totp_enabled: false,
+        kyc_status: 'verified',
+      }],
+    }),
+    bcryptImpl: {
+      compare: async () => true,
+    },
+    totpServiceImpl: {
+      enforce2faCheck: async (user) => {
+        if (user.enforce_2fa && !user.totp_enabled) {
+          return { enforced: true, message: '2FA required' };
+        }
+        return { enforced: false };
+      },
+    },
+  });
+
+  const res = await request(app)
+    .post('/api/auth/login')
+    .send({ email: 'creator@example.com', password: 'pass' });
+
+  assert.equal(res.status, 403);
+  assert.match(res.body.error, /2FA required/);
+});

--- a/backend/src/routes/users.test.js
+++ b/backend/src/routes/users.test.js
@@ -34,6 +34,23 @@ function buildApp({ queryImpl, stellarImpl, sendEmailImpl, bcryptImpl } = {}) {
     '../middleware/auth': {
       requireAuth: (_req, _res, next) => next(),
     },
+    '../services/totpService': {
+      generateFingerprint: () => 'fp-test',
+      verifyTotp: () => true,
+      generateSecret: () => 'SECRET',
+      buildOtpauthUri: () => 'otpauth://totp/test',
+      generateQrCode: () => 'data:image/png;base64,abc',
+      generateBackupCodes: async () => ({ raw: [], hashed: [] }),
+      verifyBackupCode: async () => ({ valid: false, index: -1 }),
+      removeBackupCode: async () => {},
+      logAuditEvent: async () => {},
+      isDeviceTrusted: async () => false,
+      trustDevice: async () => {},
+      revokeDevice: async () => true,
+      revokeAllDevices: async () => {},
+      getUserDevices: async () => [],
+      enforce2faCheck: async () => ({ enforced: false }),
+    },
     jsonwebtoken: {
       sign: () => 'jwt-token',
     },

--- a/backend/src/services/totpService.js
+++ b/backend/src/services/totpService.js
@@ -1,0 +1,167 @@
+const crypto = require('crypto');
+const bcrypt = require('bcryptjs');
+const { authenticator } = require('otplib');
+const qrcode = require('qrcode');
+const db = require('../config/database');
+const logger = require('../config/logger');
+
+const TOTP_WINDOW = 1;
+const BACKUP_CODE_COUNT = 10;
+const DEVICE_TRUST_DAYS = 30;
+
+function generateFingerprint(req) {
+  const raw = [
+    req.headers['user-agent'] || '',
+    req.headers['accept-language'] || '',
+  ].join('|');
+  return crypto.createHash('sha256').update(raw).digest('hex');
+}
+
+function parseJwtExpiresIn(value) {
+  const match = String(value).match(/^(\d+)([smhd])$/);
+  if (!match) return 900;
+  const num = parseInt(match[1], 10);
+  const unit = match[2];
+  if (unit === 's') return num;
+  if (unit === 'm') return num * 60;
+  if (unit === 'h') return num * 60 * 60;
+  if (unit === 'd') return num * 24 * 60 * 60;
+  return 900;
+}
+
+function getDeviceTrustTtlMs() {
+  const days = parseInt(process.env.DEVICE_TRUST_DAYS, 10) || DEVICE_TRUST_DAYS;
+  return days * 24 * 60 * 60 * 1000;
+}
+
+function verifyTotp(secret, token) {
+  return authenticator.verify({ token, secret, window: TOTP_WINDOW });
+}
+
+function generateSecret() {
+  return authenticator.generateSecret();
+}
+
+function buildOtpauthUri(email, secret) {
+  return authenticator.keyuri(email, 'CrowdPay', secret);
+}
+
+async function generateQrCode(otpauth) {
+  return qrcode.toDataURL(otpauth);
+}
+
+async function generateBackupCodes() {
+  const raw = Array.from({ length: BACKUP_CODE_COUNT }, () =>
+    crypto.randomBytes(4).toString('hex')
+  );
+  const hashed = await Promise.all(raw.map((code) => bcrypt.hash(code, 10)));
+  return { raw, hashed };
+}
+
+async function verifyBackupCode(backupCodes, code) {
+  for (let i = 0; i < backupCodes.length; i++) {
+    if (await bcrypt.compare(code, backupCodes[i])) {
+      return { valid: true, index: i };
+    }
+  }
+  return { valid: false, index: -1 };
+}
+
+async function removeBackupCode(userId, codes, index) {
+  codes.splice(index, 1);
+  await db.query('UPDATE users SET backup_codes = $1 WHERE id = $2', [
+    codes,
+    userId,
+  ]);
+}
+
+async function logAuditEvent(userId, eventType, req, metadata = {}) {
+  const ip = req.ip || req.connection?.remoteAddress;
+  const userAgent = req.headers?.['user-agent'] || null;
+  await db.query(
+    `INSERT INTO security_audit_log (user_id, event_type, ip_address, user_agent, metadata)
+     VALUES ($1, $2, $3, $4, $5)`,
+    [userId, eventType, ip, userAgent, JSON.stringify(metadata)]
+  );
+  logger.info('2FA audit event', {
+    event: eventType,
+    userId,
+    ip,
+    metadata,
+  });
+}
+
+async function isDeviceTrusted(userId, fingerprint) {
+  const { rows } = await db.query(
+    `SELECT id FROM trusted_devices
+     WHERE user_id = $1 AND device_fingerprint = $2 AND expires_at > NOW()`,
+    [userId, fingerprint]
+  );
+  return rows.length > 0;
+}
+
+async function trustDevice(userId, fingerprint, req) {
+  const deviceName = req.headers['user-agent'] || 'Unknown device';
+  const ip = req.ip || req.connection?.remoteAddress;
+  const expiresAt = new Date(Date.now() + getDeviceTrustTtlMs());
+
+  await db.query(
+    `INSERT INTO trusted_devices (user_id, device_fingerprint, device_name, ip_address, expires_at)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (user_id, device_fingerprint)
+     DO UPDATE SET trusted_at = NOW(), expires_at = $5, ip_address = $4, device_name = $3`,
+    [userId, fingerprint, deviceName, ip, expiresAt]
+  );
+}
+
+async function revokeDevice(userId, deviceId) {
+  const result = await db.query(
+    'DELETE FROM trusted_devices WHERE id = $1 AND user_id = $2',
+    [deviceId, userId]
+  );
+  return result.rowCount > 0;
+}
+
+async function revokeAllDevices(userId) {
+  await db.query('DELETE FROM trusted_devices WHERE user_id = $1', [userId]);
+}
+
+async function getUserDevices(userId) {
+  const { rows } = await db.query(
+    `SELECT id, device_name, ip_address, trusted_at, expires_at
+     FROM trusted_devices
+     WHERE user_id = $1 AND expires_at > NOW()
+     ORDER BY trusted_at DESC`,
+    [userId]
+  );
+  return rows;
+}
+
+async function enforce2faCheck(user) {
+  if (user.enforce_2fa && !user.totp_enabled) {
+    return { enforced: true, message: '2FA is required for your account. Please set up 2FA before continuing.' };
+  }
+  return { enforced: false };
+}
+
+module.exports = {
+  generateFingerprint,
+  verifyTotp,
+  generateSecret,
+  buildOtpauthUri,
+  generateQrCode,
+  generateBackupCodes,
+  verifyBackupCode,
+  removeBackupCode,
+  logAuditEvent,
+  isDeviceTrusted,
+  trustDevice,
+  revokeDevice,
+  revokeAllDevices,
+  getUserDevices,
+  enforce2faCheck,
+  parseJwtExpiresIn,
+  getDeviceTrustTtlMs,
+  TOTP_WINDOW,
+  BACKUP_CODE_COUNT,
+};


### PR DESCRIPTION
Add missing 2FA features to the existing TOTP setup:

- Clock skew grace period (window=1, 30s tolerance) via totpService
- Device trust/fingerprinting (trusted_devices table, skip 2FA on recognized devices)
- Audit logging for 2FA events (security_audit_log table)
- 2FA enforcement policies (enforce_2fa column on users)
- Backup code regeneration endpoint (10 single-use codes)
- Disable 2FA endpoint (clears secret + revokes trusted devices)
- Device management endpoints (list, trust, revoke)

New endpoints:
  POST /2fa/disable GET  /2fa/backup-codes POST /2fa/trust-device GET  /2fa/devices DELETE /2fa/devices/:deviceId GET  /2fa/audit-log

Closes #430 