### PR TITLE
fix: add missing accessibility support across frontend

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1044,3 +1044,15 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
     gap: 0.5rem;
   }
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { api } from '../services/api';
 import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
@@ -40,10 +40,36 @@ const badgeStyle = {
 };
 
 function Drawer({ title, onClose, children }) {
+  const panelRef = useRef(null);
+
+  useEffect(() => {
+    if (!onClose) return;
+    const onKey = (e) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    const panel = panelRef.current;
+    if (!panel) return;
+    const focusable = panel.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    first?.focus();
+    function trapTab(e) {
+      if (e.key !== 'Tab') return;
+      if (e.shiftKey) { if (document.activeElement === first) { e.preventDefault(); last?.focus(); } }
+      else { if (document.activeElement === last) { e.preventDefault(); first?.focus(); } }
+    }
+    panel.addEventListener('keydown', trapTab);
+    return () => panel.removeEventListener('keydown', trapTab);
+  }, [children]);
+
   return (
     <div
       role="dialog"
       aria-modal="true"
+      aria-label={title}
       style={{
         position: 'fixed',
         inset: 0,
@@ -55,6 +81,7 @@ function Drawer({ title, onClose, children }) {
       onClick={onClose}
     >
       <div
+        ref={panelRef}
         style={{
           width: 'min(520px, 100%)',
           height: '100%',
@@ -917,11 +944,10 @@ function MilestonesQueue() {
                 gap: '0.45rem',
               }}
             >
+              <label htmlFor={`milestone-reject-${m.id}`} className="sr-only">Rejection reason</label>
               <textarea
+                id={`milestone-reject-${m.id}`}
                 value={rejectReason}
-                onChange={(e) => setRejectReason(e.target.value)}
-                placeholder="Rejection reason (visible to creator)"
-                rows={2}
                 style={{
                   fontSize: '0.85rem',
                   resize: 'vertical',
@@ -1342,11 +1368,13 @@ export default function AdminDashboard() {
         Withdrawal approvals, dispute management, KYC oversight, and platform health.
       </p>
 
-      <nav style={{ display: 'flex', gap: '0.35rem', flexWrap: 'wrap', marginBottom: '1.5rem' }}>
+      <nav role="tablist" style={{ display: 'flex', gap: '0.35rem', flexWrap: 'wrap', marginBottom: '1.5rem' }}>
         {TABS.map((t) => (
           <button
             key={t.id}
             type="button"
+            role="tab"
+            aria-selected={tab === t.id}
             onClick={() => setTab(t.id)}
             style={{
               ...badgeStyle,

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { Link, useParams, useLocation, useNavigate } from 'react-router-dom';
 import DOMPurify from 'dompurify';
 import { api } from '../services/api';
@@ -199,6 +199,9 @@ export default function Campaign() {
   const [contributorRefundBusy, setContributorRefundBusy] = useState(false);
   const [contributorRefundError, setContributorRefundError] = useState('');
   const [contributorRefundSuccess, setContributorRefundSuccess] = useState('');
+  const editModalRef = useRef(null);
+  const deleteModalRef = useRef(null);
+
   const refParam = new URLSearchParams(location.search).get('ref');
 
   const currentUserId = user?.id || user?.userId;
@@ -219,6 +222,60 @@ export default function Campaign() {
       })
       .catch(() => { });
   }, [user, id]);
+
+  useEffect(() => {
+    if (!isEditingCampaign) return;
+    const onKey = (e) => { if (e.key === 'Escape') handleCloseEditModal(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isEditingCampaign, handleCloseEditModal]);
+
+  useEffect(() => {
+    if (!isEditingCampaign) return;
+    const modal = editModalRef.current;
+    if (!modal) return;
+    const focusable = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    first?.focus();
+    function trapTab(e) {
+      if (e.key !== 'Tab') return;
+      if (e.shiftKey) { if (document.activeElement === first) { e.preventDefault(); last?.focus(); } }
+      else { if (document.activeElement === last) { e.preventDefault(); first?.focus(); } }
+    }
+    modal.addEventListener('keydown', trapTab);
+    return () => modal.removeEventListener('keydown', trapTab);
+  }, [isEditingCampaign]);
+
+  useEffect(() => {
+    if (!showDeleteDialog) return;
+    const onKey = (e) => {
+      if (e.key === 'Escape') {
+        setShowDeleteDialog(false);
+        setDeleteConfirmation('');
+        setDeleteError('');
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [showDeleteDialog]);
+
+  useEffect(() => {
+    if (!showDeleteDialog) return;
+    const modal = deleteModalRef.current;
+    if (!modal) return;
+    const focusable = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    first?.focus();
+    function trapTab(e) {
+      if (e.key !== 'Tab') return;
+      if (e.shiftKey) { if (document.activeElement === first) { e.preventDefault(); last?.focus(); } }
+      else { if (document.activeElement === last) { e.preventDefault(); first?.focus(); } }
+    }
+    modal.addEventListener('keydown', trapTab);
+    return () => modal.removeEventListener('keydown', trapTab);
+  }, [showDeleteDialog]);
 
   useEffect(() => {
     if (!isOwner || !id) return;
@@ -1307,6 +1364,7 @@ export default function Campaign() {
           type="button"
           className="btn-secondary"
           data-no-print
+          aria-expanded={showQR}
           onClick={() => setShowQR((v) => !v)}
         >
           {showQR ? 'Hide QR code' : 'Show QR code'}
@@ -1381,6 +1439,7 @@ export default function Campaign() {
             <h3 style={{ margin: 0, fontSize: '1rem', fontWeight: 700 }}>Embed this campaign</h3>
             <button
               type="button"
+              aria-expanded={showEmbedSection}
               onClick={() => setShowEmbedSection(!showEmbedSection)}
               style={{
                 background: 'transparent',
@@ -1588,6 +1647,7 @@ export default function Campaign() {
       {canManageTeam && (
         <div style={{ marginBottom: '2rem' }} data-no-print>
           <div
+            role="tablist"
             style={{
               display: 'flex',
               gap: '0.5rem',
@@ -1598,6 +1658,8 @@ export default function Campaign() {
           >
             <button
               type="button"
+              role="tab"
+              aria-selected={activeTab === 'team'}
               onClick={() => setActiveTab('team')}
               style={{
                 background: activeTab === 'team' ? 'var(--color-accent)' : 'transparent',
@@ -1615,6 +1677,8 @@ export default function Campaign() {
             {canViewAnalytics && (
               <button
                 type="button"
+                role="tab"
+                aria-selected={activeTab === 'analytics'}
                 onClick={() => setActiveTab('analytics')}
                 style={{
                   background: activeTab === 'analytics' ? 'var(--color-accent)' : 'transparent',
@@ -1912,14 +1976,18 @@ export default function Campaign() {
           <strong style={{ marginBottom: '0.5rem', display: 'block' }}>
             {editingUpdateId ? 'Edit update' : 'Post update'}
           </strong>
+          <label htmlFor="update-title" className="sr-only">Update title</label>
           <input
+            id="update-title"
             placeholder="Update title"
             value={updateForm.title}
             onChange={(e) => setUpdateForm((s) => ({ ...s, title: e.target.value }))}
             required
             style={{ marginBottom: '0.5rem' }}
           />
+          <label htmlFor="update-body" className="sr-only">Update body</label>
           <textarea
+            id="update-body"
             placeholder="Write markdown update..."
             value={updateForm.body}
             onChange={(e) => setUpdateForm((s) => ({ ...s, body: e.target.value }))}
@@ -1996,6 +2064,7 @@ export default function Campaign() {
           <h2 style={styles.sectionTitle}>Analytics</h2>
 
           <div
+            role="tablist"
             style={{
               display: 'flex',
               gap: '0.5rem',
@@ -2006,6 +2075,8 @@ export default function Campaign() {
           >
             <button
               type="button"
+              role="tab"
+              aria-selected={analyticsTab === 'overview'}
               onClick={() => setAnalyticsTab('overview')}
               style={{
                 background: analyticsTab === 'overview' ? 'var(--color-accent)' : 'transparent',
@@ -2023,6 +2094,8 @@ export default function Campaign() {
 
             <button
               type="button"
+              role="tab"
+              aria-selected={analyticsTab === 'backers'}
               onClick={() => setAnalyticsTab('backers')}
               style={{
                 background: analyticsTab === 'backers' ? 'var(--color-accent)' : 'transparent',
@@ -2254,6 +2327,9 @@ export default function Campaign() {
       {/* Edit Campaign Modal */}
       {isEditingCampaign && campaign && (
         <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="edit-campaign-title"
           style={{
             position: 'fixed',
             top: 0,
@@ -2269,6 +2345,7 @@ export default function Campaign() {
           onClick={handleCloseEditModal}
         >
           <div
+            ref={editModalRef}
             style={{
               background: '#fff',
               borderRadius: '12px',
@@ -2282,6 +2359,7 @@ export default function Campaign() {
             onClick={(e) => e.stopPropagation()}
           >
             <h2
+              id="edit-campaign-title"
               style={{
                 marginTop: 0,
                 marginBottom: '1.5rem',
@@ -2439,6 +2517,9 @@ export default function Campaign() {
       {/* Delete Campaign Confirmation Dialog */}
       {showDeleteDialog && campaign && (
         <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="delete-campaign-title"
           style={{
             position: 'fixed',
             top: 0,
@@ -2453,6 +2534,7 @@ export default function Campaign() {
           }}
         >
           <div
+            ref={deleteModalRef}
             style={{
               background: 'var(--color-surface)',
               borderRadius: '8px',
@@ -2463,6 +2545,7 @@ export default function Campaign() {
             }}
           >
             <h2
+              id="delete-campaign-title"
               style={{
                 fontSize: '1.5rem',
                 fontWeight: 700,

--- a/frontend/src/pages/CampaignEmbed.jsx
+++ b/frontend/src/pages/CampaignEmbed.jsx
@@ -133,7 +133,7 @@ export default function CampaignEmbed() {
           <div style={styles.target}>{progressPct.toFixed(1)}%</div>
         </div>
 
-        <div style={styles.progressBar}>
+        <div style={styles.progressBar} role="progressbar" aria-valuenow={Math.round(progressPct)} aria-valuemin={0} aria-valuemax={100}>
           <div
             style={{
               ...styles.progressFill,

--- a/frontend/src/pages/Developer.jsx
+++ b/frontend/src/pages/Developer.jsx
@@ -449,7 +449,9 @@ export default function Developer() {
             marginBottom: '1rem',
           }}
         >
+          <label htmlFor="new-key-label" className="sr-only">API key label</label>
           <input
+            id="new-key-label"
             value={newKeyLabel}
             onChange={(e) => setNewKeyLabel(e.target.value)}
             placeholder="Label"
@@ -540,7 +542,9 @@ export default function Developer() {
             marginBottom: '1rem',
           }}
         >
+          <label htmlFor="webhook-url" className="sr-only">Webhook URL</label>
           <input
+            id="webhook-url"
             value={hookUrl}
             onChange={(e) => setHookUrl(e.target.value)}
             placeholder="https://example.com/crowdpay-webhook"

--- a/frontend/src/pages/ForgotPassword.jsx
+++ b/frontend/src/pages/ForgotPassword.jsx
@@ -51,7 +51,9 @@ export default function ForgotPassword() {
           onSubmit={handleSubmit}
           style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem' }}
         >
+          <label htmlFor="forgot-email" className="sr-only">Email</label>
           <input
+            id="forgot-email"
             type="email"
             placeholder="Email"
             value={email}

--- a/frontend/src/pages/ResetPassword.jsx
+++ b/frontend/src/pages/ResetPassword.jsx
@@ -86,7 +86,9 @@ export default function ResetPassword() {
           onSubmit={handleSubmit}
           style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem' }}
         >
+          <label htmlFor="new-password" className="sr-only">New password</label>
           <input
+            id="new-password"
             type="password"
             placeholder="New password"
             value={password}
@@ -94,7 +96,9 @@ export default function ResetPassword() {
             required
             minLength={8}
           />
+          <label htmlFor="confirm-password" className="sr-only">Confirm new password</label>
           <input
+            id="confirm-password"
             type="password"
             placeholder="Confirm new password"
             value={confirmPassword}

--- a/frontend/src/pages/Widget.jsx
+++ b/frontend/src/pages/Widget.jsx
@@ -94,7 +94,7 @@ export default function Widget() {
     <div style={styles.shell}>
       <div style={styles.card}>
         <div style={styles.title}>{data.title}</div>
-        <div style={styles.progressTrack}>
+        <div style={styles.progressTrack} role="progressbar" aria-valuenow={Math.round(pct)} aria-valuemin={0} aria-valuemax={100}>
           <div style={{ ...styles.progressFill, width: `${pct}%` }} />
         </div>
         <div style={styles.meta}>


### PR DESCRIPTION
Closes #505

---

## Summary

Adds proper accessibility support to multiple modals, dialogs, tabs, progress bars, and form inputs across the frontend.

### Changes

**Focus traps & keyboard support:**
- Edit Campaign modal: `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, focus trap, Escape key handler
- Delete Campaign dialog: same as above
- AdminDashboard Drawer: Escape key handler and focus trap (already had `role="dialog"` and `aria-modal`)

**ARIA tab roles:**
- AdminDashboard tab navigation: `role="tablist"`, `role="tab"`, `aria-selected`
- Campaign Team/Analytics tabs: same
- Campaign Analytics sub-tabs (Overview/Backers): same

**Progress bar ARIA:**
- CampaignEmbed.jsx: `role="progressbar"`, `aria-valuenow`, `aria-valuemin`, `aria-valuemax`
- Widget.jsx: same

**Toggle buttons:**
- QR code toggle: `aria-expanded`
- Embed section toggle: `aria-expanded`

**Form labels (`.sr-only`):**
- ResetPassword: password and confirm password inputs
- ForgotPassword: email input
- Campaign updates: title and body inputs
- Developer: API key label and webhook URL inputs
- AdminDashboard: milestone rejection reason textarea
