### PR TITLE
perf: add missing database indexes

### DIFF
--- a/backend/db/migrations/20260727_add_missing_db_indexes.sql
+++ b/backend/db/migrations/20260727_add_missing_db_indexes.sql
@@ -1,0 +1,20 @@
+-- Add missing database indexes for frequently queried columns
+
+CREATE INDEX IF NOT EXISTS idx_contributions_sender_public_key
+  ON contributions(sender_public_key);
+
+CREATE INDEX IF NOT EXISTS idx_withdrawal_requests_campaign_status
+  ON withdrawal_requests(campaign_id, status);
+
+DROP INDEX IF EXISTS idx_campaigns_is_hidden;
+CREATE INDEX idx_campaigns_is_hidden
+  ON campaigns(is_hidden)
+  WHERE is_hidden = FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_campaigns_is_flagged_duplicate
+  ON campaigns(is_flagged_duplicate)
+  WHERE is_flagged_duplicate = FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_campaigns_is_flagged_fraud
+  ON campaigns(is_flagged_fraud)
+  WHERE is_flagged_fraud = TRUE;

--- a/backend/src/services/sorobanService.test.js
+++ b/backend/src/services/sorobanService.test.js
@@ -236,7 +236,6 @@ describe('Soroban contract integration scenario — campaign milestone release',
     assert.equal(__mock.getCalls().length, 0);
   });
 const test = require('node:test');
-const assert = require('node:assert/strict');
 const proxyquire = require('proxyquire').noCallThru();
 
 function buildService() {

--- a/backend/src/services/sorobanService.test.js
+++ b/backend/src/services/sorobanService.test.js
@@ -235,6 +235,7 @@ describe('Soroban contract integration scenario — campaign milestone release',
     // No calls should have completed
     assert.equal(__mock.getCalls().length, 0);
   });
+});
 const test = require('node:test');
 const proxyquire = require('proxyquire').noCallThru();
 

--- a/backend/src/services/userDashboardService.js
+++ b/backend/src/services/userDashboardService.js
@@ -224,7 +224,7 @@ async function getContributorDashboard(userId) {
 }
 
 function csvEscape(value) {
-  const str = value == null ? '' : String(value);
+  const str = value === null || value === undefined ? '' : String(value);
   if (/[",\n]/.test(str)) {
     return `"${str.replace(/"/g, '""')}"`;
   }

--- a/frontend/eslint.config.cjs
+++ b/frontend/eslint.config.cjs
@@ -91,6 +91,7 @@ module.exports = [
         afterEach: 'readonly',
         vi: 'readonly',
         jest: 'readonly',
+        global: 'readonly',
       },
     },
   },


### PR DESCRIPTION
## perf: add missing database indexes

Closes #500

### Changes

Adds indexes for frequently queried columns to eliminate full table scans:

| Index | Table | Columns | Type |
|-------|-------|---------|------|
| `idx_contributions_sender_public_key` | `contributions` | `sender_public_key` | B-tree |
| `idx_withdrawal_requests_campaign_status` | `withdrawal_requests` | `campaign_id, status` | Composite B-tree |
| `idx_campaigns_is_hidden` | `campaigns` | `is_hidden` | Partial (`WHERE is_hidden = FALSE`) |
| `idx_campaigns_is_flagged_duplicate` | `campaigns` | `is_flagged_duplicate` | Partial (`WHERE is_flagged_duplicate = FALSE`) |
| `idx_campaigns_is_flagged_fraud` | `campaigns` | `is_flagged_fraud` | Partial (`WHERE is_flagged_fraud = TRUE`) |

### Notes

- The existing `idx_campaigns_is_hidden` index (filtering `is_hidden = TRUE`) has been dropped and recreated to filter `is_hidden = FALSE`, matching the common query path for public campaign listings.
- All other indexes use `IF NOT EXISTS` for idempotent re-runs.
