### PR TITLE
fix(security): enforce JWT secret entropy and validate env config

### DIFF
--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -12,6 +12,8 @@ const STORAGE_VARS = ['STORAGE_BUCKET', 'STORAGE_ENDPOINT'];
 
 function validateEnv() {
   const missing = REQUIRED.filter((key) => !process.env[key]);
+  const errors = [];
+
   if (missing.length) {
     const list = missing.map((k) => `  - ${k}`).join('\n');
     process.stderr.write(
@@ -27,12 +29,50 @@ function validateEnv() {
     process.exit(1);
   }
 
+  if (process.env.JWT_SECRET.length < 32) {
+    errors.push(
+      'JWT_SECRET must be at least 32 characters (generate with: node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'hex\'))")'
+    );
+  }
+
+  const network = process.env.STELLAR_NETWORK;
+  if (network !== 'testnet' && network !== 'mainnet') {
+    errors.push(
+      `STELLAR_NETWORK must be one of: testnet, mainnet (received: ${JSON.stringify(network)})`
+    );
+  }
+
+  const platformKey = process.env.PLATFORM_SECRET_KEY;
+  if (!/^S[A-Z2-7]{55}$/.test(platformKey)) {
+    errors.push(
+      'PLATFORM_SECRET_KEY must be a valid Stellar secret seed (56 characters, starting with S)'
+    );
+  }
+
+  const portRaw = process.env.PORT;
+  if (portRaw && portRaw.length > 0) {
+    const portNum = Number(portRaw);
+    if (!Number.isInteger(portNum) || portNum < 1 || portNum > 65535) {
+      errors.push(
+        `PORT must be an integer between 1 and 65535 (received: ${JSON.stringify(portRaw)})`
+      );
+    }
+  }
+
   const storageConfigured = STORAGE_VARS.some((key) => !!process.env[key]);
   const storageMissing = STORAGE_VARS.filter((key) => !process.env[key]);
   if (storageConfigured && storageMissing.length) {
     const list = storageMissing.map((k) => `  - ${k}`).join('\n');
     process.stderr.write(
       `\n[crowdpay] Cannot start: incomplete storage configuration. Set all of:\n${STORAGE_VARS.join(', ')}\n\nMissing:\n${list}\n\n`
+    );
+    process.exit(1);
+  }
+
+  if (errors.length) {
+    const list = errors.map((e) => `  - ${e}`).join('\n');
+    process.stderr.write(
+      `\n[crowdpay] Cannot start: invalid environment configuration:\n${list}\n\n`
     );
     process.exit(1);
   }


### PR DESCRIPTION
Hard-fail startup when:
- JWT_SECRET is shorter than 32 characters
- STELLAR_NETWORK is not testnet or mainnet
- PLATFORM_SECRET_KEY is not a valid Stellar secret seed
- PORT, when set, is not a numeric value in [1,65535]

Errors are collected and reported together so misconfigurations are fixable in a single boot cycle.