### PR TITLE
fix: add Sentry release tracking to backend and frontend (#502)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,4 +89,7 @@ jobs:
 
       - name: Run build
         working-directory: ./frontend
+        env:
+          SENTRY_RELEASE: ${{ github.sha }}
+          VITE_SENTRY_RELEASE: ${{ github.sha }}
         run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
-          envs: DATABASE_URL,JWT_SECRET,API_KEY_PEPPER,PLATFORM_SECRET_KEY,USDC_ISSUER,STELLAR_NETWORK,STELLAR_HORIZON_URL,FRONTEND_URL,DEPLOY_PATH
+          envs: DATABASE_URL,JWT_SECRET,API_KEY_PEPPER,PLATFORM_SECRET_KEY,USDC_ISSUER,STELLAR_NETWORK,STELLAR_HORIZON_URL,FRONTEND_URL,DEPLOY_PATH,SENTRY_RELEASE
           env:
             DATABASE_URL: ${{ secrets.DATABASE_URL }}
             JWT_SECRET: ${{ secrets.JWT_SECRET }}
@@ -33,6 +33,7 @@ jobs:
             STELLAR_HORIZON_URL: ${{ secrets.STELLAR_HORIZON_URL }}
             FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
             DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+            SENTRY_RELEASE: ${{ github.sha }}
           script: |
             set -euo pipefail
             cd "$DEPLOY_PATH"
@@ -48,7 +49,10 @@ jobs:
             "STELLAR_NETWORK=${STELLAR_NETWORK}" \
             "STELLAR_HORIZON_URL=${STELLAR_HORIZON_URL}" \
             "FRONTEND_URL=${FRONTEND_URL}" \
+            "SENTRY_RELEASE=${SENTRY_RELEASE}" \
             > backend/.env
+
+            export SENTRY_RELEASE="${SENTRY_RELEASE}"
 
             docker compose -f docker-compose.prod.yml up -d --build
             docker compose -f docker-compose.prod.yml exec -T backend node db/migrate.js

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -5,6 +5,7 @@ const Sentry = require("@sentry/node");
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   environment: process.env.NODE_ENV || "development",
+  release: process.env.SENTRY_RELEASE || "unknown",
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.2 : 1.0,
   enabled: !!process.env.SENTRY_DSN,
   integrations: [Sentry.expressIntegration()],

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,6 +11,8 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile.prod
+      args:
+        - SENTRY_RELEASE=${SENTRY_RELEASE:-unknown}
     ports:
       - "8080:8080"
     depends_on: [backend]

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,6 +1,11 @@
 # ── Stage 1: build ──────────────────────────────────────────────────────────
 FROM node:20-alpine AS builder
 WORKDIR /app
+
+ARG SENTRY_RELEASE
+ENV SENTRY_RELEASE=${SENTRY_RELEASE}
+ENV VITE_SENTRY_RELEASE=${SENTRY_RELEASE}
+
 COPY package*.json ./
 RUN npm ci
 COPY . .

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -9,6 +9,7 @@ import './index.css';
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
   environment: import.meta.env.MODE,
+  release: import.meta.env.VITE_SENTRY_RELEASE || 'unknown',
   tracesSampleRate: 0.1,
   enabled: !!import.meta.env.VITE_SENTRY_DSN,
   integrations: [Sentry.browserTracingIntegration()],

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig(({ mode }) => ({
             org: process.env.SENTRY_ORG,
             project: process.env.SENTRY_PROJECT,
             authToken: process.env.SENTRY_AUTH_TOKEN,
+            release: process.env.SENTRY_RELEASE || process.env.VITE_SENTRY_RELEASE || 'unknown',
             telemetry: false,
           }),
         ]


### PR DESCRIPTION
### Problem

Neither the backend nor frontend Sentry initialization included a \`release\` parameter. This caused three concrete issues:

- **Errors across deployments could not be correlated to specific code versions** — when a Sentry issue appeared in production, there was no way to determine which commit introduced it.
- **Sentry could not auto-resolve issues when a fix was deployed** — Sentry's \"Resolved in next release\" feature relies on the \`release\` field to know when a new version has shipped.
- **No deployment tracking in Sentry** — the releases dashboard remained empty, preventing visibility into deployment frequency and error trends per version.

### Solution

Added \`Sentry.init({ release })\` to both SDK initializations and wired \`\${{ github.sha }}\` through the entire build and deploy pipeline so that every production deployment is tagged with its exact commit SHA.

#### Files changed (7 files, +18 −1)

| File | Change |
|------|--------|
| \`backend/src/index.js\` | Added \`release: process.env.SENTRY_RELEASE \\|\\| 'unknown'\` to \`Sentry.init()\` |
| \`frontend/src/main.jsx\` | Added \`release: import.meta.env.VITE_SENTRY_RELEASE \\|\\| 'unknown'\` to \`Sentry.init()\` |
| \`frontend/vite.config.js\` | Added \`release\` to \`sentryVitePlugin\` config for source map uploads |
| \`frontend/Dockerfile.prod\` | Added \`ARG SENTRY_RELEASE\` and \`ENV\` for both \`SENTRY_RELEASE\` and \`VITE_SENTRY_RELEASE\` |
| \`docker-compose.prod.yml\` | Added \`SENTRY_RELEASE\` build arg for the frontend service |
| \`.github/workflows/deploy.yml\` | Wires \`github.sha\` → SSH env → \`.env\` file → shell export → docker compose |
| \`.github/workflows/ci.yml\` | Sets \`SENTRY_RELEASE\` + \`VITE_SENTRY_RELEASE\` during the frontend build step |

#### How it flows end-to-end

**Deploy workflow (production):**

\`\`\`
github.sha
  │
  ├─► SSH action env (\$SENTRY_RELEASE)
  │     │
  │     ├─► backend/.env  →  process.env.SENTRY_RELEASE  →  Sentry.init({ release })
  │     │
  │     └─► export SENTRY_RELEASE
  │           │
  │           └─► docker compose ──build-arg──► Dockerfile.prod
  │                   │
  │                   ├─► ENV VITE_SENTRY_RELEASE  →  import.meta.env  →  Sentry.init({ release })
  │                   │
  │                   └─► ENV SENTRY_RELEASE  →  sentryVitePlugin({ release })  →  source map upload
\`\`\`

#### Design decisions

- **Fallback to \`'unknown'\`**: Both SDK inits and the Vite plugin gracefully degrade to \`'unknown'\` when \`SENTRY_RELEASE\` is absent (local dev, forks, environments without the env var set).
- **\`github.sha\` over semver**: Using the full commit SHA provides unambiguous, globally unique release identifiers. Every Sentry event is traceable to exactly one commit.
- **Dual env vars in Dockerfile**: The frontend Dockerfile sets both \`SENTRY_RELEASE\` (consumed by the Vite plugin during build) and \`VITE_SENTRY_RELEASE\` (exposed via \`import.meta.env\` to the runtime SDK). Vite only exposes \`VITE_\`-prefixed vars to client code.
- **CI build receives the SHA but doesn't upload**: The \`sentryVitePlugin\` requires \`SENTRY_AUTH_TOKEN\` to upload source maps, which is intentionally absent in CI (PR builds). The CI step still sets \`SENTRY_RELEASE\` so the build embeds the correct value for smoke-testing the build process.
- **Export before docker compose**: In the deploy script, \`export SENTRY_RELEASE\` is placed before the \`docker compose up -d --build\` command so that docker compose's variable substitution (\`\${SENTRY_RELEASE:-unknown}\`) resolves correctly.

### Testing

- [x] Backend lint passes (no new errors introduced)
- [x] Frontend lint passes (no new errors introduced)
- [x] All pre-existing tests continue to pass (no runtime behavior changes — only a new property on \`Sentry.init\`)
- [x] Code reviewed for correctness of the env var plumbing through Docker → docker-compose → deploy script

Closes #502