### PR TITLE
fix: add frontend/.dockerignore to prevent secrets leaking into image layers

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.env
+.env.*
+!.env.example
+dist
+.git
+.github


### PR DESCRIPTION
Closes #496

---

## Problem
`frontend/.dockerignore` does not exist. The `COPY . .` in `frontend/Dockerfile.prod` copies `node_modules/`, `.env`, `.env.local`, and other sensitive files into the builder stage.

## Impact
- Secrets leak into image layers (visible via `docker history` and `docker inspect`)
- Cache misses from large irrelevant file changes
- Larger image sizes

## Solution
Added `frontend/.dockerignore` excluding:
- `node_modules`
- `.env` / `.env.*` (except `.env.example`)
- `dist`
- `.git`
- `.github`