### PR TITLE
Add frontend test coverage for priority pages and components(#467)

### DIFF
--- a/frontend/src/pages/CreateCampaign.jsx
+++ b/frontend/src/pages/CreateCampaign.jsx
@@ -66,6 +66,7 @@ export default function CreateCampaign() {
     max_per_user: location.state?.prefill?.max_per_user || '',
     show_backer_amounts: location.state?.prefill?.show_backer_amounts ?? true,
     milestones: [],
+    reward_tiers: [],
 
   });
   const [coverImageFile, setCoverImageFile] = useState(null);

--- a/frontend/src/pages/Developer.jsx
+++ b/frontend/src/pages/Developer.jsx
@@ -216,7 +216,19 @@ export default function Developer() {
     setNewKeyScopes((cur) => (cur.includes(sc) ? cur.filter((x) => x !== sc) : [...cur, sc]));
   }
 
-  const selectedEndpoint = v1Endpoints.find((e) => e.id === explorerEndpoint) || v1Endpoints[0];
+  const selectedEndpoint =
+    v1Endpoints.find((e) => e.id === explorerEndpoint) ||
+    v1Endpoints[0] ||
+    {
+      id: '',
+      auth: false,
+      method: 'GET',
+      path: '',
+      pathFields: [],
+      queryFields: [],
+      bodyTemplate: null,
+      label: '',
+    };
 
   function buildExplorerUrl() {
     if (!selectedEndpoint) return '';

--- a/frontend/src/test/components/KycPrompt.test.jsx
+++ b/frontend/src/test/components/KycPrompt.test.jsx
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../renderWithProviders';
+import KycPrompt from '../../components/KycPrompt';
+
+vi.mock('../../services/api', () => ({
+  api: {
+    startKyc: vi.fn(),
+  },
+}));
+
+import { api } from '../../services/api';
+
+describe('KycPrompt', () => {
+  it('starts KYC and calls onUserUpdate when the API returns a user', async () => {
+    const onUserUpdate = vi.fn();
+    api.startKyc.mockResolvedValue({ user: { id: 'user123', name: 'Creator Name' } });
+
+    renderWithProviders(<KycPrompt onUserUpdate={onUserUpdate} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /Verify your identity/i }));
+    await waitFor(() => expect(api.startKyc).toHaveBeenCalled());
+
+    expect(onUserUpdate).toHaveBeenCalledWith({ id: 'user123', name: 'Creator Name' });
+    expect(screen.getByText(/CrowdPay requires verified creator identity/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/components/MilestoneTracker.test.jsx
+++ b/frontend/src/test/components/MilestoneTracker.test.jsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../renderWithProviders';
+import MilestoneTracker from '../../components/MilestoneTracker';
+
+describe('MilestoneTracker', () => {
+  it('renders milestone status, description, and on-chain state', () => {
+    renderWithProviders(
+      <MilestoneTracker
+        milestones={[
+          {
+            id: 'milestone-1',
+            title: 'Build community garden',
+            description: 'Prepare the site and purchase materials.',
+            release_percentage: '50',
+            status: 'released',
+            on_chain: true,
+          },
+        ]}
+        assetType="USDC"
+        contractMilestones={[{ index: 0, on_chain_status: 'released' }]}
+      />
+    );
+
+    expect(screen.getByText(/Milestone releases/i)).toBeInTheDocument();
+    expect(screen.getByText(/Build community garden/i)).toBeInTheDocument();
+    expect(screen.getByText(/Released on-chain/i)).toBeInTheDocument();
+    expect(screen.getByText(/Releases 50% of campaign funds in USDC/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/components/NotificationDropdown.test.jsx
+++ b/frontend/src/test/components/NotificationDropdown.test.jsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../renderWithProviders';
+import NotificationDropdown from '../../components/NotificationDropdown';
+
+vi.mock('../../services/api', () => ({
+  api: {
+    markNotificationRead: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+import { api } from '../../services/api';
+
+describe('NotificationDropdown', () => {
+  it('marks an unread notification as read and closes the dropdown', async () => {
+    const onMarkRead = vi.fn();
+    const onMarkAllRead = vi.fn();
+    const onClose = vi.fn();
+    const notifications = [
+      {
+        id: 'notif-1',
+        title: 'New contribution',
+        body: 'A supporter just backed your campaign.',
+        created_at: '2026-07-25T12:00:00.000Z',
+        read_at: null,
+        link: '/campaigns/1',
+      },
+    ];
+
+    renderWithProviders(
+      <NotificationDropdown
+        notifications={notifications}
+        onMarkRead={onMarkRead}
+        onMarkAllRead={onMarkAllRead}
+        onClose={onClose}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /New contribution/i }));
+    await waitFor(() => expect(api.markNotificationRead).toHaveBeenCalledWith('notif-1'));
+    expect(onMarkRead).toHaveBeenCalledWith('notif-1');
+    expect(onClose).toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: /Mark all as read/i }));
+    expect(onMarkAllRead).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/test/components/TransactionHistory.test.jsx
+++ b/frontend/src/test/components/TransactionHistory.test.jsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../renderWithProviders';
+import TransactionHistory from '../../components/TransactionHistory';
+
+vi.mock('../../services/api', () => ({
+  api: {
+    getStellarTransactions: vi.fn(),
+  },
+}));
+
+import { api } from '../../services/api';
+
+describe('TransactionHistory', () => {
+  it('loads transaction records and supports loading more', async () => {
+    const transactions = Array.from({ length: 11 }, (_, index) => ({
+      id: `tx-${index}`,
+      kind: 'contribution',
+      status: 'indexed',
+      created_at: '2026-07-25T00:00:00.000Z',
+      tx_hash: `HASH00000${index}`,
+    }));
+
+    api.getStellarTransactions.mockResolvedValue(transactions);
+
+    renderWithProviders(<TransactionHistory campaignId="campaign-1" isCreator />);
+
+    await screen.findByText(/Transaction history/i);
+    expect(api.getStellarTransactions).toHaveBeenCalledWith({ campaignId: 'campaign-1', limit: 11 });
+    expect(screen.getByText(/HASH0000…000000/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /Load more/i }));
+    await waitFor(() => expect(api.getStellarTransactions).toHaveBeenCalledTimes(2));
+    expect(api.getStellarTransactions).toHaveBeenLastCalledWith({ campaignId: 'campaign-1', limit: 21 });
+  });
+});

--- a/frontend/src/test/components/WithdrawalsSection.test.jsx
+++ b/frontend/src/test/components/WithdrawalsSection.test.jsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../renderWithProviders';
+import WithdrawalsSection from '../../components/WithdrawalsSection';
+
+vi.mock('../../services/api', () => ({
+  api: {
+    getWithdrawalCapabilities: vi.fn(),
+    listWithdrawals: vi.fn(),
+    getCampaignBalance: vi.fn(),
+    requestWithdrawal: vi.fn(),
+  },
+}));
+
+import { api } from '../../services/api';
+
+describe('WithdrawalsSection', () => {
+  it('renders the release request form and submits a withdrawal request', async () => {
+    const onReleased = vi.fn();
+    const campaign = {
+      id: 'campaign-1',
+      creator_id: 'user-1',
+      status: 'active',
+      asset_type: 'USDC',
+    };
+    const user = { id: 'user-1', role: 'creator', wallet_public_key: 'GABCDEF' };
+
+    api.getWithdrawalCapabilities.mockResolvedValue({ can_approve_platform: false });
+    api.listWithdrawals.mockResolvedValue([]);
+    api.getCampaignBalance.mockResolvedValue({ USDC: '250' });
+    api.requestWithdrawal.mockResolvedValue({});
+
+    renderWithProviders(
+      <WithdrawalsSection
+        campaign={campaign}
+        milestones={[]}
+        user={user}
+        token="test-token"
+        onReleased={onReleased}
+      />
+    );
+
+    await screen.findByText(/Available on-chain:/i);
+    await userEvent.type(screen.getByLabelText(/Destination address/i), 'GDEST12345');
+    await userEvent.type(screen.getByLabelText(/Amount \(USDC\)/i), '200');
+    await userEvent.click(screen.getByRole('button', { name: /Submit request/i }));
+
+    await waitFor(() =>
+      expect(api.requestWithdrawal).toHaveBeenCalledWith({
+        campaign_id: 'campaign-1',
+        destination_key: 'GDEST12345',
+        amount: '200',
+      })
+    );
+    expect(onReleased).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/test/pages/About.test.jsx
+++ b/frontend/src/test/pages/About.test.jsx
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import About from '../../pages/About';
+import { renderWithProviders } from '../renderWithProviders';
+
+describe('About page', () => {
+  it('renders the about page heading and content', () => {
+    renderWithProviders(<About />);
+
+    expect(screen.getByRole('heading', { name: /About CrowdPay/i })).toBeInTheDocument();
+    expect(screen.getByText(/CrowdPay is a fundraising platform built to move contributions/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/pages/AdminDashboard.test.jsx
+++ b/frontend/src/test/pages/AdminDashboard.test.jsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import AdminDashboard from '../../pages/AdminDashboard';
+import { renderWithProviders } from '../renderWithProviders';
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'admin', role: 'admin', is_admin: true }, ready: true }),
+}));
+
+const apiMocks = vi.hoisted(() => ({
+  getAdminHealth: vi.fn().mockResolvedValue({
+    active_campaigns: 3,
+    total_raised: '5000',
+    pending_withdrawals: { count: 1, total_value: '200' },
+    open_disputes: 0,
+    failed_webhook_deliveries: 0,
+    stellar: { network: 'Testnet', current_ledger: 12345, base_fee_stroops: 100, horizon_latency_ms: 50 },
+    load_time_ms: 12,
+    recent_reconciliation_runs: [],
+  }),
+  getAdminWebhookDeliveries: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../services/api', () => ({ api: apiMocks }));
+
+describe('AdminDashboard page', () => {
+  it('renders admin dashboard heading and platform health data', async () => {
+    renderWithProviders(<AdminDashboard />);
+
+    expect(await screen.findByRole('heading', { name: /Admin Dashboard/i })).toBeInTheDocument();
+    expect(screen.getByText(/Active campaigns/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/pages/CreateCampaign.test.jsx
+++ b/frontend/src/test/pages/CreateCampaign.test.jsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import CreateCampaign from '../../pages/CreateCampaign';
+import { renderWithProviders } from '../renderWithProviders';
+
+vi.mock('react-simplemde-editor', () => ({
+  default: ({ id, value, onChange }) => (
+    <textarea id={id} value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'user1', role: 'creator', kyc_status: 'verified' },
+    ready: true,
+    updateUser: vi.fn(),
+  }),
+}));
+
+const apiMocks = vi.hoisted(() => ({
+  getMe: vi.fn().mockResolvedValue({ id: 'user1', role: 'creator' }),
+  checkDuplicateCampaign: vi.fn().mockResolvedValue({ isDuplicate: false }),
+  createCampaign: vi.fn().mockResolvedValue({ id: 'new-campaign' }),
+  uploadCampaignCoverImage: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('../../services/api', () => ({ api: apiMocks }));
+
+describe('CreateCampaign page', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, '');
+  });
+
+  it('submits the campaign creation form with correct values', async () => {
+    renderWithProviders(<CreateCampaign />);
+
+    const title = await screen.findByLabelText(/Campaign title/i);
+    fireEvent.change(title, { target: { value: 'New campaign' } });
+
+    const target = screen.getByLabelText(/Fundraising goal/i);
+    fireEvent.change(target, { target: { value: '500' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue to details/i }));
+
+    const description = await screen.findByLabelText(/Description/i);
+    fireEvent.change(description, { target: { value: 'This is a test campaign.' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue to milestones/i }));
+
+    fireEvent.click(await screen.findByRole('button', { name: /Launch campaign/i }));
+
+    await waitFor(() => {
+      expect(apiMocks.createCampaign).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'New campaign',
+          description: 'This is a test campaign.',
+          target_amount: '500',
+        })
+      );
+    });
+  });
+});

--- a/frontend/src/test/pages/Dashboard.test.jsx
+++ b/frontend/src/test/pages/Dashboard.test.jsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import Dashboard from '../../pages/Dashboard';
+import { renderWithProviders } from '../renderWithProviders';
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'user1', role: 'creator' },
+    ready: true,
+    updateUser: vi.fn(),
+  }),
+}));
+
+const apiMocks = vi.hoisted(() => ({
+  getMyBalance: vi.fn().mockResolvedValue({ balance: { USDC: '100' } }),
+  getMe: vi.fn().mockResolvedValue({ id: 'user1', role: 'creator' }),
+  getMyStats: vi.fn().mockResolvedValue({ total_campaigns: 1 }),
+  getUserDashboardAnalytics: vi.fn().mockResolvedValue([]),
+  getMyCampaigns: vi.fn().mockResolvedValue({ data: [], pagination: { totalPages: 1, total: 0 } }),
+}));
+
+vi.mock('../../services/api', () => ({ api: apiMocks }));
+
+describe('Dashboard page', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the dashboard heading and balance section', async () => {
+    renderWithProviders(<Dashboard />);
+
+    expect(await screen.findByRole('heading', { name: /Dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add Funds/i })).toBeInTheDocument();
+  });
+
+  it('shows an error message when the dashboard APIs fail', async () => {
+    apiMocks.getMyStats.mockRejectedValueOnce(new Error('Dashboard failed'));
+
+    renderWithProviders(<Dashboard />);
+
+    await waitFor(() => expect(apiMocks.getMyStats).toHaveBeenCalled());
+    expect(screen.getByText('Dashboard failed')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/pages/Developer.test.jsx
+++ b/frontend/src/test/pages/Developer.test.jsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import Developer from '../../pages/Developer';
+import { renderWithProviders } from '../renderWithProviders';
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user1', role: 'creator' }, ready: true }),
+}));
+
+const apiMocks = vi.hoisted(() => ({
+  listApiKeys: vi.fn().mockResolvedValue([]),
+  listWebhooks: vi.fn().mockResolvedValue([]),
+  listWebhookDeliveries: vi.fn().mockResolvedValue([]),
+  createApiKey: vi.fn().mockResolvedValue({ api_key: 'new-key' }),
+}));
+
+vi.mock('../../services/api', () => ({ api: apiMocks }));
+
+describe('Developer page', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the developer page and creates an API key', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        paths: {
+          '/users/me': {
+            get: {
+              summary: 'Get user',
+              responses: {},
+            },
+          },
+        },
+      }),
+    });
+
+    renderWithProviders(<Developer />);
+
+    expect(await screen.findByRole('heading', { name: /API keys/i })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/Label/i), { target: { value: 'Integration' } });
+    fireEvent.click(screen.getByRole('button', { name: /Create key/i }));
+
+    await waitFor(() => expect(apiMocks.createApiKey).toHaveBeenCalledWith({ name: 'Integration', scopes: ['read', 'write', 'withdrawals'] }));
+    expect(await screen.findByText(/Copy now:/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/pages/ForgotPassword.test.jsx
+++ b/frontend/src/test/pages/ForgotPassword.test.jsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import ForgotPassword from '../../pages/ForgotPassword';
+import { renderWithProviders } from '../renderWithProviders';
+
+const apiMocks = vi.hoisted(() => ({
+  forgotPassword: vi.fn().mockResolvedValue({ message: 'Reset email sent' }),
+}));
+
+vi.mock('../../services/api', () => ({ api: apiMocks }));
+
+describe('ForgotPassword page', () => {
+  it('submits the forgot password form', async () => {
+    renderWithProviders(<ForgotPassword />);
+
+    fireEvent.change(screen.getByPlaceholderText(/Email/i), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Send reset link/i }));
+
+    await waitFor(() => expect(apiMocks.forgotPassword).toHaveBeenCalledWith({ email: 'test@example.com' }));
+    expect(await screen.findByText(/Reset email sent/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/pages/Home.test.jsx
+++ b/frontend/src/test/pages/Home.test.jsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import Home from '../../pages/Home';
+import { renderWithProviders } from '../renderWithProviders';
+
+const apiMocks = vi.hoisted(() => ({
+  getCampaignCategories: vi.fn().mockResolvedValue([]),
+  getFeaturedCampaigns: vi.fn().mockResolvedValue([]),
+  getCampaigns: vi.fn().mockResolvedValue({ campaigns: [{ id: '1', title: 'Test campaign', status: 'active', target_amount: '100', asset_type: 'USDC' }], total: 1 }),
+  getCampaign: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ user: null, ready: true }),
+}));
+
+vi.mock('../../services/api', () => ({ api: apiMocks }));
+
+describe('Home page', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the hero heading and call to action', async () => {
+    renderWithProviders(<Home />);
+
+    expect(await screen.findByRole('heading', { name: /Explore campaigns/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Create account/i })).toBeInTheDocument();
+  });
+
+  it('shows a skeleton while campaigns are loading', async () => {
+    apiMocks.getCampaigns.mockImplementation(() => new Promise(() => {}));
+
+    const { container } = renderWithProviders(<Home />);
+
+    await waitFor(() => {
+      expect(container.querySelector('.skeleton--card')).toBeInTheDocument();
+    });
+  });
+
+  it('renders an error message when campaigns fail to load', async () => {
+    apiMocks.getCampaigns.mockRejectedValue(new Error('Unable to load campaigns'));
+
+    renderWithProviders(<Home />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load campaigns');
+  });
+});

--- a/frontend/src/test/pages/HowItWorks.test.jsx
+++ b/frontend/src/test/pages/HowItWorks.test.jsx
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import HowItWorks from '../../pages/HowItWorks';
+import { renderWithProviders } from '../renderWithProviders';
+
+describe('HowItWorks page', () => {
+  it('renders the how it works heading and steps', () => {
+    renderWithProviders(<HowItWorks />);
+
+    expect(screen.getByRole('heading', { name: /How CrowdPay works/i })).toBeInTheDocument();
+    expect(screen.getByText(/Discover a cause/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/pages/Landing.test.jsx
+++ b/frontend/src/test/pages/Landing.test.jsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import Landing from '../../pages/Landing';
+import { renderWithProviders } from '../renderWithProviders';
+
+const apiMocks = vi.hoisted(() => ({
+  getFeaturedCampaigns: vi.fn().mockResolvedValue([]),
+  getCampaigns: vi.fn().mockResolvedValue({ campaigns: [], total: 0 }),
+}));
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ user: null, ready: true }),
+}));
+
+vi.mock('../../services/api', () => ({ api: apiMocks }));
+
+describe('Landing page', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the landing heading and main call to action', async () => {
+    renderWithProviders(<Landing />);
+
+    expect(await screen.findByRole('heading', { name: /Support with Confidence/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Explore Support Spaces/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/pages/MyContributions.test.jsx
+++ b/frontend/src/test/pages/MyContributions.test.jsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import MyContributions from '../../pages/MyContributions';
+import { renderWithProviders } from '../renderWithProviders';
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user1' }, token: 'token', ready: true }),
+}));
+
+const apiMocks = vi.hoisted(() => ({
+  getMyContributions: vi.fn().mockResolvedValue([
+    {
+      id: 'c1',
+      campaign_id: 'campaign-1',
+      campaign_title: 'Support project',
+      campaign_status: 'active',
+      amount: '100',
+      asset: 'XLM',
+      created_at: '2024-01-01T00:00:00.000Z',
+      tx_hash: 'ABC12345XYZ',
+    },
+  ]),
+}));
+
+vi.mock('../../services/api', () => ({ api: apiMocks }));
+
+describe('MyContributions page', () => {
+  it('renders contribution records from the API', async () => {
+    renderWithProviders(<MyContributions />);
+
+    expect(await screen.findByRole('heading', { name: /My Contributions/i })).toBeInTheDocument();
+    expect(screen.getByText(/Support project/i)).toBeInTheDocument();
+    expect(screen.getByText(/100 XLM/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/pages/NotFound.test.jsx
+++ b/frontend/src/test/pages/NotFound.test.jsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import NotFound from '../../pages/NotFound';
+import { render } from '@testing-library/react';
+
+describe('NotFound page', () => {
+  it('renders the 404 heading and a link back to home', () => {
+    render(
+      <MemoryRouter>
+        <NotFound />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: /Page not found/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: /Home/i })[0]).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/pages/Pricing.test.jsx
+++ b/frontend/src/test/pages/Pricing.test.jsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import Pricing from '../../pages/Pricing';
+import { renderWithProviders } from '../renderWithProviders';
+
+const apiMocks = vi.hoisted(() => ({
+  getPlatformConfig: vi.fn().mockResolvedValue({ platform_fee_bps: 250 }),
+}));
+
+vi.mock('../../services/api', () => ({ api: apiMocks }));
+
+describe('Pricing page', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the pricing heading and fee details', async () => {
+    renderWithProviders(<Pricing />);
+
+    expect(await screen.findByRole('heading', { name: /Pricing/i })).toBeInTheDocument();
+    expect(screen.getByText(/2.50% of each contribution/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/pages/Profile.test.jsx
+++ b/frontend/src/test/pages/Profile.test.jsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import Profile from '../../pages/Profile';
+import { renderWithProviders } from '../renderWithProviders';
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({
+    user: {
+      id: 'user1',
+      name: 'Alice',
+      email: 'alice@example.com',
+      created_at: '2024-01-01T00:00:00.000Z',
+      wallet_public_key: 'GABCDEF',
+      kyc_status: 'verified',
+    },
+    token: 'token',
+    ready: true,
+    updateUser: vi.fn(),
+  }),
+}));
+
+describe('Profile page', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders profile fields and submits changes', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'user1', name: 'Alice Updated' }),
+    });
+
+    renderWithProviders(<Profile />);
+
+    expect(await screen.findByRole('heading', { name: /Your Profile/i })).toBeInTheDocument();
+
+    const form = screen.getByRole('button', { name: /Save changes/i }).closest('form');
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/users/me'), expect.objectContaining({ method: 'PATCH' }));
+    });
+
+    expect(await screen.findByText(/Profile updated successfully/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/pages/ResetPassword.test.jsx
+++ b/frontend/src/test/pages/ResetPassword.test.jsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import ResetPassword from '../../pages/ResetPassword';
+import { renderWithProviders } from '../renderWithProviders';
+
+const apiMocks = vi.hoisted(() => ({
+  resetPassword: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('../../services/api', () => ({ api: apiMocks }));
+
+describe('ResetPassword page', () => {
+  it('submits the reset password form with a valid token', async () => {
+    renderWithProviders(<ResetPassword />, { route: '/reset-password?token=abc123' });
+
+    const passwordInputs = screen.getAllByPlaceholderText(/New password/i);
+    fireEvent.change(passwordInputs[0], {
+      target: { value: 'Password1' },
+    });
+    fireEvent.change(passwordInputs[1], {
+      target: { value: 'Password1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Reset password/i }));
+
+    await waitFor(() => expect(apiMocks.resetPassword).toHaveBeenCalledWith({ token: 'abc123', password: 'Password1' }));
+  });
+});

--- a/frontend/src/test/pages/Resources.test.jsx
+++ b/frontend/src/test/pages/Resources.test.jsx
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import Resources from '../../pages/Resources';
+import { renderWithProviders } from '../renderWithProviders';
+
+describe('Resources page', () => {
+  it('renders the resources page heading and links', () => {
+    renderWithProviders(<Resources />);
+
+    expect(screen.getByRole('heading', { name: /Resources/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /How CrowdPay works/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/renderWithProviders.jsx
+++ b/frontend/src/test/renderWithProviders.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from '../context/ThemeContext';
+import { ToastProvider } from '../context/ToastContext';
+import { NetworkStatusProvider } from '../context/NetworkStatusContext';
+
+export function renderWithProviders(ui, { route = '/', ...options } = {}) {
+  const Wrapper = ({ children }) => (
+    <ThemeProvider>
+      <ToastProvider>
+        <NetworkStatusProvider>
+          <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
+        </NetworkStatusProvider>
+      </ToastProvider>
+    </ThemeProvider>
+  );
+
+  return render(ui, { wrapper: Wrapper, ...options });
+}

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -10,6 +10,19 @@ if (typeof globalThis.ResizeObserver === 'undefined') {
   };
 }
 
+if (typeof window.matchMedia === 'undefined') {
+  window.matchMedia = function () {
+    return {
+      matches: false,
+      media: '',
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    };
+  };
+}
+
 function lookup(obj, path) {
   return path.split('.').reduce((o, k) => (o && o[k] !== null && o[k] !== undefined ? o[k] : undefined), obj);
 }


### PR DESCRIPTION
# PR: Frontend Test Coverage for Priority Pages And Componenets

## Summary
This PR adds focused frontend test coverage for the CrowdPay application, targeting priority pages and components in the `frontend` codebase. It introduces a shared test utility and improves the Vitest test environment, enabling stable and maintainable UI tests.

Closes #467 

## What changed
- Added shared rendering helper: `frontend/src/test/renderWithProviders.jsx`
- Updated test environment setup in `frontend/src/test/setup.js`
- Added page-level tests for:
  - `frontend/src/test/pages/About.test.jsx`
  - `frontend/src/test/pages/AdminDashboard.test.jsx`
  - `frontend/src/test/pages/CreateCampaign.test.jsx`
  - `frontend/src/test/pages/Dashboard.test.jsx`
  - `frontend/src/test/pages/Developer.test.jsx`
  - `frontend/src/test/pages/ForgotPassword.test.jsx`
  - `frontend/src/test/pages/Home.test.jsx`
  - `frontend/src/test/pages/HowItWorks.test.jsx`
  - `frontend/src/test/pages/Landing.test.jsx`
  - `frontend/src/test/pages/MyContributions.test.jsx`
  - `frontend/src/test/pages/NotFound.test.jsx`
  - `frontend/src/test/pages/Pricing.test.jsx`
  - `frontend/src/test/pages/Profile.test.jsx`
  - `frontend/src/test/pages/ResetPassword.test.jsx`
  - `frontend/src/test/pages/Resources.test.jsx`
- Added component-level tests for:
  - `frontend/src/test/components/KycPrompt.test.jsx`
  - `frontend/src/test/components/MilestoneTracker.test.jsx`
  - `frontend/src/test/components/NotificationDropdown.test.jsx`
  - `frontend/src/test/components/TransactionHistory.test.jsx`
  - `frontend/src/test/components/WithdrawalsSection.test.jsx`

## Test environment improvements
- Added JSDOM compatibility shim for `window.matchMedia` in `frontend/src/test/setup.js`
- Ensured `ResizeObserver` is available during tests
- Centralized provider rendering for React Router, theme, toast, and network status contexts

## Fixes and improvements
- Updated `frontend/src/pages/Developer.jsx` to safely handle missing OpenAPI endpoint metadata
- Added test-friendly state initialization in `CreateCampaign` flows
- Stabilized page tests with proper API mocks and form interaction expectations

## Validation
- Executed `cd frontend && npx vitest run src/test`
- Result: `30 passed (30)`

## Branch
- `feat/frontend-test-coverage`

## Notes
This PR is intentionally scoped to frontend test coverage and test support infrastructure only. No production feature behavior was changed outside the necessary adjustments for reliable test execution.
