### PR TITLE
Add campaign comments, contributor dashboard upgrades, webhook events, and campaign cloning

### DIFF
--- a/backend/db/migrations/20260725_campaign_comments.sql
+++ b/backend/db/migrations/20260725_campaign_comments.sql
@@ -1,0 +1,28 @@
+-- Threaded campaign comments + moderation flags (#437)
+CREATE TABLE campaign_comments (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id   UUID NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  author_id     UUID NOT NULL REFERENCES users(id),
+  parent_id     UUID REFERENCES campaign_comments(id) ON DELETE CASCADE,
+  body          TEXT NOT NULL,
+  hidden        BOOLEAN NOT NULL DEFAULT FALSE,
+  hidden_reason TEXT,
+  hidden_by     UUID REFERENCES users(id),
+  hidden_at     TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX campaign_comments_campaign_created_idx
+  ON campaign_comments (campaign_id, created_at DESC);
+CREATE INDEX campaign_comments_parent_idx
+  ON campaign_comments (parent_id);
+
+CREATE TABLE campaign_comment_flags (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  comment_id  UUID NOT NULL REFERENCES campaign_comments(id) ON DELETE CASCADE,
+  flagged_by  UUID NOT NULL REFERENCES users(id),
+  reason      TEXT,
+  created_at  TIMESTAMPTZ DEFAULT NOW(),
+  CONSTRAINT campaign_comment_flags_unique UNIQUE (comment_id, flagged_by)
+);

--- a/backend/db/migrations/20260725_campaign_draft_and_clone.sql
+++ b/backend/db/migrations/20260725_campaign_draft_and_clone.sql
@@ -1,0 +1,14 @@
+-- Campaign clone + draft status + scheduled publishing (#432)
+
+-- Drafts have no on-chain wallet yet; allow NULL (UNIQUE still permits multiple NULLs).
+ALTER TABLE campaigns ALTER COLUMN wallet_public_key DROP NOT NULL;
+
+ALTER TABLE campaigns
+  DROP CONSTRAINT IF EXISTS campaigns_status_check;
+
+ALTER TABLE campaigns
+  ADD CONSTRAINT campaigns_status_check
+    CHECK (status IN ('draft', 'active', 'funded', 'in_progress', 'completed', 'closed', 'withdrawn', 'failed', 'refunded'));
+
+ALTER TABLE campaigns ADD COLUMN scheduled_publish_at TIMESTAMPTZ;
+ALTER TABLE campaigns ADD COLUMN cloned_from UUID REFERENCES campaigns(id);

--- a/backend/db/migrations/20260725_contributor_favorites.sql
+++ b/backend/db/migrations/20260725_contributor_favorites.sql
@@ -1,0 +1,7 @@
+-- Contributor campaign favorites/wishlist (#433)
+CREATE TABLE contributor_favorites (
+  user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  campaign_id UUID NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  created_at  TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (user_id, campaign_id)
+);

--- a/backend/db/migrations/20260725_webhook_backoff_config.sql
+++ b/backend/db/migrations/20260725_webhook_backoff_config.sql
@@ -1,0 +1,3 @@
+-- Configurable per-webhook retry backoff (#434)
+ALTER TABLE webhooks ADD COLUMN backoff_strategy JSONB;
+ALTER TABLE campaign_webhooks ADD COLUMN backoff_strategy JSONB;

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -234,6 +234,7 @@ app.use("/api/referrals", require("./routes/referrals"));
 app.use("/api/users", require("./routes/users"));
 app.use("/api/invites", require("./routes/invites"));
 app.use("/api/campaigns", require("./routes/campaignUpdates"));
+app.use("/api/campaigns", require("./routes/campaignComments"));
 app.use("/api/campaigns", require("./routes/campaigns"));
 app.use("/api/anchor", require("./routes/anchor"));
 app.use("/api/contributions", require("./routes/contributions"));
@@ -382,6 +383,31 @@ function startWeeklyDigestCron() {
   logger.info("Weekly digest cron scheduled", { schedule });
 }
 
+function startScheduledPublishCron() {
+  if (!ff.isEnabled("scheduled-publish-cron")) return;
+  const cron = require("node-cron");
+  const db = require("./config/database");
+  const { publishDraftCampaign } = require("./services/campaignPublishing");
+  cron.schedule("*/5 * * * *", async () => {
+    try {
+      const { rows } = await db.query(
+        `SELECT id FROM campaigns
+         WHERE status = 'draft' AND scheduled_publish_at IS NOT NULL AND scheduled_publish_at <= NOW()`
+      );
+      for (const row of rows) {
+        try {
+          await publishDraftCampaign(row.id);
+        } catch (err) {
+          logger.error("Scheduled publish failed for campaign", { campaign_id: row.id, error: err.message });
+        }
+      }
+    } catch (err) {
+      logger.error("Scheduled publish cron failed", { error: err.message });
+    }
+  });
+  logger.info("Scheduled publish cron scheduled (every 5 minutes)");
+}
+
 function startNotificationDigestCron() {
   if (!ff.isEnabled("notification-quiet-hours-cron")) return;
   const cron = require("node-cron");
@@ -408,6 +434,7 @@ async function bootstrap() {
     startWebhookRetryPoller();
     startCampaignStatusCron();
     startReconciliationCron();
+    startScheduledPublishCron();
     startWeeklyDigestCron();
     startNotificationDigestCron();
   });

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1101,6 +1101,57 @@ router.post('/webhook-deliveries/:id/retry', async (req, res) => {
 });
 
 /**
+ * GET /api/admin/webhooks/metrics
+ * Delivery observability: success rate, average latency, and failure counts
+ * per event type across both user-level and campaign-level webhooks.
+ */
+router.get('/webhooks/metrics', async (req, res) => {
+  try {
+    const [userMetrics, campaignMetrics] = await Promise.all([
+      db.query(`
+        SELECT event_type AS event,
+               COUNT(*)::int AS total,
+               COUNT(*) FILTER (WHERE status = 'delivered')::int AS delivered,
+               COUNT(*) FILTER (WHERE status = 'failed')::int AS failed,
+               COUNT(*) FILTER (WHERE status IN ('pending', 'delivering', 'retrying'))::int AS in_flight,
+               ROUND(AVG(EXTRACT(EPOCH FROM (delivered_at - created_at)) * 1000)
+                 FILTER (WHERE status = 'delivered'))::int AS avg_latency_ms
+        FROM webhook_deliveries
+        GROUP BY event_type
+        ORDER BY event_type
+      `),
+      db.query(`
+        SELECT event,
+               COUNT(*)::int AS total,
+               COUNT(*) FILTER (WHERE status = 'delivered')::int AS delivered,
+               COUNT(*) FILTER (WHERE status = 'failed')::int AS failed,
+               COUNT(*) FILTER (WHERE status IN ('pending', 'delivering', 'retrying'))::int AS in_flight,
+               ROUND(AVG(EXTRACT(EPOCH FROM (delivered_at - created_at)) * 1000)
+                 FILTER (WHERE status = 'delivered'))::int AS avg_latency_ms
+        FROM campaign_webhook_deliveries
+        GROUP BY event
+        ORDER BY event
+      `),
+    ]);
+
+    function withSuccessRate(rows) {
+      return rows.map((row) => ({
+        ...row,
+        success_rate: row.total > 0 ? Number((row.delivered / row.total).toFixed(4)) : 0,
+      }));
+    }
+
+    res.json({
+      user_webhooks: withSuccessRate(userMetrics.rows),
+      campaign_webhooks: withSuccessRate(campaignMetrics.rows),
+    });
+  } catch (err) {
+    logger.error('Error fetching webhook metrics', { error: err.message });
+    res.status(500).json({ error: 'Failed to fetch webhook metrics' });
+  }
+});
+
+/**
  * GET /api/admin/campaigns/:id/contributions
  * Contributor audit trail for withdrawal review
  */

--- a/backend/src/routes/campaignComments.js
+++ b/backend/src/routes/campaignComments.js
@@ -1,0 +1,285 @@
+const router = require("express").Router();
+const db = require("../config/database");
+const { requireAuth, authenticate } = require("../middleware/auth");
+const asyncHandler = require("../utils/asyncHandler");
+const logger = require("../config/logger");
+const { createNotification } = require("../services/notifications");
+
+function cleanText(value = "") {
+  return String(value)
+    .replace(/<[^>]*>/g, "")
+    .trim();
+}
+
+async function requireCampaignCreator(req, res, next) {
+  const campaignId = req.params.id;
+
+  const { rows } = await db.query(
+    "SELECT id, creator_id, title FROM campaigns WHERE id = $1",
+    [campaignId],
+  );
+
+  if (!rows.length) {
+    return res.status(404).json({ error: "Campaign not found" });
+  }
+
+  if (rows[0].creator_id !== req.user.userId && req.user.role !== "admin") {
+    return res.status(403).json({
+      error: "Only the campaign creator can moderate comments",
+    });
+  }
+
+  req.campaign = rows[0];
+  next();
+}
+
+const COMMENT_COLUMNS = `cc.id, cc.campaign_id, cc.author_id, cc.parent_id, cc.body,
+       cc.hidden, cc.hidden_reason, cc.created_at, cc.updated_at,
+       u.name AS author_name`;
+
+// Public (optionally authenticated): list comments newest first, flat with parent_id.
+// Hidden comments are only visible to the campaign creator/admin.
+router.get(
+  "/:id/comments",
+  asyncHandler(async (req, res) => {
+    const { rows: campaigns } = await db.query(
+      "SELECT id, creator_id FROM campaigns WHERE id = $1",
+      [req.params.id],
+    );
+    if (!campaigns.length) return res.status(404).json({ error: "Campaign not found" });
+
+    try {
+      await authenticate(req);
+    } catch {
+      // anonymous viewer — proceed without req.user
+    }
+
+    const canSeeHidden =
+      req.user && (req.user.userId === campaigns[0].creator_id || req.user.role === "admin");
+
+    const { rows } = await db.query(
+      `SELECT ${COMMENT_COLUMNS}
+       FROM campaign_comments cc
+       JOIN users u ON u.id = cc.author_id
+       WHERE cc.campaign_id = $1 ${canSeeHidden ? "" : "AND cc.hidden = FALSE"}
+       ORDER BY cc.created_at DESC`,
+      [req.params.id],
+    );
+
+    res.json(rows);
+  }),
+);
+
+// Any authenticated user: post a top-level comment or a reply
+router.post(
+  "/:id/comments",
+  requireAuth,
+  asyncHandler(async (req, res) => {
+    const body = cleanText(req.body.body);
+    if (!body) return res.status(422).json({ error: "Body is required" });
+
+    const { rows: campaigns } = await db.query(
+      "SELECT id, creator_id, title FROM campaigns WHERE id = $1",
+      [req.params.id],
+    );
+    if (!campaigns.length) return res.status(404).json({ error: "Campaign not found" });
+    const campaign = campaigns[0];
+
+    let parentComment = null;
+    if (req.body.parent_id) {
+      const { rows: parents } = await db.query(
+        "SELECT id, author_id, campaign_id FROM campaign_comments WHERE id = $1",
+        [req.body.parent_id],
+      );
+      if (!parents.length || parents[0].campaign_id !== campaign.id) {
+        return res.status(422).json({ error: "Invalid parent_id" });
+      }
+      parentComment = parents[0];
+    }
+
+    const { rows } = await db.query(
+      `INSERT INTO campaign_comments (campaign_id, author_id, parent_id, body)
+       VALUES ($1, $2, $3, $4)
+       RETURNING id, campaign_id, author_id, parent_id, body, hidden, hidden_reason, created_at, updated_at`,
+      [req.params.id, req.user.userId, parentComment ? parentComment.id : null, body],
+    );
+    const { rows: authorRows } = await db.query("SELECT name FROM users WHERE id = $1", [
+      req.user.userId,
+    ]);
+    const comment = { ...rows[0], author_name: authorRows[0]?.name };
+
+    setImmediate(() => {
+      const excerpt = body.length > 160 ? `${body.slice(0, 160).trim()}…` : body;
+      if (parentComment) {
+        if (parentComment.author_id !== req.user.userId) {
+          createNotification(parentComment.author_id, {
+            type: "comment_reply",
+            title: `New reply on "${campaign.title}"`,
+            body: excerpt,
+            link: `/campaigns/${campaign.id}`,
+          }).catch((err) =>
+            logger.error("Comment reply notification failed", { error: err.message }),
+          );
+        }
+      } else if (campaign.creator_id !== req.user.userId) {
+        createNotification(campaign.creator_id, {
+          type: "campaign_comment",
+          title: `New comment on "${campaign.title}"`,
+          body: excerpt,
+          link: `/campaigns/${campaign.id}`,
+        }).catch((err) => logger.error("Comment notification failed", { error: err.message }));
+      }
+    });
+
+    res.status(201).json(comment);
+  }),
+);
+
+// Author only: edit own comment within 24 hours
+router.patch(
+  "/:id/comments/:commentId",
+  requireAuth,
+  asyncHandler(async (req, res) => {
+    const body = cleanText(req.body.body);
+    if (!body) return res.status(422).json({ error: "Body is required" });
+
+    const { rows } = await db.query(
+      `UPDATE campaign_comments
+       SET body = $1, updated_at = NOW()
+       WHERE id = $2
+         AND campaign_id = $3
+         AND author_id = $4
+         AND created_at >= NOW() - INTERVAL '24 hours'
+       RETURNING id, campaign_id, author_id, parent_id, body, hidden, hidden_reason, created_at, updated_at`,
+      [body, req.params.commentId, req.params.id, req.user.userId],
+    );
+
+    if (!rows.length) {
+      return res.status(403).json({ error: "Comment not found or edit window has expired" });
+    }
+
+    res.json(rows[0]);
+  }),
+);
+
+// Author (own comment) OR campaign creator/admin (moderation): delete a comment
+router.delete(
+  "/:id/comments/:commentId",
+  requireAuth,
+  asyncHandler(async (req, res) => {
+    const { rows: campaigns } = await db.query(
+      "SELECT id, creator_id FROM campaigns WHERE id = $1",
+      [req.params.id],
+    );
+    if (!campaigns.length) return res.status(404).json({ error: "Campaign not found" });
+
+    const isModerator =
+      campaigns[0].creator_id === req.user.userId || req.user.role === "admin";
+
+    const { rowCount } = await db.query(
+      `DELETE FROM campaign_comments
+       WHERE id = $1
+         AND campaign_id = $2
+         ${isModerator ? "" : "AND author_id = $3"}`,
+      isModerator
+        ? [req.params.commentId, req.params.id]
+        : [req.params.commentId, req.params.id, req.user.userId],
+    );
+
+    if (!rowCount) {
+      return res.status(404).json({ error: "Comment not found" });
+    }
+
+    res.status(204).send();
+  }),
+);
+
+// Any authenticated user: flag a comment for moderation review
+router.post(
+  "/:id/comments/:commentId/flag",
+  requireAuth,
+  asyncHandler(async (req, res) => {
+    const reason = cleanText(req.body.reason || "");
+
+    const { rows } = await db.query(
+      "SELECT id FROM campaign_comments WHERE id = $1 AND campaign_id = $2",
+      [req.params.commentId, req.params.id],
+    );
+    if (!rows.length) return res.status(404).json({ error: "Comment not found" });
+
+    await db.query(
+      `INSERT INTO campaign_comment_flags (comment_id, flagged_by, reason)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (comment_id, flagged_by) DO NOTHING`,
+      [req.params.commentId, req.user.userId, reason || null],
+    );
+
+    res.status(204).send();
+  }),
+);
+
+// Creator/admin only: review queue of flagged and hidden comments
+router.get(
+  "/:id/comments/moderation",
+  requireAuth,
+  requireCampaignCreator,
+  asyncHandler(async (req, res) => {
+    const { rows } = await db.query(
+      `SELECT ${COMMENT_COLUMNS}, COALESCE(f.flag_count, 0)::int AS flag_count
+       FROM campaign_comments cc
+       JOIN users u ON u.id = cc.author_id
+       LEFT JOIN (
+         SELECT comment_id, COUNT(*) AS flag_count
+         FROM campaign_comment_flags
+         GROUP BY comment_id
+       ) f ON f.comment_id = cc.id
+       WHERE cc.campaign_id = $1 AND (cc.hidden = TRUE OR COALESCE(f.flag_count, 0) > 0)
+       ORDER BY flag_count DESC, cc.created_at DESC`,
+      [req.params.id],
+    );
+
+    res.json(rows);
+  }),
+);
+
+// Creator/admin only: hide a comment
+router.post(
+  "/:id/comments/:commentId/hide",
+  requireAuth,
+  requireCampaignCreator,
+  asyncHandler(async (req, res) => {
+    const reason = cleanText(req.body.reason || "");
+
+    const { rows } = await db.query(
+      `UPDATE campaign_comments
+       SET hidden = TRUE, hidden_reason = $1, hidden_by = $2, hidden_at = NOW()
+       WHERE id = $3 AND campaign_id = $4
+       RETURNING id, campaign_id, author_id, parent_id, body, hidden, hidden_reason, created_at, updated_at`,
+      [reason || null, req.user.userId, req.params.commentId, req.params.id],
+    );
+
+    if (!rows.length) return res.status(404).json({ error: "Comment not found" });
+    res.json(rows[0]);
+  }),
+);
+
+// Creator/admin only: unhide a comment
+router.post(
+  "/:id/comments/:commentId/unhide",
+  requireAuth,
+  requireCampaignCreator,
+  asyncHandler(async (req, res) => {
+    const { rows } = await db.query(
+      `UPDATE campaign_comments
+       SET hidden = FALSE, hidden_reason = NULL, hidden_by = NULL, hidden_at = NULL
+       WHERE id = $1 AND campaign_id = $2
+       RETURNING id, campaign_id, author_id, parent_id, body, hidden, hidden_reason, created_at, updated_at`,
+      [req.params.commentId, req.params.id],
+    );
+
+    if (!rows.length) return res.status(404).json({ error: "Comment not found" });
+    res.json(rows[0]);
+  }),
+);
+
+module.exports = router;

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -25,6 +25,7 @@ const { sendEmail, sendTeamMemberInvitedEmail } = require('../services/emailServ
 const { uploadCampaignCoverImage } = require('../services/storage');
 const { isKycRequiredForCampaigns } = require('../services/kycProvider');
 const { listCreatorCampaigns } = require('../services/userDashboardService');
+const { publishDraftCampaign, CampaignNotPublishableError } = require('../services/campaignPublishing');
 const {
   MAX_TIERS_PER_CAMPAIGN,
   validateTiersInput,
@@ -432,6 +433,144 @@ router.get('/:id/clone-data', requireAuth, requireCampaignMember('owner'), async
   });
 }));
 
+// One-click clone: copies fields, milestones, and reward tiers into a new
+// draft campaign with no on-chain wallet/contracts yet (instant, no gas cost).
+router.post('/:id/clone', requireAuth, requireCampaignMember('owner'), asyncHandler(async (req, res) => {
+  const sourceId = req.params.id;
+
+  const { rows: campaignRows } = await db.query(
+    `SELECT title, description, target_amount, asset_type, category,
+            min_contribution, max_contribution, max_per_user, show_backer_amounts
+     FROM campaigns WHERE id = $1`,
+    [sourceId]
+  );
+  if (!campaignRows.length) return res.status(404).json({ error: 'Campaign not found' });
+  const source = campaignRows[0];
+
+  const { rows: milestoneRows } = await db.query(
+    'SELECT title, description, release_percentage, sort_order FROM milestones WHERE campaign_id = $1 ORDER BY sort_order ASC',
+    [sourceId]
+  );
+  const { rows: tierRows } = await db.query(
+    'SELECT title, description, min_amount, asset_type, tier_limit, estimated_delivery FROM reward_tiers WHERE campaign_id = $1 ORDER BY min_amount ASC',
+    [sourceId]
+  );
+
+  const { rows: userRows } = await db.query('SELECT email FROM users WHERE id = $1', [req.user.userId]);
+  const creatorEmail = userRows[0]?.email;
+
+  const client = await db.connect();
+  let clone;
+  try {
+    await client.query('BEGIN');
+
+    const { rows } = await client.query(
+      `INSERT INTO campaigns
+         (title, description, target_amount, asset_type, creator_id, status,
+          category, min_contribution, max_contribution, max_per_user, show_backer_amounts,
+          raised_amount, cloned_from)
+       VALUES ($1, $2, $3, $4, $5, 'draft', $6, $7, $8, $9, $10, 0, $11)
+       RETURNING *`,
+      [
+        `${source.title} (Copy)`,
+        source.description,
+        source.target_amount,
+        source.asset_type,
+        req.user.userId,
+        source.category,
+        source.min_contribution,
+        source.max_contribution,
+        source.max_per_user,
+        source.show_backer_amounts,
+        sourceId,
+      ]
+    );
+    clone = rows[0];
+
+    await client.query(
+      `INSERT INTO campaign_members (campaign_id, user_id, email, role, accepted_at)
+       VALUES ($1, $2, $3, 'owner', NOW())`,
+      [clone.id, req.user.userId, creatorEmail]
+    );
+
+    for (const milestone of milestoneRows) {
+      await client.query(
+        `INSERT INTO milestones (campaign_id, title, description, release_percentage, sort_order)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [clone.id, milestone.title, milestone.description, milestone.release_percentage, milestone.sort_order]
+      );
+    }
+
+    if (tierRows.length) {
+      await insertTiers(
+        client,
+        clone.id,
+        tierRows.map((t) => ({
+          title: t.title,
+          description: t.description,
+          min_amount: t.min_amount,
+          asset_type: t.asset_type,
+          tier_limit: t.tier_limit,
+          estimated_delivery: t.estimated_delivery,
+        }))
+      );
+    }
+
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    logger.error('[campaigns] clone failed', { source_campaign_id: sourceId, error: err.message });
+    return res.status(500).json({ error: 'Could not clone campaign' });
+  } finally {
+    client.release();
+  }
+
+  res.status(201).json(clone);
+}));
+
+// Schedule (or clear) auto-publish for a draft campaign.
+router.post('/:id/schedule-publish', requireAuth, requireCampaignMember('owner'), asyncHandler(async (req, res) => {
+  const { scheduled_publish_at } = req.body || {};
+
+  const { rows: campaignRows } = await db.query('SELECT status FROM campaigns WHERE id = $1', [req.params.id]);
+  if (!campaignRows.length) return res.status(404).json({ error: 'Campaign not found' });
+  if (campaignRows[0].status !== 'draft') {
+    return res.status(409).json({ error: 'Only draft campaigns can be scheduled for publishing' });
+  }
+
+  let value = null;
+  if (scheduled_publish_at) {
+    const date = new Date(scheduled_publish_at);
+    if (isNaN(date.getTime())) {
+      return res.status(422).json({ error: 'scheduled_publish_at must be a valid ISO 8601 date' });
+    }
+    if (date.getTime() <= Date.now()) {
+      return res.status(422).json({ error: 'scheduled_publish_at must be in the future' });
+    }
+    value = date.toISOString();
+  }
+
+  const { rows } = await db.query(
+    'UPDATE campaigns SET scheduled_publish_at = $1 WHERE id = $2 RETURNING *',
+    [value, req.params.id]
+  );
+  res.json(rows[0]);
+}));
+
+// Deploy the on-chain wallet + contracts for a draft campaign and make it active.
+router.post('/:id/publish', requireAuth, requireCampaignMember('owner'), asyncHandler(async (req, res) => {
+  try {
+    const campaign = await publishDraftCampaign(req.params.id);
+    res.json(campaign);
+  } catch (err) {
+    if (err instanceof CampaignNotPublishableError) {
+      return res.status(409).json({ error: err.message });
+    }
+    logger.error('[campaigns] publish failed', { campaign_id: req.params.id, error: err.message });
+    res.status(502).json({ error: 'Could not publish campaign', detail: err.message });
+  }
+}));
+
 // Get single Campaign
 // Get featured campaigns
 router.get('/featured', asyncHandler(async (req, res) => {
@@ -447,6 +586,29 @@ router.get('/featured', asyncHandler(async (req, res) => {
     LIMIT 3
   `);
   res.json(rows);
+}));
+
+// Add campaign to the current user's favorites/wishlist
+router.post('/:id/favorite', requireAuth, asyncHandler(async (req, res) => {
+  const { rows: campaigns } = await db.query('SELECT id FROM campaigns WHERE id = $1', [req.params.id]);
+  if (!campaigns.length) return res.status(404).json({ error: 'Campaign not found' });
+
+  await db.query(
+    `INSERT INTO contributor_favorites (user_id, campaign_id)
+     VALUES ($1, $2)
+     ON CONFLICT (user_id, campaign_id) DO NOTHING`,
+    [req.user.userId, req.params.id]
+  );
+  res.status(204).send();
+}));
+
+// Remove campaign from the current user's favorites/wishlist
+router.delete('/:id/favorite', requireAuth, asyncHandler(async (req, res) => {
+  await db.query(
+    'DELETE FROM contributor_favorites WHERE user_id = $1 AND campaign_id = $2',
+    [req.user.userId, req.params.id]
+  );
+  res.status(204).send();
 }));
 
 router.get('/categories', asyncHandler(async (req, res) => {

--- a/backend/src/routes/contributions.js
+++ b/backend/src/routes/contributions.js
@@ -26,8 +26,13 @@ const {
   buildContributionMemo,
   submitCustodialContribution,
 } = require('../services/contributionService');
-const { listUserContributions, getContributorDashboard } = require('../services/userDashboardService');
+const {
+  listUserContributions,
+  getContributorDashboard,
+  getContributorDashboardCsv,
+} = require('../services/userDashboardService');
 const { triggerRefund } = require('../services/sorobanService');
+const { emitWebhookEventForUser, emitWebhookEventForCampaign, WEBHOOK_EVENTS } = require('../services/webhookDispatcher');
 const { assertUserKycVerified } = require('../services/kycService');
 const asyncHandler = require('../utils/asyncHandler');
 const { getReferralCodeFromRequest } = require('../services/referralService');
@@ -147,6 +152,14 @@ router.get('/dashboard', requireAuth, asyncHandler(async (req, res) => {
   const data = await getContributorDashboard(req.user.userId);
   if (data === null) return res.status(404).json({ error: 'User not found' });
   res.json(data);
+}));
+
+router.get('/dashboard/export.csv', requireAuth, asyncHandler(async (req, res) => {
+  const csv = await getContributorDashboardCsv(req.user.userId);
+  if (csv === null) return res.status(404).json({ error: 'User not found' });
+  res.setHeader('Content-Type', 'text/csv');
+  res.setHeader('Content-Disposition', 'attachment; filename="contributions.csv"');
+  res.send(csv);
 }));
 
 router.get('/campaign/:campaignId', async (req, res) => {
@@ -594,7 +607,7 @@ router.post('/:id/refund', requireAuth, asyncHandler(async (req, res) => {
   const signerSecret = req.body.signer_secret || process.env.PLATFORM_SECRET_KEY;
 
   const { rows: contributions } = await db.query(
-    `SELECT ct.*, c.escrow_contract_id, c.status AS campaign_status, c.deadline
+    `SELECT ct.*, c.escrow_contract_id, c.status AS campaign_status, c.deadline, c.creator_id
      FROM contributions ct
      JOIN campaigns c ON c.id = ct.campaign_id
      WHERE ct.id = $1`,
@@ -658,6 +671,23 @@ router.post('/:id/refund', requireAuth, asyncHandler(async (req, res) => {
       contributionId,
       escrowContractId: contribution.escrow_contract_id,
       result,
+    });
+
+    setImmediate(() => {
+      const refundPayload = {
+        campaign_id: contribution.campaign_id,
+        contribution_id: contribution.id,
+        amount: String(contribution.amount),
+        asset: contribution.asset,
+        tx_hash: result?.toString() || null,
+        timestamp: new Date().toISOString(),
+      };
+      emitWebhookEventForUser(contribution.creator_id, WEBHOOK_EVENTS.CONTRIBUTION_REFUNDED, refundPayload).catch(
+        (err) => logger.error('Contribution refunded webhook emit failed', { error: err.message })
+      );
+      emitWebhookEventForCampaign(contribution.campaign_id, WEBHOOK_EVENTS.CONTRIBUTION_REFUNDED, refundPayload).catch(
+        (err) => logger.error('Contribution refunded webhook emit failed', { error: err.message })
+      );
     });
 
     res.json({

--- a/backend/src/routes/disputes.js
+++ b/backend/src/routes/disputes.js
@@ -8,6 +8,7 @@ const {
   sendDisputeResolvedContributorEmail,
 } = require('../services/emailService');
 const logger = require('../config/logger');
+const { emitWebhookEventForUser, emitWebhookEventForCampaign, WEBHOOK_EVENTS } = require('../services/webhookDispatcher');
 
 function frontendBaseUrl() {
   return (process.env.FRONTEND_URL || 'http://localhost:5173').replace(/\/$/, '');
@@ -120,6 +121,17 @@ router.post('/campaigns/:id/disputes', requireAuth, async (req, res) => {
     );
 
     logger.info('Dispute raised', { dispute_id: dispute.id, campaign_id: campaign.id });
+
+    setImmediate(() => {
+      const payload = { dispute, campaign_id: campaign.id };
+      emitWebhookEventForUser(campaign.creator_id, WEBHOOK_EVENTS.DISPUTE_OPENED, payload).catch((err) =>
+        logger.error('Dispute opened webhook emit failed', { error: err.message })
+      );
+      emitWebhookEventForCampaign(campaign.id, WEBHOOK_EVENTS.DISPUTE_OPENED, payload).catch((err) =>
+        logger.error('Dispute opened webhook emit failed', { error: err.message })
+      );
+    });
+
     res.status(201).json(dispute);
   } catch (err) {
     await client.query('ROLLBACK');
@@ -161,6 +173,11 @@ router.patch('/disputes/:id', requireAuth, requireRole('admin'), async (req, res
   );
   if (!disputes.length) return res.status(404).json({ error: 'Dispute not found' });
   const dispute = disputes[0];
+
+  const { rows: disputeCampaigns } = await db.query('SELECT creator_id FROM campaigns WHERE id = $1', [
+    dispute.campaign_id,
+  ]);
+  const campaignCreatorId = disputeCampaigns[0]?.creator_id;
 
   const client = await db.connect();
   try {
@@ -259,12 +276,20 @@ router.patch('/disputes/:id', requireAuth, requireRole('admin'), async (req, res
 
     if (status === 'resolved_creator') {
       // Unfreeze pending on_hold withdrawals for this campaign
-      await client.query(
+      const { rows: unfrozen } = await client.query(
         `UPDATE withdrawal_requests
          SET status = 'pending', dispute_id = NULL
-         WHERE campaign_id = $1 AND status = 'on_hold' AND dispute_id = $2`,
+         WHERE campaign_id = $1 AND status = 'on_hold' AND dispute_id = $2
+         RETURNING *`,
         [dispute.campaign_id, dispute.id]
       );
+      for (const withdrawal of unfrozen) {
+        setImmediate(() =>
+          emitWebhookEventForUser(campaignCreatorId, WEBHOOK_EVENTS.WITHDRAWAL_UPDATED, {
+            withdrawal,
+          }).catch((err) => logger.error('Withdrawal updated webhook emit failed', { error: err.message }))
+        );
+      }
 
       const { rows: creatorRows } = await db.query(
         `SELECT u.email, u.name, c.title
@@ -286,6 +311,19 @@ router.patch('/disputes/:id', requireAuth, requireRole('admin'), async (req, res
     }
 
     await client.query('COMMIT');
+
+    if (['resolved_creator', 'resolved_contributor', 'closed'].includes(status)) {
+      setImmediate(() => {
+        const payload = { dispute: updated[0], campaign_id: dispute.campaign_id };
+        emitWebhookEventForUser(campaignCreatorId, WEBHOOK_EVENTS.DISPUTE_RESOLVED, payload).catch((err) =>
+          logger.error('Dispute resolved webhook emit failed', { error: err.message })
+        );
+        emitWebhookEventForCampaign(dispute.campaign_id, WEBHOOK_EVENTS.DISPUTE_RESOLVED, payload).catch((err) =>
+          logger.error('Dispute resolved webhook emit failed', { error: err.message })
+        );
+      });
+    }
+
     res.json(updated[0]);
   } catch (err) {
     await client.query('ROLLBACK');

--- a/backend/src/routes/milestones.js
+++ b/backend/src/routes/milestones.js
@@ -477,7 +477,7 @@ router.post('/:id/reject', requireAuth, async (req, res) => {
 
   // Soroban integration: Reject milestone on-chain
   const { rows: campaignRows } = await db.query(
-    'SELECT milestones_contract_id FROM campaigns WHERE id = $1',
+    'SELECT milestones_contract_id, creator_id FROM campaigns WHERE id = $1',
     [rows[0].campaign_id]
   );
   const contractId = campaignRows[0]?.milestones_contract_id;
@@ -496,6 +496,16 @@ router.post('/:id/reject', requireAuth, async (req, res) => {
   }
 
   evaluateCampaign(rows[0].campaign_id).catch(err => logger.error('Fraud evaluate failed in milestone reject', { error: err.message }));
+
+  if (campaignRows[0]?.creator_id) {
+    setImmediate(() => {
+      emitWebhookEventForUser(campaignRows[0].creator_id, WEBHOOK_EVENTS.MILESTONE_REJECTED, {
+        milestone: rows[0],
+        campaign_id: rows[0].campaign_id,
+        reason,
+      }).catch((err) => logger.error('Milestone rejected webhook emit failed', { error: err.message }));
+    });
+  }
 
   res.json(rows[0]);
 });

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -82,6 +82,19 @@ router.get('/me/contributions', requireAuth, asyncHandler(async (req, res) => {
   res.json(rows);
 }));
 
+router.get('/me/favorites', requireAuth, asyncHandler(async (req, res) => {
+  const { rows } = await db.query(
+    `SELECT c.id, c.title, c.description, c.target_amount, c.raised_amount,
+            c.asset_type, c.status, c.deadline, cf.created_at AS favorited_at
+     FROM contributor_favorites cf
+     JOIN campaigns c ON c.id = cf.campaign_id
+     WHERE cf.user_id = $1
+     ORDER BY cf.created_at DESC`,
+    [req.user.userId]
+  );
+  res.json(rows);
+}));
+
 router.get('/me/notification-preferences', requireAuth, asyncHandler(async (req, res) => {
   const { rows: users } = await db.query(
     'SELECT email FROM users WHERE id = $1',

--- a/backend/src/routes/webhooks.js
+++ b/backend/src/routes/webhooks.js
@@ -4,7 +4,11 @@ const crypto = require('crypto');
 const db = require('../config/database');
 const logger = require('../config/logger');
 const { requireAuth } = require('../middleware/auth');
-const { ALL_WEBHOOK_EVENTS, processDelivery } = require('../services/webhookDispatcher');
+const {
+  ALL_WEBHOOK_EVENTS,
+  processDelivery,
+  isValidBackoffStrategy,
+} = require('../services/webhookDispatcher');
 const {
   processIncomingWebhook,
   verifyWebhookSignature,
@@ -100,7 +104,7 @@ router.get('/', requireAuth, async (req, res) => {
 });
 
 router.post('/', requireAuth, async (req, res) => {
-  const { url, events } = req.body || {};
+  const { url, events, backoff_strategy } = req.body || {};
   if (!url || !events) {
     return res.status(400).json({ error: 'url and events array are required' });
   }
@@ -111,13 +115,18 @@ router.post('/', requireAuth, async (req, res) => {
   if (!ev.length) {
     return res.status(400).json({ error: `events must include at least one of: ${ALL_WEBHOOK_EVENTS.join(', ')}` });
   }
+  if (backoff_strategy !== undefined && backoff_strategy !== null && !isValidBackoffStrategy(backoff_strategy)) {
+    return res.status(400).json({
+      error: 'backoff_strategy must be { base_ms, max_ms, multiplier } with positive numbers',
+    });
+  }
 
   const secret = `whsec_${crypto.randomBytes(32).toString('hex')}`;
   const { rows } = await db.query(
-    `INSERT INTO webhooks (user_id, url, events, secret)
-     VALUES ($1, $2, $3, $4)
-     RETURNING id, url, events, created_at`,
-    [req.user.userId, url, ev, secret]
+    `INSERT INTO webhooks (user_id, url, events, secret, backoff_strategy)
+     VALUES ($1, $2, $3, $4, $5::jsonb)
+     RETURNING id, url, events, backoff_strategy, created_at`,
+    [req.user.userId, url, ev, secret, backoff_strategy ? JSON.stringify(backoff_strategy) : null]
   );
 
   res.status(201).json({
@@ -125,6 +134,24 @@ router.post('/', requireAuth, async (req, res) => {
     secret,
     message: 'Store the signing secret; it is only shown once.',
   });
+});
+
+router.patch('/:id/backoff-strategy', requireAuth, async (req, res) => {
+  const { backoff_strategy } = req.body || {};
+  if (backoff_strategy !== null && !isValidBackoffStrategy(backoff_strategy)) {
+    return res.status(400).json({
+      error: 'backoff_strategy must be { base_ms, max_ms, multiplier } with positive numbers, or null to reset to defaults',
+    });
+  }
+
+  const { rows } = await db.query(
+    `UPDATE webhooks SET backoff_strategy = $1::jsonb
+     WHERE id = $2 AND user_id = $3 AND revoked_at IS NULL
+     RETURNING id, url, events, backoff_strategy`,
+    [backoff_strategy ? JSON.stringify(backoff_strategy) : null, req.params.id, req.user.userId]
+  );
+  if (!rows.length) return res.status(404).json({ error: 'Webhook not found' });
+  res.json(rows[0]);
 });
 
 router.delete('/:id', requireAuth, async (req, res) => {

--- a/backend/src/routes/withdrawals.js
+++ b/backend/src/routes/withdrawals.js
@@ -29,6 +29,13 @@ function frontendBaseUrl() {
   return (process.env.FRONTEND_URL || 'http://localhost:5173').replace(/\/$/, '');
 }
 
+function emitWithdrawalUpdated(creatorId, withdrawalRow) {
+  if (!creatorId) return;
+  emitWebhookEventForUser(creatorId, WEBHOOK_EVENTS.WITHDRAWAL_UPDATED, {
+    withdrawal: withdrawalRow,
+  }).catch((err) => logger.error('Withdrawal updated webhook emit failed', { error: err.message }));
+}
+
 /** Fail closed when PLATFORM_APPROVER_USER_ID is unset. */
 function canPerformPlatformSignature(userId) {
   if (!process.env.PLATFORM_APPROVER_USER_ID) return false;
@@ -595,6 +602,7 @@ router.post('/:id/cancel', requireAuth, async (req, res) => {
       metadata: {},
     });
     await client.query('COMMIT');
+    setImmediate(() => emitWithdrawalUpdated(requestRow.creator_id, updated[0]));
     res.json(updated[0]);
   } catch (err) {
     await client.query('ROLLBACK');
@@ -698,6 +706,7 @@ router.post('/:id/reject', requireAuth, requirePlatformApprover, async (req, res
         body: `Your withdrawal request was rejected. Reason: ${reason}`,
         link: `/campaigns/${requestRow.campaign_id}`,
       }).catch(() => {});
+      emitWithdrawalUpdated(cRows[0].creator_id, updated[0]);
     }
 
     res.json(updated[0]);

--- a/backend/src/services/campaignPublishing.js
+++ b/backend/src/services/campaignPublishing.js
@@ -1,0 +1,92 @@
+const db = require('../config/database');
+const logger = require('../config/logger');
+const { Keypair } = require('@stellar/stellar-sdk');
+const { createCampaignWallet } = require('./stellarService');
+const { deployCampaignContracts } = require('./sorobanService');
+const { watchCampaignWallet } = require('./ledgerMonitor');
+
+const MILESTONE_PERCENT_SCALE = 10000;
+
+class CampaignNotPublishableError extends Error {}
+
+/**
+ * Deploys the on-chain wallet + Soroban contracts for a draft campaign and
+ * flips it to 'active'. Shared by the manual POST /:id/publish route and the
+ * scheduled-publish cron so both call sites stay in sync.
+ */
+async function publishDraftCampaign(campaignId) {
+  const { rows: campaigns } = await db.query(
+    'SELECT id, title, target_amount, asset_type, deadline, creator_id, status FROM campaigns WHERE id = $1',
+    [campaignId]
+  );
+  if (!campaigns.length || campaigns[0].status !== 'draft') {
+    throw new CampaignNotPublishableError('Campaign not found or is not a draft');
+  }
+  const campaign = campaigns[0];
+
+  const { rows: users } = await db.query('SELECT wallet_public_key FROM users WHERE id = $1', [
+    campaign.creator_id,
+  ]);
+  const creatorPublicKey = users[0]?.wallet_public_key;
+  if (!creatorPublicKey) {
+    throw new CampaignNotPublishableError('Campaign creator has no wallet configured');
+  }
+
+  const { rows: milestoneRows } = await db.query(
+    'SELECT title, description, release_percentage, sort_order FROM milestones WHERE campaign_id = $1 ORDER BY sort_order ASC',
+    [campaignId]
+  );
+  const milestones = milestoneRows.map((m) => ({
+    title: m.title,
+    description: m.description,
+    release_percentage: Number(m.release_percentage).toFixed(4),
+    release_percentage_units: Math.round(Number(m.release_percentage) * MILESTONE_PERCENT_SCALE),
+    sort_order: m.sort_order,
+  }));
+
+  const wallet = await createCampaignWallet(creatorPublicKey);
+
+  const platformPublicKey = Keypair.fromSecret(process.env.PLATFORM_SECRET_KEY).publicKey();
+  const platformFeeBps = parseInt(process.env.PLATFORM_FEE_BPS || '0', 10);
+  const deadlineUnix = campaign.deadline ? Math.floor(new Date(campaign.deadline).getTime() / 1000) : 0;
+  const assetContractAddress = process.env.USDC_CONTRACT_ADDRESS || process.env.USDC_ISSUER;
+
+  const { escrowContractId, milestonesContractId } = await deployCampaignContracts({
+    creatorPublicKey,
+    platformPublicKey,
+    campaignId: campaign.title + Date.now(),
+    targetAmount: Math.floor(parseFloat(campaign.target_amount) * 10_000_000),
+    deadlineUnix,
+    assetContractAddress,
+    platformFeeBps,
+    milestones,
+    signerSecret: process.env.PLATFORM_SECRET_KEY,
+  });
+
+  const { rows: updated } = await db.query(
+    `UPDATE campaigns
+     SET wallet_public_key = $1, escrow_contract_id = $2, milestones_contract_id = $3,
+         contract_address = $2, contract_deployed_at = NOW(), platform_fee_bps = $4,
+         status = 'active', scheduled_publish_at = NULL
+     WHERE id = $5 AND status = 'draft'
+     RETURNING *`,
+    [wallet.publicKey, escrowContractId, milestonesContractId, platformFeeBps, campaignId]
+  );
+
+  if (!updated.length) {
+    logger.error('[campaignPublishing] Campaign status changed during publish. Orphaned wallet:', {
+      publicKey: wallet.publicKey,
+      campaignId,
+    });
+    throw new CampaignNotPublishableError('Campaign is no longer a draft');
+  }
+
+  watchCampaignWallet(updated[0].id, wallet.publicKey);
+
+  return updated[0];
+}
+
+module.exports = {
+  CampaignNotPublishableError,
+  publishDraftCampaign,
+};

--- a/backend/src/services/campaignStatusActions.js
+++ b/backend/src/services/campaignStatusActions.js
@@ -314,6 +314,20 @@ async function queueFailedCampaignRefunds(campaignId, actorUserId) {
               logger.error(`Failed to send refund email to ${users[0].email}:`, { error: emailErr.message });
             });
           }
+
+          const refundPayload = {
+            campaign_id: campaign.id,
+            contribution_id: contribution.id,
+            amount: String(contribution.amount),
+            asset: contribution.asset,
+            timestamp: new Date().toISOString(),
+          };
+          emitWebhookEventForUser(campaign.creator_id, WEBHOOK_EVENTS.CONTRIBUTION_REFUNDED, refundPayload).catch(
+            (err) => logger.error('Contribution refunded webhook emit failed', { error: err.message })
+          );
+          emitWebhookEventForCampaign(campaign.id, WEBHOOK_EVENTS.CONTRIBUTION_REFUNDED, refundPayload).catch(
+            (err) => logger.error('Contribution refunded webhook emit failed', { error: err.message })
+          );
         } catch (err) {
           logger.warn('On-chain refund failed for contribution, falling back to Stellar withdrawal', {
             campaign_id: campaignId,

--- a/backend/src/services/featureFlags.js
+++ b/backend/src/services/featureFlags.js
@@ -79,6 +79,14 @@ const FLAGS = {
     allowedRoles: null,
     allowedUserIds: null,
   },
+  'scheduled-publish-cron': {
+    description: 'Enable the cron that auto-publishes draft campaigns at their scheduled_publish_at time',
+    envVar: 'ENABLE_SCHEDULED_PUBLISH_CRON',
+    defaultValue: true,
+    rolloutPct: null,
+    allowedRoles: null,
+    allowedUserIds: null,
+  },
   'serve-frontend': {
     description: 'Serve the compiled frontend SPA from the backend Express server',
     envVar: 'SERVE_FRONTEND',

--- a/backend/src/services/userDashboard.test.js
+++ b/backend/src/services/userDashboard.test.js
@@ -177,4 +177,51 @@ test('getContributorDashboard returns empty shape when there are no contribution
   const dashboard = await getContributorDashboard('user-1');
   assert.deepEqual(dashboard.campaigns, []);
   assert.equal(dashboard.stats.active_campaigns_backed, 0);
+  assert.equal(dashboard.stats.campaigns_backed, 0);
+  assert.equal(dashboard.stats.avg_contribution, 0);
+  assert.ok(Array.isArray(dashboard.stats.badges));
+  assert.equal(
+    dashboard.stats.badges.find((b) => b.id === 'first_contribution').earned,
+    false
+  );
+});
+
+test('getContributorDashboard computes campaigns_backed, avg_contribution, and badges', async () => {
+  const { db } = buildDashboardDb(5);
+  const { getContributorDashboard } = proxyquire('./userDashboardService', {
+    '../config/database': db,
+  });
+
+  const dashboard = await getContributorDashboard('user-1');
+
+  assert.equal(dashboard.stats.campaigns_backed, 5);
+  assert.equal(dashboard.stats.total_contributed, 50);
+  assert.equal(dashboard.stats.avg_contribution, 10);
+  assert.equal(dashboard.stats.badges.find((b) => b.id === 'first_contribution').earned, true);
+  assert.equal(dashboard.stats.badges.find((b) => b.id === 'backed_5_campaigns').earned, true);
+  assert.equal(dashboard.stats.badges.find((b) => b.id === 'backed_10_campaigns').earned, false);
+  assert.equal(dashboard.stats.badges.find((b) => b.id === 'contributed_1000').earned, false);
+});
+
+test('getContributorDashboardCsv builds a CSV with one row per contribution', async () => {
+  const { db } = buildDashboardDb(2);
+  const { getContributorDashboardCsv } = proxyquire('./userDashboardService', {
+    '../config/database': db,
+  });
+
+  const csv = await getContributorDashboardCsv('user-1');
+  const lines = csv.trim().split('\n');
+  assert.equal(lines[0], 'date,campaign,amount,asset,tx_hash,refund_status');
+  assert.equal(lines.length, 3); // header + 2 contributions
+  assert.match(lines[1], /Campaign 1/);
+  assert.match(lines[1], /hash-0/);
+});
+
+test('getContributorDashboardCsv returns null for an unknown user', async () => {
+  const { getContributorDashboardCsv } = proxyquire('./userDashboardService', {
+    '../config/database': { query: async () => ({ rows: [] }) },
+  });
+
+  const csv = await getContributorDashboardCsv('missing');
+  assert.equal(csv, null);
 });

--- a/backend/src/services/userDashboardService.js
+++ b/backend/src/services/userDashboardService.js
@@ -61,6 +61,43 @@ async function listUserContributions(userId) {
 }
 
 const ACTIVE_CAMPAIGN_STATUSES = new Set(['active', 'funded']);
+const COMPLETED_CAMPAIGN_STATUSES = new Set(['completed', 'funded', 'withdrawn']);
+
+const BADGE_DEFINITIONS = [
+  {
+    id: 'first_contribution',
+    label: 'First contribution',
+    earned: (stats) => stats.campaigns_backed >= 1,
+  },
+  {
+    id: 'backed_5_campaigns',
+    label: 'Backed 5 campaigns',
+    earned: (stats) => stats.campaigns_backed >= 5,
+  },
+  {
+    id: 'backed_10_campaigns',
+    label: 'Backed 10 campaigns',
+    earned: (stats) => stats.campaigns_backed >= 10,
+  },
+  {
+    id: 'contributed_1000',
+    label: 'Contributed 1,000+',
+    earned: (stats) => stats.total_contributed >= 1000,
+  },
+  {
+    id: 'backed_completed_campaign',
+    label: 'Backed a completed campaign',
+    earned: (stats) => stats.campaigns_completed >= 1,
+  },
+];
+
+function computeBadges(stats) {
+  return BADGE_DEFINITIONS.map((def) => ({
+    id: def.id,
+    label: def.label,
+    earned: def.earned(stats),
+  }));
+}
 
 async function getContributorDashboard(userId) {
   const { rows: userRows } = await db.query(
@@ -84,8 +121,16 @@ async function getContributorDashboard(userId) {
   );
 
   if (!contribs.length) {
+    const emptyStats = {
+      total_contributed: 0,
+      active_campaigns_backed: 0,
+      total_refunded: 0,
+      campaigns_backed: 0,
+      campaigns_completed: 0,
+      avg_contribution: 0,
+    };
     return {
-      stats: { total_contributed: 0, active_campaigns_backed: 0, total_refunded: 0 },
+      stats: { ...emptyStats, badges: computeBadges(emptyStats) },
       campaigns: [],
     };
   }
@@ -155,22 +200,67 @@ async function getContributorDashboard(userId) {
     });
   }
 
-  const activeCampaignsBacked = [...campaignsMap.values()].filter((campaign) =>
+  const allCampaigns = [...campaignsMap.values()];
+  const activeCampaignsBacked = allCampaigns.filter((campaign) =>
     ACTIVE_CAMPAIGN_STATUSES.has(campaign.status)
   ).length;
+  const campaignsCompleted = allCampaigns.filter((campaign) =>
+    COMPLETED_CAMPAIGN_STATUSES.has(campaign.status)
+  ).length;
+
+  const stats = {
+    total_contributed: totalContributed,
+    active_campaigns_backed: activeCampaignsBacked,
+    total_refunded: totalRefunded,
+    campaigns_backed: allCampaigns.length,
+    campaigns_completed: campaignsCompleted,
+    avg_contribution: contribs.length ? totalContributed / contribs.length : 0,
+  };
 
   return {
-    stats: {
-      total_contributed: totalContributed,
-      active_campaigns_backed: activeCampaignsBacked,
-      total_refunded: totalRefunded,
-    },
-    campaigns: [...campaignsMap.values()],
+    stats: { ...stats, badges: computeBadges(stats) },
+    campaigns: allCampaigns,
   };
+}
+
+function csvEscape(value) {
+  const str = value == null ? '' : String(value);
+  if (/[",\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+async function getContributorDashboardCsv(userId) {
+  const dashboard = await getContributorDashboard(userId);
+  if (!dashboard) return null;
+
+  const header = ['date', 'campaign', 'amount', 'asset', 'tx_hash', 'refund_status'];
+  const rows = [header.join(',')];
+
+  for (const campaign of dashboard.campaigns) {
+    for (const contribution of campaign.contributions) {
+      rows.push(
+        [
+          new Date(contribution.created_at).toISOString(),
+          campaign.title,
+          contribution.amount,
+          contribution.asset,
+          contribution.tx_hash || '',
+          contribution.refund_status || '',
+        ]
+          .map(csvEscape)
+          .join(',')
+      );
+    }
+  }
+
+  return rows.join('\n');
 }
 
 module.exports = {
   listCreatorCampaigns,
   listUserContributions,
   getContributorDashboard,
+  getContributorDashboardCsv,
 };

--- a/backend/src/services/webhookDispatcher.js
+++ b/backend/src/services/webhookDispatcher.js
@@ -8,8 +8,13 @@ const WEBHOOK_EVENTS = {
   CAMPAIGN_FAILED: 'campaign.failed',
   CONTRIBUTION_RECEIVED: 'contribution.received',
   CONTRIBUTION_INDEXED: 'contribution.indexed', // campaign-level event
+  CONTRIBUTION_REFUNDED: 'contribution.refunded',
   MILESTONE_APPROVED: 'milestone.approved',
+  MILESTONE_REJECTED: 'milestone.rejected',
   WITHDRAWAL_COMPLETED: 'withdrawal.completed',
+  WITHDRAWAL_UPDATED: 'withdrawal.updated',
+  DISPUTE_OPENED: 'dispute.opened',
+  DISPUTE_RESOLVED: 'dispute.resolved',
 };
 
 const ALL_WEBHOOK_EVENTS = Object.values(WEBHOOK_EVENTS);
@@ -21,12 +26,32 @@ function hmacSignature(secret, bodyUtf8) {
   return crypto.createHmac('sha256', secret).update(bodyUtf8, 'utf8').digest('hex');
 }
 
-function backoffMs(attemptNumber) {
+function isValidBackoffStrategy(strategy) {
+  return Boolean(
+    strategy &&
+    typeof strategy === 'object' &&
+    Number.isFinite(strategy.base_ms) &&
+    strategy.base_ms > 0 &&
+    Number.isFinite(strategy.max_ms) &&
+    strategy.max_ms > 0 &&
+    Number.isFinite(strategy.multiplier) &&
+    strategy.multiplier > 0
+  );
+}
+
+function customBackoffMs(attemptNumber, strategy) {
+  const delay = strategy.base_ms * strategy.multiplier ** Math.max(0, attemptNumber - 1);
+  return Math.min(strategy.max_ms, Math.round(delay));
+}
+
+function backoffMs(attemptNumber, strategy) {
+  if (isValidBackoffStrategy(strategy)) return customBackoffMs(attemptNumber, strategy);
   const boundedAttempt = Math.min(Math.max(attemptNumber, 1), WEBHOOK_RETRY_DELAYS_MS.length);
   return WEBHOOK_RETRY_DELAYS_MS[boundedAttempt - 1];
 }
 
-function backoffMsForCampaign(attemptNumber) {
+function backoffMsForCampaign(attemptNumber, strategy) {
+  if (isValidBackoffStrategy(strategy)) return customBackoffMs(attemptNumber, strategy);
   // Campaign webhooks: exponential backoff (5s, 30s, 5min)
   const delays = [5000, 30000, 300000];
   return delays[Math.min(attemptNumber - 1, delays.length - 1)];
@@ -58,7 +83,7 @@ async function emitWebhookEventForUser(ownerUserId, eventType, payload) {
 async function processDelivery(deliveryId) {
   const { rows } = await db.query(
     `SELECT d.id, d.attempt_count, d.status, d.payload, d.event_type,
-            w.url, w.secret, w.revoked_at
+            w.url, w.secret, w.revoked_at, w.backoff_strategy
      FROM webhook_deliveries d
      JOIN webhooks w ON w.id = d.webhook_id
      WHERE d.id = $1`,
@@ -108,7 +133,7 @@ async function processDelivery(deliveryId) {
     });
     responseText = await res.text();
   } catch (err) {
-    await scheduleRetry(deliveryId, nextAttempt, err.message || String(err), null, null);
+    await scheduleRetry(deliveryId, nextAttempt, err.message || String(err), null, null, row.backoff_strategy);
     return;
   }
 
@@ -129,7 +154,8 @@ async function processDelivery(deliveryId) {
     nextAttempt,
     `HTTP ${res.status}`,
     res.status,
-    snippet
+    snippet,
+    row.backoff_strategy
   );
 }
 
@@ -159,7 +185,7 @@ async function notifyCreatorOfFailedDelivery(deliveryId, errMsg) {
   }
 }
 
-async function scheduleRetry(deliveryId, attemptJustUsed, errMsg, httpStatus, snippet) {
+async function scheduleRetry(deliveryId, attemptJustUsed, errMsg, httpStatus, snippet, backoffStrategy) {
   if (attemptJustUsed >= MAX_DELIVERY_ATTEMPTS) {
     await db.query(
       `UPDATE webhook_deliveries
@@ -171,7 +197,7 @@ async function scheduleRetry(deliveryId, attemptJustUsed, errMsg, httpStatus, sn
     return;
   }
 
-  const delay = backoffMs(attemptJustUsed);
+  const delay = backoffMs(attemptJustUsed, backoffStrategy);
   const nextAt = new Date(Date.now() + delay);
   await db.query(
     `UPDATE webhook_deliveries
@@ -227,7 +253,7 @@ async function emitWebhookEventForCampaign(campaignId, eventType, payload) {
 async function processCampaignWebhookDelivery(deliveryId) {
   const { rows } = await db.query(
     `SELECT d.id, d.attempt_count, d.status, d.payload, d.event,
-            w.url, w.secret, w.active
+            w.url, w.secret, w.active, w.backoff_strategy
      FROM campaign_webhook_deliveries d
      JOIN campaign_webhooks w ON w.id = d.webhook_id
      WHERE d.id = $1`,
@@ -275,7 +301,13 @@ async function processCampaignWebhookDelivery(deliveryId) {
       signal: AbortSignal.timeout(9000),
     });
   } catch (err) {
-    await scheduleCampaignWebhookRetry(deliveryId, nextAttempt, err.message || String(err), null);
+    await scheduleCampaignWebhookRetry(
+      deliveryId,
+      nextAttempt,
+      err.message || String(err),
+      null,
+      row.backoff_strategy
+    );
     return;
   }
 
@@ -293,11 +325,12 @@ async function processCampaignWebhookDelivery(deliveryId) {
     deliveryId,
     nextAttempt,
     `HTTP ${res.status}`,
-    res.status
+    res.status,
+    row.backoff_strategy
   );
 }
 
-async function scheduleCampaignWebhookRetry(deliveryId, attemptJustUsed, errMsg, httpStatus) {
+async function scheduleCampaignWebhookRetry(deliveryId, attemptJustUsed, errMsg, httpStatus, backoffStrategy) {
   if (attemptJustUsed >= MAX_CAMPAIGN_DELIVERY_ATTEMPTS) {
     await db.query(
       `UPDATE campaign_webhook_deliveries
@@ -308,7 +341,7 @@ async function scheduleCampaignWebhookRetry(deliveryId, attemptJustUsed, errMsg,
     return;
   }
 
-  const delay = backoffMsForCampaign(attemptJustUsed);
+  const delay = backoffMsForCampaign(attemptJustUsed, backoffStrategy);
   const nextAt = new Date(Date.now() + delay);
   await db.query(
     `UPDATE campaign_webhook_deliveries
@@ -352,6 +385,8 @@ module.exports = {
   MAX_CAMPAIGN_DELIVERY_ATTEMPTS,
   hmacSignature,
   backoffMs,
+  backoffMsForCampaign,
+  isValidBackoffStrategy,
   emitWebhookEventForUser,
   emitWebhookEventForCampaign,
   processDelivery,

--- a/backend/src/services/webhookDispatcher.test.js
+++ b/backend/src/services/webhookDispatcher.test.js
@@ -29,3 +29,53 @@ test('backoffMs uses the requested exponential schedule', () => {
   assert.equal(backoffMs(5), 86_400_000);
   assert.equal(backoffMs(6), 86_400_000);
 });
+
+test('WEBHOOK_EVENTS registers the new #434 event types', () => {
+  const { WEBHOOK_EVENTS, ALL_WEBHOOK_EVENTS } = loadDispatcher();
+  assert.equal(WEBHOOK_EVENTS.CONTRIBUTION_REFUNDED, 'contribution.refunded');
+  assert.equal(WEBHOOK_EVENTS.MILESTONE_REJECTED, 'milestone.rejected');
+  assert.equal(WEBHOOK_EVENTS.WITHDRAWAL_UPDATED, 'withdrawal.updated');
+  assert.equal(WEBHOOK_EVENTS.DISPUTE_OPENED, 'dispute.opened');
+  assert.equal(WEBHOOK_EVENTS.DISPUTE_RESOLVED, 'dispute.resolved');
+  for (const event of Object.values(WEBHOOK_EVENTS)) {
+    assert.ok(ALL_WEBHOOK_EVENTS.includes(event));
+  }
+});
+
+test('isValidBackoffStrategy validates shape', () => {
+  const { isValidBackoffStrategy } = loadDispatcher();
+  assert.equal(isValidBackoffStrategy({ base_ms: 1000, max_ms: 60000, multiplier: 2 }), true);
+  assert.equal(isValidBackoffStrategy(null), false);
+  assert.equal(isValidBackoffStrategy({}), false);
+  assert.equal(isValidBackoffStrategy({ base_ms: -1, max_ms: 60000, multiplier: 2 }), false);
+  assert.equal(isValidBackoffStrategy({ base_ms: 1000, max_ms: 60000, multiplier: 0 }), false);
+});
+
+test('backoffMs uses a custom strategy when provided and valid', () => {
+  const { backoffMs } = loadDispatcher();
+  const strategy = { base_ms: 1000, max_ms: 10000, multiplier: 2 };
+  assert.equal(backoffMs(1, strategy), 1000);
+  assert.equal(backoffMs(2, strategy), 2000);
+  assert.equal(backoffMs(3, strategy), 4000);
+  assert.equal(backoffMs(10, strategy), 10000); // capped at max_ms
+});
+
+test('backoffMs falls back to the default schedule for an invalid strategy', () => {
+  const { backoffMs } = loadDispatcher();
+  assert.equal(backoffMs(1, { base_ms: -5 }), 60_000);
+});
+
+test('backoffMsForCampaign uses a custom strategy when provided and valid', () => {
+  const { backoffMsForCampaign } = loadDispatcher();
+  const strategy = { base_ms: 2000, max_ms: 20000, multiplier: 3 };
+  assert.equal(backoffMsForCampaign(1, strategy), 2000);
+  assert.equal(backoffMsForCampaign(2, strategy), 6000);
+  assert.equal(backoffMsForCampaign(3, strategy), 18000);
+});
+
+test('backoffMsForCampaign falls back to the fixed default schedule without a strategy', () => {
+  const { backoffMsForCampaign } = loadDispatcher();
+  assert.equal(backoffMsForCampaign(1), 5000);
+  assert.equal(backoffMsForCampaign(2), 30000);
+  assert.equal(backoffMsForCampaign(3), 300000);
+});

--- a/frontend/src/components/CampaignComments.jsx
+++ b/frontend/src/components/CampaignComments.jsx
@@ -1,0 +1,338 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { api } from '../services/api';
+import { useAuth } from '../context/AuthContext';
+import { useToast } from '../context/ToastContext';
+
+function timeAgo(dateStr) {
+  return new Date(dateStr).toLocaleString();
+}
+
+function CommentComposer({ placeholder, submitLabel, onSubmit, onCancel, autoFocus }) {
+  const [value, setValue] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (!value.trim()) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      await onSubmit(value.trim());
+      setValue('');
+      onCancel?.();
+    } catch (err) {
+      setError(err.message || 'Could not post comment');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} style={{ marginTop: '0.5rem' }}>
+      <textarea
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+        rows={2}
+        style={{
+          width: '100%',
+          borderRadius: '8px',
+          border: '1px solid var(--color-border-lighter)',
+          padding: '0.5rem 0.65rem',
+          fontFamily: 'inherit',
+          fontSize: '0.88rem',
+          resize: 'vertical',
+        }}
+      />
+      {error && (
+        <p className="alert alert--error" style={{ marginTop: '0.35rem', fontSize: '0.8rem' }}>
+          {error}
+        </p>
+      )}
+      <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.4rem' }}>
+        <button type="submit" className="btn-primary" disabled={submitting || !value.trim()}>
+          {submitting ? 'Posting…' : submitLabel}
+        </button>
+        {onCancel && (
+          <button type="button" onClick={onCancel} disabled={submitting}>
+            Cancel
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}
+
+function CommentItem({ comment, replies, campaignId, isModerator, currentUserId, onChanged }) {
+  const toast = useToast();
+  const [replying, setReplying] = useState(false);
+  const [error, setError] = useState('');
+
+  const isAuthor = currentUserId && String(comment.author_id) === String(currentUserId);
+  const canDelete = isAuthor || isModerator;
+
+  async function reply(body) {
+    await api.postCampaignComment(campaignId, { body, parent_id: comment.id });
+    onChanged();
+  }
+
+  async function remove() {
+    if (!window.confirm('Delete this comment?')) return;
+    try {
+      await api.deleteCampaignComment(campaignId, comment.id);
+      onChanged();
+    } catch (err) {
+      setError(err.message || 'Could not delete comment');
+    }
+  }
+
+  async function flag() {
+    try {
+      await api.flagCampaignComment(campaignId, comment.id, {});
+      toast?.('Comment flagged for review', 'success');
+    } catch (err) {
+      setError(err.message || 'Could not flag comment');
+    }
+  }
+
+  async function hide() {
+    try {
+      await api.hideCampaignComment(campaignId, comment.id, {});
+      onChanged();
+    } catch (err) {
+      setError(err.message || 'Could not hide comment');
+    }
+  }
+
+  async function unhide() {
+    try {
+      await api.unhideCampaignComment(campaignId, comment.id);
+      onChanged();
+    } catch (err) {
+      setError(err.message || 'Could not unhide comment');
+    }
+  }
+
+  return (
+    <div style={{ padding: '0.6rem 0', borderTop: '1px solid var(--color-border-lighter)' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.5rem', flexWrap: 'wrap' }}>
+        <strong style={{ fontSize: '0.85rem' }}>{comment.author_name}</strong>
+        <span style={{ fontSize: '0.75rem', color: 'var(--color-text-hint)' }}>
+          {timeAgo(comment.created_at)}
+        </span>
+      </div>
+
+      {comment.hidden ? (
+        <p style={{ fontSize: '0.82rem', fontStyle: 'italic', color: 'var(--color-text-hint)', margin: '0.3rem 0' }}>
+          Hidden by moderator{comment.hidden_reason ? `: ${comment.hidden_reason}` : ''}
+          {isModerator && ' (visible to you only)'}
+        </p>
+      ) : (
+        <p style={{ fontSize: '0.88rem', margin: '0.3rem 0', whiteSpace: 'pre-wrap' }}>{comment.body}</p>
+      )}
+
+      {error && (
+        <p className="alert alert--error" style={{ fontSize: '0.78rem', marginBottom: '0.3rem' }}>
+          {error}
+        </p>
+      )}
+
+      <div style={{ display: 'flex', gap: '0.6rem', fontSize: '0.78rem' }}>
+        {currentUserId && (
+          <button
+            type="button"
+            onClick={() => setReplying((r) => !r)}
+            style={{ color: 'var(--color-accent)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+          >
+            Reply
+          </button>
+        )}
+        {currentUserId && !isAuthor && (
+          <button
+            type="button"
+            onClick={flag}
+            style={{ color: 'var(--color-text-hint)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+          >
+            Flag
+          </button>
+        )}
+        {canDelete && (
+          <button
+            type="button"
+            onClick={remove}
+            style={{ color: 'var(--color-error-text)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+          >
+            Delete
+          </button>
+        )}
+        {isModerator &&
+          (comment.hidden ? (
+            <button
+              type="button"
+              onClick={unhide}
+              style={{ color: 'var(--color-text-hint)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+            >
+              Unhide
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={hide}
+              style={{ color: 'var(--color-text-hint)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+            >
+              Hide
+            </button>
+          ))}
+      </div>
+
+      {replying && (
+        <CommentComposer
+          placeholder="Write a reply…"
+          submitLabel="Reply"
+          autoFocus
+          onSubmit={reply}
+          onCancel={() => setReplying(false)}
+        />
+      )}
+
+      {replies.length > 0 && (
+        <div style={{ marginLeft: '1.25rem', marginTop: '0.4rem' }}>
+          {replies.map((reply) => (
+            <CommentItem
+              key={reply.id}
+              comment={reply}
+              replies={[]}
+              campaignId={campaignId}
+              isModerator={isModerator}
+              currentUserId={currentUserId}
+              onChanged={onChanged}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function CampaignComments({ campaignId, campaign }) {
+  const { user } = useAuth();
+  const [comments, setComments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [showModeration, setShowModeration] = useState(false);
+  const [flagged, setFlagged] = useState([]);
+
+  const currentUserId = user?.id || user?.userId;
+  const isModerator =
+    !!currentUserId && (String(campaign?.creator_id) === String(currentUserId) || user?.role === 'admin');
+
+  function load() {
+    setLoading(true);
+    setError('');
+    api
+      .getCampaignComments(campaignId)
+      .then(setComments)
+      .catch((err) => setError(err.message || 'Could not load comments'))
+      .finally(() => setLoading(false));
+  }
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [campaignId]);
+
+  useEffect(() => {
+    if (!showModeration) return;
+    api
+      .getFlaggedCampaignComments(campaignId)
+      .then(setFlagged)
+      .catch(() => setFlagged([]));
+  }, [showModeration, campaignId]);
+
+  const { topLevel, repliesByParent } = useMemo(() => {
+    const top = [];
+    const byParent = {};
+    for (const comment of comments) {
+      if (comment.parent_id) {
+        byParent[comment.parent_id] = byParent[comment.parent_id] || [];
+        byParent[comment.parent_id].push(comment);
+      } else {
+        top.push(comment);
+      }
+    }
+    return { topLevel: top, repliesByParent: byParent };
+  }, [comments]);
+
+  async function postTopLevel(body) {
+    await api.postCampaignComment(campaignId, { body });
+    load();
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '0.5rem' }}>
+        <h3 style={{ margin: 0, fontSize: '1rem' }}>Comments ({comments.filter((c) => !c.hidden).length})</h3>
+        {isModerator && (
+          <button type="button" onClick={() => setShowModeration((v) => !v)} style={{ fontSize: '0.8rem' }}>
+            {showModeration ? 'Hide moderation queue' : `Moderation queue`}
+          </button>
+        )}
+      </div>
+
+      {showModeration && (
+        <div
+          style={{
+            marginTop: '0.6rem',
+            padding: '0.6rem',
+            borderRadius: '8px',
+            background: 'var(--color-warning-bg, #fffbeb)',
+            border: '1px solid var(--color-warning-border, #fde68a)',
+          }}
+        >
+          <strong style={{ fontSize: '0.82rem' }}>Flagged / hidden comments</strong>
+          {flagged.length === 0 ? (
+            <p style={{ fontSize: '0.8rem', margin: '0.3rem 0 0' }}>Nothing needs review.</p>
+          ) : (
+            flagged.map((c) => (
+              <div key={c.id} style={{ fontSize: '0.8rem', marginTop: '0.4rem' }}>
+                <strong>{c.author_name}</strong> ({c.flag_count} flag{c.flag_count !== 1 ? 's' : ''}
+                {c.hidden ? ', hidden' : ''}): {c.body}
+              </div>
+            ))
+          )}
+        </div>
+      )}
+
+      {currentUserId && (
+        <CommentComposer placeholder="Ask a question or leave a comment…" submitLabel="Post comment" onSubmit={postTopLevel} />
+      )}
+
+      {loading && <p style={{ color: 'var(--color-text-hint)', fontSize: '0.85rem' }}>Loading comments…</p>}
+      {error && (
+        <p className="alert alert--error" style={{ fontSize: '0.82rem' }}>
+          {error}
+        </p>
+      )}
+
+      {!loading && topLevel.length === 0 && (
+        <p style={{ color: 'var(--color-text-hint)', fontSize: '0.85rem' }}>No comments yet.</p>
+      )}
+
+      <div>
+        {topLevel.map((comment) => (
+          <CommentItem
+            key={comment.id}
+            comment={comment}
+            replies={repliesByParent[comment.id] || []}
+            campaignId={campaignId}
+            isModerator={isModerator}
+            currentUserId={currentUserId}
+            onChanged={load}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/CampaignStatusBadge.jsx
+++ b/frontend/src/components/CampaignStatusBadge.jsx
@@ -21,6 +21,11 @@ const LABELS = {
     bg: 'var(--color-surface)',
     color: 'var(--color-text-secondary)',
   },
+  draft: {
+    key: 'campaignStatus.draft',
+    bg: 'var(--color-warning-bg, #fffbeb)',
+    color: 'var(--color-warning-text, #92400e)',
+  },
 };
 
 export default function CampaignStatusBadge({ status }) {

--- a/frontend/src/components/ContributorDashboard.jsx
+++ b/frontend/src/components/ContributorDashboard.jsx
@@ -234,10 +234,74 @@ function BackedCampaignCard({ campaign, onRefundClaimed }) {
   );
 }
 
+function FavoritesSection() {
+  const [favorites, setFavorites] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api
+      .getFavorites()
+      .then(setFavorites)
+      .catch(() => setFavorites([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading || favorites.length === 0) return null;
+
+  return (
+    <div style={{ marginBottom: '1.25rem' }}>
+      <div style={{ fontSize: '0.9rem', fontWeight: 700, marginBottom: '0.5rem' }}>
+        Favorites ({favorites.length})
+      </div>
+      <div style={{ display: 'grid', gap: '0.5rem', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
+        {favorites.map((campaign) => (
+          <Link
+            key={campaign.id}
+            to={`/campaigns/${campaign.id}`}
+            className="campaign-card"
+            style={{ minHeight: 'auto', padding: '0.6rem 0.75rem', color: 'inherit' }}
+          >
+            <div style={{ fontWeight: 600, fontSize: '0.85rem' }}>{campaign.title}</div>
+            <CampaignStatusBadge status={campaign.status} />
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function BadgesRow({ badges }) {
+  if (!badges?.length) return null;
+  return (
+    <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1.25rem' }}>
+      {badges.map((badge) => (
+        <span
+          key={badge.id}
+          title={badge.label}
+          style={{
+            fontSize: '0.78rem',
+            fontWeight: 600,
+            padding: '0.3rem 0.65rem',
+            borderRadius: '99px',
+            border: '1px solid var(--color-border-lighter)',
+            color: badge.earned ? 'var(--color-accent)' : 'var(--color-text-hint)',
+            background: badge.earned ? 'var(--color-accent-bg, rgba(99,102,241,0.1))' : 'transparent',
+            opacity: badge.earned ? 1 : 0.5,
+          }}
+        >
+          {badge.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
 export default function ContributorDashboard() {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [exporting, setExporting] = useState(false);
+  const toast = useToast();
 
   function load() {
     setLoading(true);
@@ -247,6 +311,25 @@ export default function ContributorDashboard() {
       .then(setData)
       .catch((err) => setError(err.message || 'Could not load contributions'))
       .finally(() => setLoading(false));
+  }
+
+  async function exportCsv() {
+    setExporting(true);
+    try {
+      const { blob, filename } = await api.exportContributionsCsv();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toast?.(err.message || 'Could not export contributions', 'error');
+    } finally {
+      setExporting(false);
+    }
   }
 
   useEffect(() => {
@@ -263,13 +346,16 @@ export default function ContributorDashboard() {
 
   if (!data?.campaigns?.length) {
     return (
-      <p className="alert alert--info">
-        You have not backed any campaigns yet.{' '}
-        <Link to="/discover" style={{ color: 'var(--color-accent)', fontWeight: 600 }}>
-          Browse campaigns
-        </Link>
-        .
-      </p>
+      <div>
+        <FavoritesSection />
+        <p className="alert alert--info">
+          You have not backed any campaigns yet.{' '}
+          <Link to="/discover" style={{ color: 'var(--color-accent)', fontWeight: 600 }}>
+            Browse campaigns
+          </Link>
+          .
+        </p>
+      </div>
     );
   }
 
@@ -277,6 +363,22 @@ export default function ContributorDashboard() {
 
   return (
     <div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          gap: '0.5rem',
+          marginBottom: '0.75rem',
+        }}
+      >
+        <div style={{ fontSize: '0.85rem', color: 'var(--color-text-hint)' }}>Your portfolio</div>
+        <button type="button" onClick={exportCsv} disabled={exporting} style={{ fontSize: '0.8rem' }}>
+          {exporting ? 'Exporting…' : 'Export CSV'}
+        </button>
+      </div>
+
       <div
         style={{
           display: 'grid',
@@ -287,7 +389,10 @@ export default function ContributorDashboard() {
       >
         {[
           ['Total contributed', stats.total_contributed.toLocaleString()],
+          ['Campaigns backed', stats.campaigns_backed],
           ['Active campaigns', stats.active_campaigns_backed],
+          ['Campaigns completed', stats.campaigns_completed],
+          ['Avg. contribution', stats.avg_contribution.toLocaleString(undefined, { maximumFractionDigits: 2 })],
           ['Total refunded', stats.total_refunded.toLocaleString()],
         ].map(([label, value]) => (
           <div key={label} className="campaign-card" style={{ minHeight: 'auto', padding: '0.75rem' }}>
@@ -298,6 +403,9 @@ export default function ContributorDashboard() {
           </div>
         ))}
       </div>
+
+      <BadgesRow badges={stats.badges} />
+      <FavoritesSection />
 
       <div style={{ display: 'grid', gap: '0.85rem' }}>
         {campaigns.map((campaign) => (

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -429,7 +429,8 @@
   "campaignStatus": {
     "goalReached": "Goal reached",
     "campaignEnded": "Campaign ended",
-    "campaignClosed": "Campaign closed"
+    "campaignClosed": "Campaign closed",
+    "draft": "Draft"
   },
   "dashboard": {
     "title": "Dashboard",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -429,7 +429,8 @@
   "campaignStatus": {
     "goalReached": "Objectif atteint",
     "campaignEnded": "Campagne terminée",
-    "campaignClosed": "Campagne fermée"
+    "campaignClosed": "Campagne fermée",
+    "draft": "Brouillon"
   },
   "dashboard": {
     "title": "Tableau de bord",

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -18,6 +18,7 @@ import CampaignQRCode from '../components/CampaignQRCode';
 import { getNetwork, signTransaction } from '@stellar/freighter-api';
 import { isConnected, getPublicKey } from '@stellar/freighter-api';
 import BackerInsightsCard from '../components/BackerInsightsCard';
+import CampaignComments from '../components/CampaignComments';
 import { addRecentlyViewed } from '../lib/recentlyViewed';
 
 
@@ -51,6 +52,158 @@ function progressColor(pct, status) {
     return '#6b7280'; // grey — ended
   if (pct >= 75) return '#3b82f6'; // blue — nearly there
   return '#7c3aed'; // default purple
+}
+
+function FavoriteToggle({ campaignId }) {
+  const [favorited, setFavorited] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  async function toggle() {
+    setBusy(true);
+    try {
+      if (favorited) {
+        await api.removeFavorite(campaignId);
+        setFavorited(false);
+      } else {
+        await api.addFavorite(campaignId);
+        setFavorited(true);
+      }
+    } catch {
+      // no-op — leave state unchanged on failure
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      disabled={busy}
+      title={favorited ? 'Remove from favorites' : 'Add to favorites'}
+      style={{
+        background: 'none',
+        border: '1px solid var(--color-border-lighter)',
+        borderRadius: '999px',
+        fontSize: '0.85rem',
+        padding: '0.2rem 0.6rem',
+        cursor: 'pointer',
+        color: favorited ? 'var(--color-accent)' : 'var(--color-text-hint)',
+      }}
+    >
+      {favorited ? '★ Favorited' : '☆ Favorite'}
+    </button>
+  );
+}
+
+function CampaignPublishControls({ campaign, isOwner, navigate }) {
+  const [cloning, setCloning] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [scheduling, setScheduling] = useState(false);
+  const [scheduledAt, setScheduledAt] = useState('');
+  const [error, setError] = useState('');
+
+  if (!isOwner) return null;
+
+  async function clone() {
+    setCloning(true);
+    setError('');
+    try {
+      const newCampaign = await api.cloneCampaign(campaign.id);
+      navigate(`/campaigns/${newCampaign.id}`);
+    } catch (err) {
+      setError(err.message || 'Could not clone campaign');
+      setCloning(false);
+    }
+  }
+
+  async function publishNow() {
+    setPublishing(true);
+    setError('');
+    try {
+      await api.publishCampaign(campaign.id);
+      window.location.reload();
+    } catch (err) {
+      setError(err.message || 'Could not publish campaign');
+      setPublishing(false);
+    }
+  }
+
+  async function schedulePublish(e) {
+    e.preventDefault();
+    setScheduling(true);
+    setError('');
+    try {
+      await api.scheduleCampaignPublish(campaign.id, { scheduled_publish_at: scheduledAt || null });
+      window.location.reload();
+    } catch (err) {
+      setError(err.message || 'Could not schedule publishing');
+      setScheduling(false);
+    }
+  }
+
+  return (
+    <div data-no-print style={{ marginBottom: '1.25rem' }}>
+      {campaign.status === 'draft' && (
+        <div
+          className="campaign-card"
+          style={{
+            minHeight: 'auto',
+            padding: '0.85rem',
+            marginBottom: '0.75rem',
+            display: 'grid',
+            gap: '0.6rem',
+          }}
+        >
+          <strong style={{ fontSize: '0.9rem' }}>This campaign is a draft</strong>
+          <p style={{ fontSize: '0.82rem', color: 'var(--color-text-hint)', margin: 0 }}>
+            No wallet or on-chain contracts exist yet. Publish now, or schedule an automatic
+            publish time.
+          </p>
+          {campaign.scheduled_publish_at && (
+            <p style={{ fontSize: '0.82rem', margin: 0 }}>
+              Scheduled to auto-publish at {new Date(campaign.scheduled_publish_at).toLocaleString()}
+            </p>
+          )}
+          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+            <button type="button" className="btn-primary" onClick={publishNow} disabled={publishing}>
+              {publishing ? 'Publishing…' : 'Publish now'}
+            </button>
+          </div>
+          <form onSubmit={schedulePublish} style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'center' }}>
+            <input
+              type="datetime-local"
+              value={scheduledAt}
+              onChange={(e) => setScheduledAt(e.target.value)}
+              style={{ fontSize: '0.85rem' }}
+            />
+            <button type="submit" className="btn-secondary" disabled={scheduling} style={{ fontSize: '0.85rem' }}>
+              {scheduling ? 'Saving…' : 'Schedule publish'}
+            </button>
+          </form>
+          {error && (
+            <p className="alert alert--error" style={{ fontSize: '0.8rem', margin: 0 }}>
+              {error}
+            </p>
+          )}
+        </div>
+      )}
+      <button
+        type="button"
+        className="btn-secondary"
+        style={{ fontSize: '0.85rem' }}
+        onClick={clone}
+        disabled={cloning}
+      >
+        {cloning ? 'Cloning…' : 'Clone campaign'}
+      </button>
+      {campaign.status !== 'draft' && error && (
+        <p className="alert alert--error" style={{ fontSize: '0.8rem', marginTop: '0.5rem' }}>
+          {error}
+        </p>
+      )}
+    </div>
+  );
 }
 
 function ContributionRow({ c }) {
@@ -955,6 +1108,7 @@ export default function Campaign() {
           <span style={styles.asset}>{campaign.asset_type}</span>
           <CampaignStatusBadge status={campaign.status} />
           <VerificationBadge status={campaign.creator_kyc_status} />
+          {user && <FavoriteToggle campaignId={campaign.id} />}
           {campaign.contract_address && (
             <span
               title="This campaign is backed by a Soroban smart contract"
@@ -1249,6 +1403,10 @@ export default function Campaign() {
           </button>
         </div>
       </div>
+
+      {user && campaign && isOwner && (
+        <CampaignPublishControls campaign={campaign} isOwner={isOwner} navigate={navigate} />
+      )}
 
       {/* Edit campaign — owner or editor */}
       {user && campaign && canEditCampaign && (
@@ -1987,6 +2145,10 @@ export default function Campaign() {
           />
         </article>
       ))}
+
+      <div style={{ marginTop: '2rem', marginBottom: '2rem' }} data-no-print>
+        <CampaignComments campaignId={campaign.id} campaign={campaign} />
+      </div>
 
       {/* Analytics Section */}
       {canViewAnalytics && (canManageTeam ? activeTab === 'analytics' : true) && (

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -342,6 +342,9 @@ export const api = {
   getCampaignBackers: (id) => request('GET', `/campaigns/${id}/backers`),
   getCampaignBalance: (id) => request('GET', `/campaigns/${id}/balance`),
   getCloneData: (id) => request('GET', `/campaigns/${id}/clone-data`),
+  cloneCampaign: (id) => request('POST', `/campaigns/${id}/clone`, {}),
+  publishCampaign: (id) => request('POST', `/campaigns/${id}/publish`, {}),
+  scheduleCampaignPublish: (id, body) => request('POST', `/campaigns/${id}/schedule-publish`, body),
   checkDuplicateCampaign: (body) => request('POST', '/campaigns/check-duplicate', body),
   createCampaign: (body) => request('POST', '/campaigns', body),
   updateCampaign: (id, body) => request('PATCH', `/campaigns/${id}`, body),
@@ -383,6 +386,22 @@ export const api = {
   deleteCampaignUpdate: (campaignId, updateId) =>
     request('DELETE', `/campaigns/${campaignId}/updates/${updateId}`),
 
+  getCampaignComments: (campaignId) => request('GET', `/campaigns/${campaignId}/comments`),
+  postCampaignComment: (campaignId, body) =>
+    request('POST', `/campaigns/${campaignId}/comments`, body),
+  updateCampaignComment: (campaignId, commentId, body) =>
+    request('PATCH', `/campaigns/${campaignId}/comments/${commentId}`, body),
+  deleteCampaignComment: (campaignId, commentId) =>
+    request('DELETE', `/campaigns/${campaignId}/comments/${commentId}`),
+  flagCampaignComment: (campaignId, commentId, body) =>
+    request('POST', `/campaigns/${campaignId}/comments/${commentId}/flag`, body),
+  getFlaggedCampaignComments: (campaignId) =>
+    request('GET', `/campaigns/${campaignId}/comments/moderation`),
+  hideCampaignComment: (campaignId, commentId, body) =>
+    request('POST', `/campaigns/${campaignId}/comments/${commentId}/hide`, body),
+  unhideCampaignComment: (campaignId, commentId) =>
+    request('POST', `/campaigns/${campaignId}/comments/${commentId}/unhide`),
+
   getContributions: (campaignId, options = {}) =>
     request('GET', `/contributions/campaign/${campaignId}`, null, {
       query: options,
@@ -421,6 +440,14 @@ export const api = {
   approveRefundPlatform: (id) => request('POST', `/campaigns/${id}/refund/approve/platform`, {}),
   requestContributionRefund: (contributionId) =>
     request('POST', `/contributions/${contributionId}/refund`, {}),
+
+  getContributorDashboard: () => request('GET', '/contributions/dashboard'),
+  exportContributionsCsv: () =>
+    downloadFile('/contributions/dashboard/export.csv', 'contributions.csv'),
+
+  getFavorites: () => request('GET', '/users/me/favorites'),
+  addFavorite: (campaignId) => request('POST', `/campaigns/${campaignId}/favorite`, {}),
+  removeFavorite: (campaignId) => request('DELETE', `/campaigns/${campaignId}/favorite`),
 
   getWithdrawalCapabilities: () => request('GET', '/withdrawals/capabilities'),
   listWithdrawals: (campaignId) => request('GET', `/withdrawals/campaign/${campaignId}`),


### PR DESCRIPTION
## Summary

Implements focused-core versions of four related feature requests, each shipped as one coherent, end-to-end vertical slice (backend + migration + frontend), with the heaviest sub-systems from the original issue wishlists explicitly deferred rather than half-built (noted per-section below).

### Campaign comments (#437)
- Threaded campaign comments (`campaign_comments`, self-referential `parent_id`) with flag/hide/delete moderation (`campaign_comment_flags`, creator/admin moderation queue)
- New `backend/src/routes/campaignComments.js`, embedded via `CampaignComments.jsx` on the campaign detail page
- Deferred: direct messaging inbox, team chat — separate large subsystems

### Contributor dashboard (#433)
- Extended the existing portfolio stats (`campaigns_backed`, `campaigns_completed`, `avg_contribution`) and added a computed badge system
- New `contributor_favorites` table + favorite/unfavorite endpoints + favorites list
- CSV export of contributions (`GET /api/contributions/dashboard/export.csv`)
- Deferred: PDF tax receipts (needs a new PDF dependency + legally-formatted templates)

### Webhook system (#434)
- New event types: `contribution.refunded`, `milestone.rejected`, `withdrawal.updated`, `dispute.opened`, `dispute.resolved`, wired to real existing trigger points
- Optional per-webhook configurable backoff (`backoff_strategy: {base_ms, max_ms, multiplier}`), falls back to existing schedule when unset
- New `GET /api/admin/webhooks/metrics` (success rate, avg latency, failures per event type)
- Deferred: `campaign.paused`/`campaign.resumed` (no "paused" campaign status exists in the app), sandbox/test mode, signature-verification SDK docs

### Campaign cloning (#432)
- `POST /:id/clone` — instant clone into a new `draft`-status campaign (fields, milestones, reward tiers copied; no on-chain wallet/contracts deployed yet, so no gas cost)
- `POST /:id/publish` — deploys the wallet + Soroban contracts and activates a draft
- `POST /:id/schedule-publish` + a 5-minute cron to auto-publish drafts at a scheduled time
- Deferred: community template library

## Test plan
- [x] All 4 new migrations apply cleanly on a fresh Postgres 16 instance built purely from `db/migrate.js`
- [x] Full existing backend test suite run before/after: identical pass/fail counts (215 pass / 75 fail — the 75 are pre-existing failures unrelated to this change, confirmed by running the same suite against unmodified `main`)
- [x] Added new unit tests for webhook event registry / configurable backoff (`webhookDispatcher.test.js`) and dashboard stats/badges/CSV export (`userDashboard.test.js`)
- [x] Live end-to-end smoke test against a real running server + seeded DB: posted/replied/flagged/hid a comment, added a favorite, fetched the extended dashboard and CSV export, cloned → published → scheduled a campaign, triggered a milestone rejection and a dispute and confirmed webhook deliveries + admin metrics reflect them (including verifying custom backoff timing matches the configured strategy)

Closes #437
Closes #433
Closes #434
Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)