### PR TITLE
chore: move hardcoded magic numbers to config/constants.js

### DIFF
--- a/backend/src/config/constants.js
+++ b/backend/src/config/constants.js
@@ -39,4 +39,24 @@ module.exports = {
 
   /** Initial reconnect delay for the ledger payment stream, in milliseconds. */
   LEDGER_MONITOR_RECONNECT_DELAY_MS: 5_000,
+
+  // ---------------------------------------------------------------------------
+  // Milestone limits
+  // ---------------------------------------------------------------------------
+
+  /** Maximum number of milestones a campaign can define. */
+  MILESTONE_LIMIT: 5,
+
+  /** Maximum file size (in bytes) for milestone evidence uploads (10 MB). */
+  MILESTONE_EVIDENCE_MAX_FILE_SIZE: 10 * 1024 * 1024,
+
+  // ---------------------------------------------------------------------------
+  // Admin
+  // ---------------------------------------------------------------------------
+
+  /** Impersonation token TTL in seconds (15 minutes). */
+  IMPERSONATION_TTL_SECONDS: 15 * 60,
+
+  /** Maximum number of admin audit log entries that can be returned in a single query. */
+  ADMIN_AUDIT_LOG_MAX_LIMIT: 1000,
 };

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -17,8 +17,7 @@ const {
 } = require('../services/webhookDispatcher');
 const cache = require('../utils/cache');
 const { parsePagination } = require('../utils/pagination');
-
-const IMPERSONATION_TTL_SECONDS = 15 * 60;
+const { IMPERSONATION_TTL_SECONDS, ADMIN_AUDIT_LOG_MAX_LIMIT } = require('../config/constants');
 
 /**
  * Log admin action to audit table
@@ -676,7 +675,7 @@ router.patch('/users/:id/unban', async (req, res) => {
 router.get('/audit-log', async (req, res) => {
   try {
     const { limit = 100, offset = 0 } = req.query;
-    const limitNum = Math.min(parseInt(limit) || 100, 1000);
+    const limitNum = Math.min(parseInt(limit) || 100, ADMIN_AUDIT_LOG_MAX_LIMIT);
     const offsetNum = parseInt(offset) || 0;
 
     const { rows } = await db.query(

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -3,6 +3,7 @@ const multer = require('multer');
 const Sentry = require('@sentry/node');
 const db = require('../config/database');
 const logger = require('../config/logger');
+const { MILESTONE_LIMIT } = require('../config/constants');
 const { requireAuth, requireRole } = require('../middleware/auth');
 const {
   createCampaignWallet,
@@ -132,7 +133,6 @@ const upload = multer({
 
 const SUPPORTED_ASSETS = getSupportedAssetCodes();
 const MILESTONE_PERCENT_SCALE = 10000;
-const MILESTONE_LIMIT = 5;
 
 function normalizeMilestonesInput(input) {
   if (input === null || input === undefined) return [];

--- a/backend/src/routes/milestones.js
+++ b/backend/src/routes/milestones.js
@@ -3,6 +3,7 @@ const multer = require('multer');
 const { Keypair } = require('@stellar/stellar-sdk');
 const db = require('../config/database');
 const logger = require('../config/logger');
+const { MILESTONE_LIMIT, MILESTONE_EVIDENCE_MAX_FILE_SIZE } = require('../config/constants');
 const { requireAuth } = require('../middleware/auth');
 const { sendAlert } = require('../services/alerting');
 const {
@@ -52,11 +53,9 @@ function toReleaseAmount(raisedAmount, releasePercentage) {
   return ((Number(raisedAmount) * Number(releasePercentage)) / 100).toFixed(7);
 }
 
-const MILESTONE_LIMIT = 5;
-
 const evidenceUpload = multer({
   storage: multer.memoryStorage(),
-  limits: { fileSize: 10 * 1024 * 1024 },
+  limits: { fileSize: MILESTONE_EVIDENCE_MAX_FILE_SIZE },
   fileFilter: (_req, file, cb) => {
     const allowed = [
       'image/jpeg',


### PR DESCRIPTION
## Summary

Centralize hardcoded magic numbers scattered across route files into `backend/src/config/constants.js`.

## Changes

### New constants added to `backend/src/config/constants.js`

| Constant | Value | Description | Moved From |
|---|---|---|---|
| `MILESTONE_LIMIT` | `5` | Max milestones per campaign | `routes/milestones.js`, `routes/campaigns.js` |
| `MILESTONE_EVIDENCE_MAX_FILE_SIZE` | `10 * 1024 * 1024` (10MB) | File upload size limit for milestone evidence | `routes/milestones.js` |
| `IMPERSONATION_TTL_SECONDS` | `15 * 60` (15 min) | Impersonation token TTL | `routes/admin.js` |
| `ADMIN_AUDIT_LOG_MAX_LIMIT` | `1000` | Max audit log entries per query | `routes/admin.js` |

### Files modified

- **`backend/src/config/constants.js`** — Added the four new constants with JSDoc documentation
- **`backend/src/routes/milestones.js`** — Imported `MILESTONE_LIMIT` and `MILESTONE_EVIDENCE_MAX_FILE_SIZE`, removed local constant definitions
- **`backend/src/routes/campaigns.js`** — Imported `MILESTONE_LIMIT` instead of defining a local constant
- **`backend/src/routes/admin.js`** — Imported `IMPERSONATION_TTL_SECONDS` and `ADMIN_AUDIT_LOG_MAX_LIMIT`, removed local constant/hardcoded value

### Testing

- Code review passed — no issues found
- Syntax verified — all files load without errors
- No behavior changes — all values remain identical

Closes #491