### PR TITLE
perf: add pagination to admin and public endpoints

### DIFF
--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -16,6 +16,7 @@ const {
   processCampaignWebhookDelivery,
 } = require('../services/webhookDispatcher');
 const cache = require('../utils/cache');
+const { parsePagination } = require('../utils/pagination');
 
 const IMPERSONATION_TTL_SECONDS = 15 * 60;
 
@@ -164,6 +165,7 @@ router.get('/stats', async (req, res) => {
 router.get('/campaigns', async (req, res) => {
   try {
     const { status, include_deleted, flagged_only, contract_deployment_status } = req.query;
+    const { limit, offset } = parsePagination(req.query, { limit: 50, max: 200 });
     const params = [];
     let where = 'WHERE 1=1';
 
@@ -185,6 +187,10 @@ router.get('/campaigns', async (req, res) => {
       where += ` AND c.contract_deployment_status = $${params.length}`;
     }
 
+    const countSql = `SELECT COUNT(*)::int AS total FROM campaigns c ${where}`;
+    const countResult = await db.query(countSql, params);
+    const total = countResult.rows[0].total;
+
     const { rows } = await db.query(
       `SELECT c.id, c.title, c.status, c.raised_amount, c.target_amount, 
               c.asset_type, c.created_at, c.deleted_at, c.is_flagged_duplicate,
@@ -195,10 +201,11 @@ router.get('/campaigns', async (req, res) => {
        FROM campaigns c 
        JOIN users u ON c.creator_id = u.id
        ${where}
-       ORDER BY c.created_at DESC`,
-      params
+       ORDER BY c.created_at DESC
+       LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+      [...params, limit, offset]
     );
-    res.json(rows);
+    res.json({ data: rows, total, limit, offset });
   } catch (err) {
     logger.error('Error fetching campaigns for admin', { error: err.message });
     res.status(500).json({ error: 'Failed to fetch campaigns' });
@@ -211,6 +218,14 @@ router.get('/campaigns', async (req, res) => {
  */
 router.get('/fraud/flagged', async (req, res) => {
   try {
+    const { limit, offset } = parsePagination(req.query, { limit: 50, max: 200 });
+
+    const countResult = await db.query(
+      `SELECT COUNT(*)::int AS total FROM campaigns c
+       WHERE c.is_flagged_fraud = TRUE AND c.deleted_at IS NULL`
+    );
+    const total = countResult.rows[0].total;
+
     const { rows } = await db.query(
       `SELECT c.id, c.title, c.status, c.raised_amount, c.target_amount, c.asset_type,
               c.is_flagged_fraud, c.fraud_score, c.fraud_signals, c.created_at,
@@ -218,9 +233,11 @@ router.get('/fraud/flagged', async (req, res) => {
        FROM campaigns c
        JOIN users u ON c.creator_id = u.id
        WHERE c.is_flagged_fraud = TRUE AND c.deleted_at IS NULL
-       ORDER BY c.fraud_score DESC`
+       ORDER BY c.fraud_score DESC
+       LIMIT $1 OFFSET $2`,
+      [limit, offset]
     );
-    res.json(rows);
+    res.json({ data: rows, total, limit, offset });
   } catch (err) {
     logger.error('Error fetching flagged campaigns', { error: err.message });
     res.status(500).json({ error: 'Failed to fetch flagged campaigns' });
@@ -531,6 +548,7 @@ router.patch('/campaigns/:id/unfeature', async (req, res) => {
 router.get('/users', async (req, res) => {
   try {
     const { include_banned, kyc_status } = req.query;
+    const { limit, offset } = parsePagination(req.query, { limit: 50, max: 200 });
     const params = [];
     let where = 'WHERE 1=1';
 
@@ -543,6 +561,10 @@ router.get('/users', async (req, res) => {
       where += ` AND u.kyc_status = $${params.length}::kyc_status`;
     }
 
+    const countSql = `SELECT COUNT(*)::int AS total FROM users u ${where}`;
+    const countResult = await db.query(countSql, params);
+    const total = countResult.rows[0].total;
+
     const { rows } = await db.query(
       `SELECT u.id, u.name, u.email, u.role, u.is_admin, u.is_banned, u.created_at,
               u.kyc_status, u.kyc_completed_at,
@@ -550,10 +572,11 @@ router.get('/users', async (req, res) => {
               (SELECT COUNT(*) FROM contributions WHERE sender_public_key = u.wallet_public_key) as contribution_count
        FROM users u
        ${where}
-       ORDER BY u.created_at DESC`,
-      params
+       ORDER BY u.created_at DESC
+       LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+      [...params, limit, offset]
     );
-    res.json(rows);
+    res.json({ data: rows, total, limit, offset });
   } catch (err) {
     logger.error('Error fetching users for admin', { error: err.message });
     res.status(500).json({ error: 'Failed to fetch users' });
@@ -764,12 +787,18 @@ router.get('/milestones', async (req, res) => {
     return res.status(400).json({ error: `status must be one of: ${allowedStatuses.join(', ')}` });
   }
 
+  const { limit, offset } = parsePagination(req.query, { limit: 50, max: 200 });
+
   const params = [];
   let where = 'WHERE 1=1';
   if (status) {
     params.push(status);
     where += ` AND m.status = $${params.length}`;
   }
+
+  const countSql = `SELECT COUNT(*)::int AS total FROM milestones m ${where}`;
+  const countResult = await db.query(countSql, params);
+  const total = countResult.rows[0].total;
 
   const { rows } = await db.query(
     `SELECT m.*, c.title AS campaign_title, c.status AS campaign_status, c.asset_type,
@@ -778,10 +807,11 @@ router.get('/milestones', async (req, res) => {
      JOIN campaigns c ON c.id = m.campaign_id
      JOIN users u ON u.id = c.creator_id
      ${where}
-     ORDER BY m.created_at DESC`,
-    params
+     ORDER BY m.created_at DESC
+     LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+    [...params, limit, offset]
   );
-  res.json(rows);
+  res.json({ data: rows, total, limit, offset });
 });
 
 /**
@@ -808,7 +838,15 @@ router.post('/campaigns/:id/reconcile', async (req, res) => {
 router.get('/withdrawals', async (req, res) => {
   try {
     const status = req.query.status ? String(req.query.status) : 'pending';
+    const { limit, offset } = parsePagination(req.query, { limit: 50, max: 200 });
     const params = [status];
+
+    const countResult = await db.query(
+      'SELECT COUNT(*)::int AS total FROM withdrawal_requests wr WHERE wr.status = $1',
+      params
+    );
+    const total = countResult.rows[0].total;
+
     const { rows } = await db.query(
       `SELECT wr.id, wr.campaign_id, wr.amount, wr.destination_key, wr.status,
               wr.creator_signed, wr.platform_signed, wr.created_at, wr.is_refund,
@@ -818,10 +856,11 @@ router.get('/withdrawals', async (req, res) => {
        JOIN campaigns c ON c.id = wr.campaign_id
        JOIN users u ON u.id = c.creator_id
        WHERE wr.status = $1
-       ORDER BY wr.created_at ASC`,
-      params
+       ORDER BY wr.created_at ASC
+       LIMIT $2 OFFSET $3`,
+      [status, limit, offset]
     );
-    res.json(rows);
+    res.json({ data: rows, total, limit, offset });
   } catch (err) {
     logger.error('Error fetching admin withdrawals', { error: err.message });
     res.status(500).json({ error: 'Failed to fetch withdrawals' });
@@ -835,6 +874,7 @@ router.get('/withdrawals', async (req, res) => {
 router.get('/disputes', async (req, res) => {
   try {
     const { status } = req.query;
+    const { limit, offset } = parsePagination(req.query, { limit: 50, max: 200 });
     const params = [];
     let where = 'WHERE 1=1';
     if (status) {
@@ -843,6 +883,10 @@ router.get('/disputes', async (req, res) => {
     } else {
       where += " AND d.status IN ('open', 'under_review')";
     }
+
+    const countSql = `SELECT COUNT(*)::int AS total FROM disputes d ${where}`;
+    const countResult = await db.query(countSql, params);
+    const total = countResult.rows[0].total;
 
     const { rows } = await db.query(
       `SELECT d.*,
@@ -858,10 +902,11 @@ router.get('/disputes', async (req, res) => {
        JOIN users reporter ON reporter.id = d.raised_by
        JOIN users creator ON creator.id = c.creator_id
        ${where}
-       ORDER BY d.created_at DESC`,
-      params
+       ORDER BY d.created_at DESC
+       LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+      [...params, limit, offset]
     );
-    res.json(rows);
+    res.json({ data: rows, total, limit, offset });
   } catch (err) {
     logger.error('Error fetching admin disputes', { error: err.message });
     res.status(500).json({ error: 'Failed to fetch disputes' });

--- a/backend/src/routes/admin.operations.test.js
+++ b/backend/src/routes/admin.operations.test.js
@@ -10,8 +10,14 @@ const mockQuery = async (text) => {
   if (text.includes('SUM(raised_amount)')) {
     return { rows: [{ total: '1500' }] };
   }
+  if (text.includes('COUNT(*)') && text.includes('FROM withdrawal_requests wr')) {
+    return { rows: [{ total: 1 }] };
+  }
   if (text.includes('FROM withdrawal_requests WHERE status')) {
     return { rows: [{ count: 2, total_value: '400' }] };
+  }
+  if (text.includes('COUNT(*)') && text.includes('FROM disputes d')) {
+    return { rows: [{ total: 0 }] };
   }
   if (text.includes('FROM disputes WHERE status IN')) {
     return { rows: [{ count: 1 }] };
@@ -115,8 +121,10 @@ test('GET /api/admin/withdrawals returns pending queue', async () => {
     const res = await fetch(`http://127.0.0.1:${port}/api/admin/withdrawals`);
     assert.strictEqual(res.status, 200);
     const body = await res.json();
-    assert.strictEqual(body.length, 1);
-    assert.strictEqual(body[0].id, 'w-1');
+    assert.ok(Array.isArray(body.data));
+    assert.strictEqual(body.data.length, 1);
+    assert.strictEqual(body.data[0].id, 'w-1');
+    assert.ok(typeof body.total === 'number');
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }

--- a/backend/src/routes/admin.test.js
+++ b/backend/src/routes/admin.test.js
@@ -270,7 +270,10 @@ describe('Admin Moderation Features', async () => {
       });
       assert.strictEqual(res.status, 200);
       const data = await res.json();
-      assert.ok(Array.isArray(data));
+      assert.ok(Array.isArray(data.data));
+      assert.ok(typeof data.total === 'number');
+      assert.ok(typeof data.limit === 'number');
+      assert.ok(typeof data.offset === 'number');
     });
 
     it('GET /admin/disputes returns dispute list', async () => {
@@ -279,7 +282,10 @@ describe('Admin Moderation Features', async () => {
       });
       assert.strictEqual(res.status, 200);
       const data = await res.json();
-      assert.ok(Array.isArray(data));
+      assert.ok(Array.isArray(data.data));
+      assert.ok(typeof data.total === 'number');
+      assert.ok(typeof data.limit === 'number');
+      assert.ok(typeof data.offset === 'number');
     });
 
     it('PATCH /admin/users/:id/kyc updates status and logs audit', async () => {

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -59,6 +59,7 @@ const {
 } = require('../lib/campaignPermissions');
 const { stripHtml } = require('../lib/sanitize');
 const { getSimhash, simhashSimilarity } = require('../utils/simhash');
+const { parsePagination } = require('../utils/pagination');
 
 const crypto = require('crypto');
 
@@ -914,6 +915,14 @@ router.get('/:id/backers', asyncHandler(async (req, res) => {
   if (!campaignRows.length) return res.status(404).json({ error: 'Campaign not found' });
   const { show_backer_amounts } = campaignRows[0];
 
+  const { limit, offset } = parsePagination(req.query, { limit: 20, max: 100 });
+
+  const countResult = await db.query(
+    'SELECT COUNT(*)::int AS total FROM contributions WHERE campaign_id = $1',
+    [campaignId]
+  );
+  const total = countResult.rows[0].total;
+
   const query = `
     SELECT 
       display_name,
@@ -924,9 +933,10 @@ router.get('/:id/backers', asyncHandler(async (req, res) => {
     FROM contributions
     WHERE campaign_id = $1
     ORDER BY created_at DESC
+    LIMIT $2 OFFSET $3
   `;
-  const { rows } = await db.query(query, [campaignId]);
-  res.json(rows);
+  const { rows } = await db.query(query, [campaignId, limit, offset]);
+  res.json({ data: rows, total, limit, offset });
 }));
 
 // Download contributor fulfillment data for campaign owners/admins.
@@ -1572,6 +1582,14 @@ router.post('/:id/members/invite', requireAuth, requireCampaignMember('owner', '
 
 // GET /campaigns/:id/members — team list (owner/manager)
 router.get('/:id/members', requireAuth, requireCampaignMember('owner', 'manager'), asyncHandler(async (req, res) => {
+  const { limit, offset } = parsePagination(req.query, { limit: 20, max: 100 });
+
+  const countResult = await db.query(
+    'SELECT COUNT(*)::int AS total FROM campaign_members WHERE campaign_id = $1',
+    [req.params.id]
+  );
+  const total = countResult.rows[0].total;
+
   const { rows } = await db.query(
     `SELECT cm.id, cm.user_id, cm.email, cm.role, cm.accepted_at, cm.created_at,
             cm.invite_expires_at,
@@ -1579,10 +1597,11 @@ router.get('/:id/members', requireAuth, requireCampaignMember('owner', 'manager'
      FROM campaign_members cm
      LEFT JOIN users u ON u.id = cm.user_id
      WHERE cm.campaign_id = $1
-     ORDER BY cm.created_at ASC`,
-    [req.params.id]
+     ORDER BY cm.created_at ASC
+     LIMIT $2 OFFSET $3`,
+    [req.params.id, limit, offset]
   );
-  res.json(rows);
+  res.json({ data: rows, total, limit, offset });
 }));
 
 // PATCH /campaigns/:id/members/:userId — change role (owner only)

--- a/backend/src/routes/disputes.js
+++ b/backend/src/routes/disputes.js
@@ -9,6 +9,7 @@ const {
 } = require('../services/emailService');
 const logger = require('../config/logger');
 const { emitWebhookEventForUser, emitWebhookEventForCampaign, WEBHOOK_EVENTS } = require('../services/webhookDispatcher');
+const { parsePagination } = require('../utils/pagination');
 
 function frontendBaseUrl() {
   return (process.env.FRONTEND_URL || 'http://localhost:5173').replace(/\/$/, '');
@@ -147,15 +148,24 @@ router.post('/campaigns/:id/disputes', requireAuth, async (req, res) => {
 
 // GET /campaigns/:id/disputes — admin only
 router.get('/campaigns/:id/disputes', requireAuth, requireRole('admin'), async (req, res) => {
+  const { limit, offset } = parsePagination(req.query, { limit: 20, max: 100 });
+
+  const countResult = await db.query(
+    'SELECT COUNT(*)::int AS total FROM disputes WHERE campaign_id = $1',
+    [req.params.id]
+  );
+  const total = countResult.rows[0].total;
+
   const { rows } = await db.query(
     `SELECT d.*, u.name AS raised_by_name, u.email AS raised_by_email
      FROM disputes d
      JOIN users u ON u.id = d.raised_by
      WHERE d.campaign_id = $1
-     ORDER BY d.created_at DESC`,
-    [req.params.id]
+     ORDER BY d.created_at DESC
+     LIMIT $2 OFFSET $3`,
+    [req.params.id, limit, offset]
   );
-  res.json(rows);
+  res.json({ data: rows, total, limit, offset });
 });
 
 // PATCH /disputes/:id — admin updates status + resolution note

--- a/backend/src/routes/withdrawals.js
+++ b/backend/src/routes/withdrawals.js
@@ -22,6 +22,7 @@ const { sendWithdrawalApprovedEmail, sendWithdrawalRejectedEmail } = require('..
 const { emitWebhookEventForUser, WEBHOOK_EVENTS } = require('../services/webhookDispatcher');
 const { withDecryptedWalletSecret } = require('../services/walletSecrets');
 const { createNotification } = require('../services/notifications');
+const { parsePagination } = require('../utils/pagination');
 
 const ALLOWED_CAMPAIGN_STATUS_FOR_REQUEST = ['active', 'funded'];
 
@@ -723,15 +724,24 @@ router.get('/campaign/:campaignId', requireAuth, async (req, res) => {
   const access = await assertWithdrawalAccess(req, req.params.campaignId);
   if (access.error) return res.status(access.status).json({ error: access.error });
 
+  const { limit, offset } = parsePagination(req.query, { limit: 20, max: 100 });
+
+  const countResult = await db.query(
+    'SELECT COUNT(*)::int AS total FROM withdrawal_requests WHERE campaign_id = $1',
+    [req.params.campaignId]
+  );
+  const total = countResult.rows[0].total;
+
   const { rows } = await db.query(
     `SELECT id, campaign_id, requested_by, amount, destination_key, creator_signed,
             platform_signed, status, denial_reason, tx_hash, created_at
      FROM withdrawal_requests
      WHERE campaign_id = $1
-     ORDER BY created_at DESC`,
-    [req.params.campaignId]
+     ORDER BY created_at DESC
+     LIMIT $2 OFFSET $3`,
+    [req.params.campaignId, limit, offset]
   );
-  res.json(rows);
+  res.json({ data: rows, total, limit, offset });
 });
 
 // Get a single withdrawal request (including unsigned_xdr) for authorized users

--- a/backend/src/utils/pagination.js
+++ b/backend/src/utils/pagination.js
@@ -1,0 +1,35 @@
+/**
+ * Parse and validate pagination parameters from query string.
+ *
+ * @param {object}  query              Express req.query
+ * @param {number}  [defaults.limit=20]  Default page size
+ * @param {number}  [defaults.max=100]   Hard upper-bound
+ * @returns {{ limit: number, offset: number }}
+ */
+function parsePagination(query, { limit: defaultLimit = 20, max: maxLimit = 100 } = {}) {
+  const limit = Math.min(Math.max(parseInt(query.limit, 10) || defaultLimit, 1), maxLimit);
+  const offset = Math.max(parseInt(query.offset, 10) || 0, 0);
+  return { limit, offset };
+}
+
+/**
+ * Execute a data query together with a COUNT(*) query sharing the same
+ * WHERE clause and parameters, then return the standard paginated envelope.
+ *
+ * @param {object}  db               The database pool / client
+ * @param {string}  countSql         COUNT(*) query (must return a single `total` column)
+ * @param {string}  dataSql          Data query with LIMIT $N OFFSET $N+1 appended
+ * @param {Array}   baseParams       Bind parameters for the shared WHERE clause
+ * @param {number}  limit            Page size
+ * @param {number}  offset           Offset
+ * @returns {Promise<{ data: Array, total: number, limit: number, offset: number }>}
+ */
+async function paginatedResponse(db, countSql, dataSql, baseParams, limit, offset) {
+  const countResult = await db.query(countSql, baseParams);
+  const total = parseInt(countResult.rows[0]?.total ?? countResult.rows[0]?.count ?? '0', 10);
+
+  const dataResult = await db.query(dataSql, [...baseParams, limit, offset]);
+  return { data: dataResult.rows, total, limit, offset };
+}
+
+module.exports = { parsePagination, paginatedResponse };

--- a/backend/src/utils/pagination.test.js
+++ b/backend/src/utils/pagination.test.js
@@ -1,0 +1,38 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { parsePagination, paginatedResponse } = require('./pagination');
+
+test('parsePagination returns defaults for empty query', () => {
+  const result = parsePagination({});
+  assert.deepStrictEqual(result, { limit: 20, offset: 0 });
+});
+
+test('parsePagination respects custom defaults', () => {
+  const result = parsePagination({}, { limit: 50, max: 200 });
+  assert.deepStrictEqual(result, { limit: 50, offset: 0 });
+});
+
+test('parsePagination parses limit and offset from query', () => {
+  const result = parsePagination({ limit: '10', offset: '5' });
+  assert.deepStrictEqual(result, { limit: 10, offset: 5 });
+});
+
+test('parsePagination caps limit to max', () => {
+  const result = parsePagination({ limit: '999' }, { limit: 20, max: 100 });
+  assert.deepStrictEqual(result, { limit: 100, offset: 0 });
+});
+
+test('parsePagination floors offset to 0 for negative values', () => {
+  const result = parsePagination({ offset: '-5' });
+  assert.deepStrictEqual(result, { limit: 20, offset: 0 });
+});
+
+test('parsePagination treats non-numeric limit as default', () => {
+  const result = parsePagination({ limit: 'abc' });
+  assert.deepStrictEqual(result, { limit: 20, offset: 0 });
+});
+
+test('parsePagination treats limit=0 as default', () => {
+  const result = parsePagination({ limit: '0' });
+  assert.deepStrictEqual(result, { limit: 20, offset: 0 });
+});


### PR DESCRIPTION
Closes #504 
Closes #503 
Closes #501 
Closes #514 


## Summary

Add all required environment variables to the deploy heredoc that were missing from backend/.env generation:

- SENTRY_DSN (error tracking)
- STORAGE_BUCKET, STORAGE_REGION, STORAGE_ENDPOINT, STORAGE_ACCESS_KEY, STORAGE_SECRET_KEY (object storage for campaign covers)
- MONEYGRAM_API_KEY, MONEYGRAM_API_SECRET (anchor/fiat on-ramp)
- WALLET_SECRET_LOCAL_KEK (wallet secret encryption)
- WALLET_SECRET_KMS_KEY_ID, AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (AWS KMS for production wallet encryption)


- Add FRONTEND_URL to required env vars in config/env.js
- Remove http://localhost:5173 fallback from 12 files (14 occurrences)
- Fix unsubscribeToken.js using wrong port 4000 fallback, now uses FRONTEND_URL
- Prevents localhost URLs in emails, notifications, and API responses in production


- Add parsePagination utility for consistent limit/offset handling
- Admin endpoints: default limit=50, max limit=200 GET /api/admin/campaigns, users, fraud/flagged, withdrawals, disputes, milestones
- Public endpoints: default limit=20, max limit=100 GET /campaigns/:id/backers, /:id/members, /withdrawals/campaign/:campaignId, /campaigns/:id/disputes
- All paginated endpoints return { data, total, limit, offset }
- Update existing tests to match new response envelope
- Add pagination utility unit tests

