### PR TITLE
Webhook rate limiting, query param validation, console.error cleanup, and test coverage

### DIFF
--- a/backend/src/routes/contributions.js
+++ b/backend/src/routes/contributions.js
@@ -8,6 +8,7 @@ const { requireAuth } = require('../middleware/auth');
 const logger = require('../config/logger');
 const { sendAlert } = require('../services/alerting');
 const { contributionValidation, contributionQuoteValidation, validateRequest } = require('../middleware/validation');
+const { parsePagination } = require('../utils/pagination');
 const {
   buildUnsignedContributionPayment,
   buildUnsignedContributionPathPayment,
@@ -163,8 +164,7 @@ router.get('/dashboard/export.csv', requireAuth, asyncHandler(async (req, res) =
 }));
 
 router.get('/campaign/:campaignId', async (req, res) => {
-  const limit = Math.min(parseInt(req.query.limit) || 20, 100);
-  const offset = Math.max(parseInt(req.query.offset) || 0, 0);
+  const { limit, offset } = parsePagination(req.query, { limit: 20, max: 100 });
 
   const { rows } = await db.query(
     `SELECT c.id, c.sender_public_key, c.amount, c.asset, c.payment_type,

--- a/backend/src/routes/contributions.test.js
+++ b/backend/src/routes/contributions.test.js
@@ -1056,3 +1056,57 @@ test('POST /api/contributions/:id/refund processes an eligible failed-campaign r
   assert.equal(response.body.tx_hash, 'refund-tx-hash');
   assert.equal(updates.length, 1);
 });
+
+// --- GET /api/contributions/campaign/:campaignId pagination bounds (#490) ---
+//
+// limit/offset previously used plain parseInt() with no radix and no upper
+// bound on limit; both are now delegated to the shared parsePagination()
+// utility (the same one campaigns.js/admin.js/withdrawals.js/disputes.js use).
+
+test('GET /api/contributions/campaign/:campaignId uses default limit/offset when none given', async () => {
+  let receivedParams;
+  const app = buildApp({
+    queryImpl: async (_sql, params) => {
+      receivedParams = params;
+      return { rows: [] };
+    },
+  });
+
+  const res = await request(app).get('/api/contributions/campaign/cam-1');
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body, { contributions: [], total: 0, limit: 20, offset: 0 });
+  assert.deepEqual(receivedParams, ['cam-1', 20, 0]);
+});
+
+test('GET /api/contributions/campaign/:campaignId clamps ?limit= to the 100 upper bound', async () => {
+  let receivedParams;
+  const app = buildApp({
+    queryImpl: async (_sql, params) => {
+      receivedParams = params;
+      return { rows: [] };
+    },
+  });
+
+  const res = await request(app).get('/api/contributions/campaign/cam-1?limit=999999');
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.limit, 100);
+  assert.deepEqual(receivedParams, ['cam-1', 100, 0]);
+});
+
+test('GET /api/contributions/campaign/:campaignId parses ?offset= with radix 10 and floors at 0', async () => {
+  let receivedParams;
+  const app = buildApp({
+    queryImpl: async (_sql, params) => {
+      receivedParams = params;
+      return { rows: [] };
+    },
+  });
+
+  const res = await request(app).get('/api/contributions/campaign/cam-1?offset=-5');
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.offset, 0);
+  assert.deepEqual(receivedParams, ['cam-1', 20, 0]);
+});

--- a/backend/src/routes/disputes.js
+++ b/backend/src/routes/disputes.js
@@ -15,6 +15,15 @@ function frontendBaseUrl() {
   return (process.env.FRONTEND_URL || 'http://localhost:5173').replace(/\/$/, '');
 }
 
+function isValidEvidenceUrl(urlString) {
+  try {
+    const u = new URL(urlString);
+    return u.protocol === 'https:' || u.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
 async function logDisputeEvent(client, { disputeId, actorId, action, note }) {
   await client.query(
     `INSERT INTO dispute_events (dispute_id, actor_id, action, note)
@@ -33,6 +42,9 @@ router.post('/campaigns/:id/disputes', requireAuth, async (req, res) => {
   }
   if (!description || !description.trim()) {
     return res.status(422).json({ error: 'description is required' });
+  }
+  if (evidence_url !== undefined && evidence_url !== null && evidence_url !== '' && !isValidEvidenceUrl(evidence_url)) {
+    return res.status(422).json({ error: 'evidence_url must be a valid http(s) URL' });
   }
 
   const { rows: campaigns } = await db.query(

--- a/backend/src/routes/disputes.test.js
+++ b/backend/src/routes/disputes.test.js
@@ -1,0 +1,149 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const proxyquire = require('proxyquire').noCallThru();
+
+const CAMPAIGN_ID = 'cam-1';
+const CONTRIBUTOR_ID = 'user-1';
+
+function buildApp({ queryImpl, hasContributed = true } = {}) {
+  const defaultQuery = async (sql, params) => {
+    if (sql.includes('SELECT id, creator_id, title FROM campaigns')) {
+      return { rows: [{ id: CAMPAIGN_ID, creator_id: 'creator-1', title: 'Test Campaign' }] };
+    }
+    if (sql.includes('FROM contributions')) {
+      return { rows: hasContributed ? [{ id: 'contrib-1' }] : [] };
+    }
+    if (sql.includes('INSERT INTO disputes')) {
+      const [campaignId, raisedBy, reason, description, evidenceUrl] = params;
+      return {
+        rows: [
+          {
+            id: 'dispute-1',
+            campaign_id: campaignId,
+            raised_by: raisedBy,
+            reason,
+            description,
+            evidence_url: evidenceUrl,
+            status: 'open',
+          },
+        ],
+      };
+    }
+    if (sql.includes("SELECT email, name FROM users WHERE role = 'admin'")) {
+      return { rows: [] };
+    }
+    return { rows: [] };
+  };
+
+  const query = queryImpl || defaultQuery;
+
+  const router = proxyquire('./disputes', {
+    '../config/database': {
+      query,
+      connect: async () => ({
+        query,
+        release: () => {},
+      }),
+    },
+    '../middleware/auth': {
+      requireAuth: (req, _res, next) => {
+        req.user = { userId: CONTRIBUTOR_ID };
+        next();
+      },
+      requireRole: () => (_req, _res, next) => next(),
+    },
+    '../services/emailService': {
+      sendDisputeOpenedCreatorEmail: async () => {},
+      sendDisputeOpenedAdminEmail: async () => {},
+      sendDisputeResolvedCreatorEmail: async () => {},
+      sendDisputeResolvedContributorEmail: async () => {},
+    },
+    '../services/webhookDispatcher': {
+      emitWebhookEventForUser: async () => {},
+      emitWebhookEventForCampaign: async () => {},
+      WEBHOOK_EVENTS: { DISPUTE_RAISED: 'dispute.raised' },
+    },
+    '../config/logger': { info: () => {}, warn: () => {}, error: () => {} },
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api', router);
+  return app;
+}
+
+// --- evidence_url validation (#490) -----------------------------------------
+
+test('POST /campaigns/:id/disputes returns 422 for an invalid reason', async () => {
+  const app = buildApp();
+
+  const res = await request(app)
+    .post(`/api/campaigns/${CAMPAIGN_ID}/disputes`)
+    .send({ reason: 'made_up_reason', description: 'Something went wrong' });
+
+  assert.equal(res.status, 422);
+  assert.match(res.body.error, /reason must be one of/);
+});
+
+test('POST /campaigns/:id/disputes returns 422 for a missing description', async () => {
+  const app = buildApp();
+
+  const res = await request(app)
+    .post(`/api/campaigns/${CAMPAIGN_ID}/disputes`)
+    .send({ reason: 'non_delivery', description: '   ' });
+
+  assert.equal(res.status, 422);
+  assert.match(res.body.error, /description is required/);
+});
+
+test('POST /campaigns/:id/disputes returns 422 for a malformed evidence_url', async () => {
+  const app = buildApp();
+
+  const res = await request(app)
+    .post(`/api/campaigns/${CAMPAIGN_ID}/disputes`)
+    .send({
+      reason: 'non_delivery',
+      description: 'The item never arrived',
+      evidence_url: 'not a url at all',
+    });
+
+  assert.equal(res.status, 422);
+  assert.match(res.body.error, /evidence_url must be a valid/);
+});
+
+test('POST /campaigns/:id/disputes accepts a missing evidence_url', async () => {
+  const app = buildApp();
+
+  const res = await request(app)
+    .post(`/api/campaigns/${CAMPAIGN_ID}/disputes`)
+    .send({ reason: 'non_delivery', description: 'The item never arrived' });
+
+  assert.equal(res.status, 201);
+});
+
+test('POST /campaigns/:id/disputes accepts a valid https evidence_url', async () => {
+  const app = buildApp();
+
+  const res = await request(app)
+    .post(`/api/campaigns/${CAMPAIGN_ID}/disputes`)
+    .send({
+      reason: 'non_delivery',
+      description: 'The item never arrived',
+      evidence_url: 'https://example.com/proof.png',
+    });
+
+  assert.equal(res.status, 201);
+  assert.equal(res.body.evidence_url, 'https://example.com/proof.png');
+});
+
+test('POST /campaigns/:id/disputes returns 403 for a non-contributor', async () => {
+  const app = buildApp({ hasContributed: false });
+
+  const res = await request(app)
+    .post(`/api/campaigns/${CAMPAIGN_ID}/disputes`)
+    .send({ reason: 'non_delivery', description: 'The item never arrived' });
+
+  assert.equal(res.status, 403);
+});

--- a/backend/src/routes/emails.js
+++ b/backend/src/routes/emails.js
@@ -1,9 +1,14 @@
 const router = require('express').Router();
 const db = require('../config/database');
 const { verifyUnsubscribeToken } = require('../utils/unsubscribeToken');
+const { isUuid } = require('../utils/validation');
 
 router.get('/unsubscribe', async (req, res) => {
   const { email, category, sig, campaign_id: campaignId } = req.query;
+
+  if (campaignId !== undefined && !isUuid(campaignId)) {
+    return res.status(400).send('Invalid campaign_id.');
+  }
 
   if (!verifyUnsubscribeToken({ email, category, sig, campaign_id: campaignId })) {
     return res.status(400).send('Invalid or expired unsubscribe link.');
@@ -30,7 +35,7 @@ router.get('/unsubscribe', async (req, res) => {
       `INSERT INTO campaign_update_unsubscribes (email, campaign_id)
        VALUES ($1, $2)
        ON CONFLICT (email, campaign_id) DO NOTHING`,
-      [String(email).toLowerCase(), Number(campaignId)]
+      [String(email).toLowerCase(), campaignId]
     );
     return res.send('You have been unsubscribed from updates for this campaign.');
   }

--- a/backend/src/routes/emails.test.js
+++ b/backend/src/routes/emails.test.js
@@ -43,3 +43,41 @@ test('GET /api/emails/unsubscribe rejects a tampered signature', async () => {
 
   assert.equal(res.status, 400);
 });
+
+// --- campaign_id validation (#490) -------------------------------------------
+//
+// campaign_id is a UUID column (campaign_update_unsubscribes.campaign_id
+// references campaigns(id)); it was previously coerced with Number(campaignId),
+// which is always NaN for a real UUID and silently broke both signature
+// verification and the insert. These tests cover a valid UUID campaign_id
+// round-tripping correctly, and a malformed campaign_id being rejected with 400
+// instead of hitting the database.
+
+test('GET /api/emails/unsubscribe records a campaign-scoped unsubscribe for a valid UUID campaign_id', async () => {
+  const campaignId = '11111111-1111-1111-1111-111111111111';
+  const { app, calls } = buildApp();
+  const url = buildUnsubscribeUrl({ email: 'a@test.com', category: 'campaign_update', campaignId });
+  const path = url.split('/api/emails')[1];
+
+  const res = await request(app).get(`/api/emails${path}`);
+
+  assert.equal(res.status, 200);
+  const insertCall = calls.find((c) => c.text.includes('INSERT INTO campaign_update_unsubscribes'));
+  assert.ok(insertCall);
+  assert.deepEqual(insertCall.params, ['a@test.com', campaignId]);
+});
+
+test('GET /api/emails/unsubscribe returns 400 for a malformed campaign_id', async () => {
+  const { app } = buildApp();
+
+  const res = await request(app)
+    .get('/api/emails/unsubscribe')
+    .query({
+      email: 'a@test.com',
+      category: 'campaign_update',
+      sig: 'irrelevant-checked-after-campaign_id',
+      campaign_id: 'not-a-uuid',
+    });
+
+  assert.equal(res.status, 400);
+});

--- a/backend/src/routes/stellarTransactions.js
+++ b/backend/src/routes/stellarTransactions.js
@@ -2,6 +2,8 @@ const router = require('express').Router();
 const db = require('../config/database');
 const { requireAuth } = require('../middleware/auth');
 const asyncHandler = require('../utils/asyncHandler');
+const { isUuid } = require('../utils/validation');
+const { parsePagination } = require('../utils/pagination');
 
 function isPlatformApprover(userId) {
   if (!process.env.PLATFORM_APPROVER_USER_ID) return false;
@@ -22,11 +24,15 @@ async function assertCampaignReportingAccess(req, campaignId) {
  * Reporting index: Stellar transactions auditable by campaign creators and platform operators.
  */
 router.get('/', requireAuth, asyncHandler(async (req, res) => {
-  const { campaign_id: campaignId, status, limit } = req.query;
-  const max = Math.min(parseInt(limit, 10) || 50, 200);
+  const { campaign_id: campaignId, status } = req.query;
+  const { limit: max } = parsePagination(req.query, { limit: 50, max: 200 });
 
   if (!campaignId && !isPlatformApprover(req.user.userId)) {
     return res.status(400).json({ error: 'campaign_id is required unless using a platform operator account' });
+  }
+
+  if (campaignId && !isUuid(campaignId)) {
+    return res.status(400).json({ error: 'campaign_id must be a valid UUID' });
   }
 
   if (campaignId) {

--- a/backend/src/routes/stellarTransactions.test.js
+++ b/backend/src/routes/stellarTransactions.test.js
@@ -66,7 +66,7 @@ test('GET /api/stellar/transactions lists rows for campaign creator', async () =
   });
 
   const res = await request(app)
-    .get('/api/stellar/transactions?campaign_id=camp-1')
+    .get('/api/stellar/transactions?campaign_id=11111111-1111-1111-1111-111111111111')
     .set('Authorization', 'Bearer t');
 
   assert.equal(res.status, 200);
@@ -85,10 +85,26 @@ test('GET /api/stellar/transactions rejects invalid status filter', async () => 
   });
 
   const res = await request(app)
-    .get('/api/stellar/transactions?campaign_id=camp-1&status=bad')
+    .get('/api/stellar/transactions?campaign_id=11111111-1111-1111-1111-111111111111&status=bad')
     .set('Authorization', 'Bearer t');
 
   assert.equal(res.status, 400);
+  assert.match(res.body.error, /status must be one of/);
+});
+
+// #490: campaign_id is a UUID column; passing a non-UUID string previously
+// went straight to the database instead of returning a clean validation error.
+test('GET /api/stellar/transactions rejects a malformed campaign_id', async () => {
+  const app = buildApp({
+    queryImpl: async () => ({ rows: [] }),
+  });
+
+  const res = await request(app)
+    .get('/api/stellar/transactions?campaign_id=not-a-uuid')
+    .set('Authorization', 'Bearer t');
+
+  assert.equal(res.status, 400);
+  assert.match(res.body.error, /valid UUID/);
 });
 
 test('GET /api/stellar/transactions/:id denies unrelated users', async () => {

--- a/backend/src/routes/wallets.js
+++ b/backend/src/routes/wallets.js
@@ -10,6 +10,7 @@ const {
   recoverWalletFromSecret,
 } = require('../services/stellarService');
 const { decryptSecret } = require('../services/walletService');
+const { parsePagination } = require('../utils/pagination');
 
 const isTest = process.env.NODE_ENV === 'test';
 const recoverLimiter = rateLimit({
@@ -47,7 +48,7 @@ router.get('/:campaignId/transactions', requireAuth, async (req, res) => {
     return res.status(403).json({ error: 'Unauthorized' });
   }
 
-  const limit = parseInt(req.query.limit) || 50;
+  const { limit } = parsePagination(req.query, { limit: 50, max: 100 });
   const txs = await getWalletTransactionHistory(rows[0].wallet_public_key, limit);
   res.json(txs);
 });
@@ -63,7 +64,7 @@ router.get('/:campaignId/payments', requireAuth, async (req, res) => {
     return res.status(403).json({ error: 'Unauthorized' });
   }
 
-  const limit = parseInt(req.query.limit) || 100;
+  const { limit } = parsePagination(req.query, { limit: 100, max: 200 });
   const payments = await getWalletPayments(rows[0].wallet_public_key, limit);
   res.json(payments);
 });

--- a/backend/src/routes/wallets.test.js
+++ b/backend/src/routes/wallets.test.js
@@ -137,6 +137,44 @@ test('GET /api/wallets/:campaignId/transactions honors a custom ?limit=', async 
   assert.equal(receivedLimit, 5);
 });
 
+// #490: limit had no upper bound before parsePagination was adopted here —
+// an unbounded ?limit= could force an unbounded history fetch.
+test('GET /api/wallets/:campaignId/transactions clamps ?limit= to the 100 upper bound', async () => {
+  let receivedLimit;
+  const { app } = buildApp({
+    queryImpl: async () => ({ rows: [campaignRow()] }),
+    stellarImpl: {
+      getWalletTransactionHistory: async (_publicKey, limit) => {
+        receivedLimit = limit;
+        return [];
+      },
+    },
+  });
+
+  const res = await request(app).get(`/api/wallets/${CAMPAIGN_ID}/transactions?limit=999999`);
+
+  assert.equal(res.status, 200);
+  assert.equal(receivedLimit, 100);
+});
+
+test('GET /api/wallets/:campaignId/transactions falls back to the default limit for a non-numeric ?limit=', async () => {
+  let receivedLimit;
+  const { app } = buildApp({
+    queryImpl: async () => ({ rows: [campaignRow()] }),
+    stellarImpl: {
+      getWalletTransactionHistory: async (_publicKey, limit) => {
+        receivedLimit = limit;
+        return [];
+      },
+    },
+  });
+
+  const res = await request(app).get(`/api/wallets/${CAMPAIGN_ID}/transactions?limit=not-a-number`);
+
+  assert.equal(res.status, 200);
+  assert.equal(receivedLimit, 50);
+});
+
 test('GET /api/wallets/:campaignId/transactions returns 404 for unknown campaign', async () => {
   const { app } = buildApp({
     queryImpl: async () => ({ rows: [] }),
@@ -196,6 +234,25 @@ test('GET /api/wallets/:campaignId/payments honors a custom ?limit=', async () =
 
   assert.equal(res.status, 200);
   assert.equal(receivedLimit, 7);
+});
+
+// #490: limit had no upper bound before parsePagination was adopted here.
+test('GET /api/wallets/:campaignId/payments clamps ?limit= to the 200 upper bound', async () => {
+  let receivedLimit;
+  const { app } = buildApp({
+    queryImpl: async () => ({ rows: [campaignRow()] }),
+    stellarImpl: {
+      getWalletPayments: async (_publicKey, limit) => {
+        receivedLimit = limit;
+        return [];
+      },
+    },
+  });
+
+  const res = await request(app).get(`/api/wallets/${CAMPAIGN_ID}/payments?limit=999999`);
+
+  assert.equal(res.status, 200);
+  assert.equal(receivedLimit, 200);
 });
 
 test('GET /api/wallets/:campaignId/payments returns 404 for unknown campaign', async () => {

--- a/backend/src/routes/webhooks.js
+++ b/backend/src/routes/webhooks.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const crypto = require('crypto');
+const rateLimit = require('express-rate-limit');
 const db = require('../config/database');
 const logger = require('../config/logger');
 const { requireAuth } = require('../middleware/auth');
@@ -14,6 +15,21 @@ const {
   verifyWebhookSignature,
   WebhookError,
 } = require('../services/webhookService');
+
+const isTest = process.env.NODE_ENV === 'test';
+
+// Per-IP: 30 req/min on the public webhook ingress endpoint. This route has
+// no auth (any caller with a valid webhook id + signature can post to it),
+// so it's a DoS vector without its own limiter — the global 100 req/15min
+// limit is far too permissive for a single public endpoint.
+const incomingWebhookLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: isTest ? 100000 : 30,
+  message: { error: 'Too many webhook deliveries from this IP. Please try again later.' },
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => isTest,
+});
 
 function isValidWebhookUrl(urlString) {
   try {
@@ -39,7 +55,7 @@ function normalizeEvents(events) {
 
 // KYC webhooks are handled at POST /api/webhooks/kyc (raw body + Persona signature verification).
 
-router.post('/incoming/:id', express.raw({ type: 'application/json' }), async (req, res) => {
+router.post('/incoming/:id', incomingWebhookLimiter, express.raw({ type: 'application/json' }), async (req, res) => {
   try {
     const { rows } = await db.query(
       `SELECT id, user_id, secret FROM webhooks WHERE id = $1 AND revoked_at IS NULL`,

--- a/backend/src/routes/webhooks.test.js
+++ b/backend/src/routes/webhooks.test.js
@@ -154,3 +154,60 @@ test('POST /incoming/:id links a matching contribution and returns success', asy
   assert.equal(res.body.body.linked, true);
   assert.equal(res.body.body.contribution_id, 'c-1');
 });
+
+// --- POST /api/webhooks/incoming/:id rate limiting (#489) -------------------
+//
+// The route's `incomingWebhookLimiter` is built with `skip: () => isTest`, so
+// under the suite's normal `NODE_ENV=test` it never actually limits (matching
+// the existing auth.js limiters' convention of being inert in tests). To
+// exercise the real 30 req/min ceiling, this test loads a fresh, uncached copy
+// of the module with NODE_ENV temporarily forced to a non-test value so the
+// limiter's `max` is the real production value (30) instead of the
+// effectively-infinite test value.
+test('POST /incoming/:id returns 429 after 30 requests per minute from the same IP', async () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'production';
+  const modulePath = require.resolve('./webhooks');
+  delete require.cache[modulePath];
+
+  try {
+    const router = proxyquire('./webhooks', {
+      '../config/database': {
+        query: async () => ({ rows: [{ id: WEBHOOK_ID, user_id: OWNER, secret: SECRET }] }),
+      },
+      '../middleware/auth': { requireAuth: (req, _res, next) => next() },
+      '../services/webhookDispatcher': { ALL_WEBHOOK_EVENTS: [], processDelivery: async () => {} },
+      '../services/webhookService': proxyquire('../services/webhookService', {
+        '../config/database': { query: async () => ({ rows: [] }) },
+        '../config/logger': { info: () => {}, warn: () => {}, error: () => {} },
+        './notifications': { createNotification: async () => {} },
+      }),
+    });
+
+    const app = express();
+    app.use('/api/webhooks', router);
+
+    const body = JSON.stringify({ type: 'contribution.confirmed', tx_hash: 'tx-limit' });
+    const sig = sign(SECRET, Buffer.from(body));
+
+    for (let i = 0; i < 30; i += 1) {
+      await request(app)
+        .post(`/api/webhooks/incoming/${WEBHOOK_ID}`)
+        .set('Content-Type', 'application/json')
+        .set('x-signature-256', sig)
+        .send(body);
+    }
+
+    const res = await request(app)
+      .post(`/api/webhooks/incoming/${WEBHOOK_ID}`)
+      .set('Content-Type', 'application/json')
+      .set('x-signature-256', sig)
+      .send(body);
+
+    assert.equal(res.status, 429);
+    assert.match(res.body.error, /Too many webhook deliveries/);
+  } finally {
+    process.env.NODE_ENV = originalNodeEnv;
+    delete require.cache[modulePath];
+  }
+});

--- a/backend/src/utils/unsubscribeToken.js
+++ b/backend/src/utils/unsubscribeToken.js
@@ -22,7 +22,7 @@ function buildUnsubscribeUrl({ email, category, campaignId }) {
 
 function verifyUnsubscribeToken({ email, category, sig, campaign_id: campaignId }) {
   if (!email || !category || !sig) return false;
-  const expected = sign(email, category, campaignId ? Number(campaignId) : undefined);
+  const expected = sign(email, category, campaignId || undefined);
   const a = Buffer.from(expected);
   const b = Buffer.from(String(sig));
   return a.length === b.length && crypto.timingSafeEqual(a, b);

--- a/backend/src/utils/validation.js
+++ b/backend/src/utils/validation.js
@@ -1,0 +1,7 @@
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isUuid(value) {
+  return typeof value === 'string' && UUID_REGEX.test(value);
+}
+
+module.exports = { isUuid };

--- a/frontend/src/components/DepositModal.test.jsx
+++ b/frontend/src/components/DepositModal.test.jsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DepositModal from './DepositModal';
+
+const mockGetMyBalance = vi.fn();
+const mockGetSep24Assets = vi.fn();
+const mockStartWalletDeposit = vi.fn();
+const mockGetAnchorDepositStatus = vi.fn();
+
+vi.mock('../services/api', () => ({
+  api: {
+    getMyBalance: (...args) => mockGetMyBalance(...args),
+    getSep24Assets: (...args) => mockGetSep24Assets(...args),
+    startWalletDeposit: (...args) => mockStartWalletDeposit(...args),
+    getAnchorDepositStatus: (...args) => mockGetAnchorDepositStatus(...args),
+  },
+}));
+
+const ANCHOR = {
+  id: 'anchor-1',
+  name: 'MoneyGram',
+  available: true,
+  asset: { code: 'USDC' },
+  rails: ['bank_transfer'],
+  environment: 'testnet',
+};
+
+function setup({ balance = { USDC: 0 }, anchors = [ANCHOR] } = {}) {
+  mockGetMyBalance.mockResolvedValue({ balance });
+  mockGetSep24Assets.mockResolvedValue({ anchors });
+  const onClose = vi.fn();
+  const onSuccess = vi.fn();
+  const utils = render(<DepositModal onClose={onClose} onSuccess={onSuccess} />);
+  return { ...utils, onClose, onSuccess };
+}
+
+describe('DepositModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.open = vi.fn(() => ({ closed: false, location: {}, close: vi.fn() }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders the deposit form and auto-selects the first available anchor', async () => {
+    setup();
+
+    expect(await screen.findByText('Add Funds')).toBeInTheDocument();
+    const radio = await screen.findByRole('radio', { name: /MoneyGram/i });
+    expect(radio).toBeChecked();
+  });
+
+  it('shows the current wallet balance once loaded', async () => {
+    setup({ balance: { USDC: 42.5 } });
+
+    expect(await screen.findByText(/Current wallet balance/i)).toBeInTheDocument();
+    expect(await screen.findByText(/42.5 USDC/)).toBeInTheDocument();
+  });
+
+  it('shows a validation error for a zero or empty amount', async () => {
+    const user = userEvent.setup();
+    setup();
+
+    await screen.findByRole('radio', { name: /MoneyGram/i });
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Enter an amount greater than zero.'
+    );
+    expect(mockStartWalletDeposit).not.toHaveBeenCalled();
+  });
+
+  it('shows an error when no anchor is available', async () => {
+    const user = userEvent.setup();
+    setup({ anchors: [] });
+
+    const amountInput = await screen.findByLabelText(/Amount/i);
+    await user.type(amountInput, '10');
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'No deposit anchor is available.'
+    );
+  });
+
+  it('starts the deposit flow and transitions to the anchor phase on submit', async () => {
+    const user = userEvent.setup();
+    mockStartWalletDeposit.mockResolvedValue({
+      id: 'session-1',
+      interactive_url: 'https://anchor.example/interactive',
+      status: 'pending',
+    });
+    mockGetAnchorDepositStatus.mockResolvedValue({
+      id: 'session-1',
+      status: 'pending',
+    });
+
+    setup();
+
+    const amountInput = await screen.findByLabelText(/Amount/i);
+    await user.type(amountInput, '25');
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(await screen.findByText('Complete your deposit')).toBeInTheDocument();
+    expect(mockStartWalletDeposit).toHaveBeenCalledWith({
+      amount: '25',
+      anchor_id: 'anchor-1',
+    });
+  });
+
+  it('shows an error and returns to the form when starting the deposit fails', async () => {
+    const user = userEvent.setup();
+    mockStartWalletDeposit.mockRejectedValue(new Error('Anchor unavailable'));
+
+    setup();
+
+    const amountInput = await screen.findByLabelText(/Amount/i);
+    await user.type(amountInput, '5');
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Anchor unavailable');
+    expect(screen.getByText('Add Funds')).toBeInTheDocument();
+  });
+
+  it('polls the deposit status and calls onSuccess once completed', async () => {
+    const user = userEvent.setup();
+    mockStartWalletDeposit.mockResolvedValue({
+      id: 'session-1',
+      interactive_url: 'https://anchor.example/interactive',
+      status: 'pending',
+    });
+    mockGetAnchorDepositStatus.mockResolvedValue({
+      id: 'session-1',
+      status: 'completed',
+    });
+
+    const { onSuccess } = setup();
+
+    const amountInput = await screen.findByLabelText(/Amount/i);
+    await user.type(amountInput, '25');
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('Deposit submitted')).toBeInTheDocument();
+  });
+
+  it('surfaces a friendly error and returns to the form when the deposit fails', async () => {
+    const user = userEvent.setup();
+    mockStartWalletDeposit.mockResolvedValue({
+      id: 'session-1',
+      interactive_url: 'https://anchor.example/interactive',
+      status: 'pending',
+    });
+    mockGetAnchorDepositStatus.mockResolvedValue({
+      id: 'session-1',
+      status: 'failed',
+      last_anchor_status: 'too_small',
+    });
+
+    setup();
+
+    const amountInput = await screen.findByLabelText(/Amount/i);
+    await user.type(amountInput, '25');
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(
+      await screen.findByText('Deposit amount is below the minimum limit allowed by the partner.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Add Funds')).toBeInTheDocument();
+  });
+
+  it('calls onClose when the Cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    const { onClose } = setup();
+
+    await screen.findByRole('radio', { name: /MoneyGram/i });
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/context/AuthContext.test.jsx
+++ b/frontend/src/context/AuthContext.test.jsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AuthProvider, useAuth } from './AuthContext';
+
+const mockGetMe = vi.fn();
+const mockLogout = vi.fn();
+const mockAdminExitImpersonation = vi.fn();
+
+vi.mock('../services/api', () => ({
+  api: {
+    getMe: (...args) => mockGetMe(...args),
+    logout: (...args) => mockLogout(...args),
+    adminExitImpersonation: (...args) => mockAdminExitImpersonation(...args),
+  },
+}));
+
+const mockSetUser = vi.fn();
+vi.mock('@sentry/react', () => ({
+  setUser: (...args) => mockSetUser(...args),
+}));
+
+function Consumer() {
+  const { user, ready, login, logout, updateUser, exitImpersonation } = useAuth();
+  return (
+    <div>
+      <span data-testid="ready">{String(ready)}</span>
+      <span data-testid="user">{user ? user.email : 'none'}</span>
+      <button onClick={() => login({ id: '1', email: 'new@test.com', role: 'user' })}>
+        Login
+      </button>
+      <button onClick={() => logout()}>Logout</button>
+      <button onClick={() => updateUser({ id: '1', email: 'updated@test.com' })}>
+        Update
+      </button>
+      <button onClick={() => exitImpersonation()}>Exit impersonation</button>
+    </div>
+  );
+}
+
+function renderAuth() {
+  return render(
+    <AuthProvider>
+      <Consumer />
+    </AuthProvider>
+  );
+}
+
+describe('AuthContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sets ready and user from a valid session on mount', async () => {
+    mockGetMe.mockResolvedValue({ id: '1', email: 'a@test.com', role: 'user' });
+    renderAuth();
+
+    expect(screen.getByTestId('ready')).toHaveTextContent('false');
+
+    await waitFor(() => expect(screen.getByTestId('ready')).toHaveTextContent('true'));
+    expect(screen.getByTestId('user')).toHaveTextContent('a@test.com');
+  });
+
+  it('sets user to null when getMe returns no user data', async () => {
+    mockGetMe.mockResolvedValue(null);
+    renderAuth();
+
+    await waitFor(() => expect(screen.getByTestId('ready')).toHaveTextContent('true'));
+    expect(screen.getByTestId('user')).toHaveTextContent('none');
+  });
+
+  it('logs the session out when getMe fails with 401', async () => {
+    const error = new Error('Unauthorized');
+    error.status = 401;
+    mockGetMe.mockRejectedValue(error);
+    renderAuth();
+
+    await waitFor(() => expect(screen.getByTestId('ready')).toHaveTextContent('true'));
+    expect(screen.getByTestId('user')).toHaveTextContent('none');
+  });
+
+  it('logs the session out when getMe fails with 404 (deleted user)', async () => {
+    const error = new Error('Not found');
+    error.status = 404;
+    mockGetMe.mockRejectedValue(error);
+    renderAuth();
+
+    await waitFor(() => expect(screen.getByTestId('ready')).toHaveTextContent('true'));
+    expect(screen.getByTestId('user')).toHaveTextContent('none');
+  });
+
+  it('keeps the current user for a non-auth error (e.g. transient network failure)', async () => {
+    const error = new Error('Network error');
+    error.status = 500;
+    mockGetMe.mockRejectedValue(error);
+    renderAuth();
+
+    await waitFor(() => expect(screen.getByTestId('ready')).toHaveTextContent('true'));
+    // user stays at its initial null value; the important behavior is that
+    // a 500 does NOT force a logout the way 401/404 does
+    expect(screen.getByTestId('user')).toHaveTextContent('none');
+  });
+
+  it('login sets the user, marks ready, and reports identity to Sentry', async () => {
+    mockGetMe.mockResolvedValue(null);
+    const user = userEvent.setup();
+    renderAuth();
+
+    await waitFor(() => expect(screen.getByTestId('ready')).toHaveTextContent('true'));
+
+    await user.click(screen.getByRole('button', { name: 'Login' }));
+
+    expect(screen.getByTestId('user')).toHaveTextContent('new@test.com');
+    expect(mockSetUser).toHaveBeenCalledWith({
+      id: '1',
+      email: 'new@test.com',
+      role: 'user',
+    });
+  });
+
+  it('logout calls the API, clears the user, and clears Sentry identity', async () => {
+    mockGetMe.mockResolvedValue({ id: '1', email: 'a@test.com', role: 'user' });
+    mockLogout.mockResolvedValue({});
+    const user = userEvent.setup();
+    renderAuth();
+
+    await waitFor(() => expect(screen.getByTestId('user')).toHaveTextContent('a@test.com'));
+
+    await user.click(screen.getByRole('button', { name: 'Logout' }));
+
+    await waitFor(() => expect(screen.getByTestId('user')).toHaveTextContent('none'));
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+    expect(mockSetUser).toHaveBeenCalledWith(null);
+  });
+
+  it('logout still clears the user locally even if the API call fails', async () => {
+    mockGetMe.mockResolvedValue({ id: '1', email: 'a@test.com', role: 'user' });
+    mockLogout.mockRejectedValue(new Error('Network error'));
+    const user = userEvent.setup();
+    renderAuth();
+
+    await waitFor(() => expect(screen.getByTestId('user')).toHaveTextContent('a@test.com'));
+
+    await user.click(screen.getByRole('button', { name: 'Logout' }));
+
+    await waitFor(() => expect(screen.getByTestId('user')).toHaveTextContent('none'));
+  });
+
+  it('updateUser replaces the user without calling the API', async () => {
+    mockGetMe.mockResolvedValue({ id: '1', email: 'a@test.com', role: 'user' });
+    const user = userEvent.setup();
+    renderAuth();
+
+    await waitFor(() => expect(screen.getByTestId('user')).toHaveTextContent('a@test.com'));
+
+    await user.click(screen.getByRole('button', { name: 'Update' }));
+
+    expect(screen.getByTestId('user')).toHaveTextContent('updated@test.com');
+    expect(mockGetMe).toHaveBeenCalledTimes(1);
+  });
+
+  it('exitImpersonation calls the API and refreshes the user from the server', async () => {
+    mockGetMe.mockResolvedValueOnce({ id: '1', email: 'admin@test.com', role: 'admin' });
+    mockAdminExitImpersonation.mockResolvedValue({});
+    mockGetMe.mockResolvedValueOnce({ id: '2', email: 'real-admin@test.com', role: 'admin' });
+    const user = userEvent.setup();
+    renderAuth();
+
+    await waitFor(() => expect(screen.getByTestId('user')).toHaveTextContent('admin@test.com'));
+
+    await user.click(screen.getByRole('button', { name: 'Exit impersonation' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('user')).toHaveTextContent('real-admin@test.com')
+    );
+    expect(mockAdminExitImpersonation).toHaveBeenCalledTimes(1);
+  });
+
+  it('useAuth returns null when used outside an AuthProvider', () => {
+    function Bare() {
+      const auth = useAuth();
+      return <span data-testid="bare">{String(auth)}</span>;
+    }
+    render(<Bare />);
+    expect(screen.getByTestId('bare')).toHaveTextContent('null');
+  });
+});

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -1,10 +1,12 @@
 /* eslint-disable */
 import { useEffect, useState, useCallback, useRef } from 'react';
+import * as Sentry from '@sentry/react';
 import { api } from '../services/api';
 import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import RelativeTime from '../components/RelativeTime';
 import DisputeResolveModal from '../components/DisputeResolveModal';
+import { useToast } from '../context/ToastContext';
 
 const DISPUTE_STATUSES = [
   'open',
@@ -1192,6 +1194,7 @@ function FraudQueue() {
   const [campaigns, setCampaigns] = useState([]);
   const [stats, setStats] = useState({ false_positives: 0, true_positives: 0, false_positive_rate: 0 });
   const [loading, setLoading] = useState(true);
+  const toast = useToast();
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -1203,11 +1206,12 @@ function FraudQueue() {
       setCampaigns(cList);
       setStats(cStats);
     } catch (err) {
-      console.error('Failed to load fraud data', err);
+      toast?.('Failed to load fraud data. Please try again.', 'error');
+      Sentry.captureException(err);
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [toast]);
 
   useEffect(() => {
     load();

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { Link, useParams, useLocation, useNavigate } from 'react-router-dom';
 import DOMPurify from 'dompurify';
+import * as Sentry from '@sentry/react';
 import { api } from '../services/api';
 import { useAuth } from '../context/AuthContext';
+import { useToast } from '../context/ToastContext';
 import ContributeModal from '../components/ContributeModal';
 import RelativeTime from '../components/RelativeTime';
 import DisputeModal from '../components/DisputeModal';
@@ -284,6 +286,7 @@ export default function Campaign() {
   const location = useLocation();
   const navigate = useNavigate();
   const { user, token } = useAuth();
+  const toast = useToast();
 
   const [campaign, setCampaign] = useState(null);
   const [loadError, setLoadError] = useState('');
@@ -1365,7 +1368,8 @@ export default function Campaign() {
                 });
               } catch (err) {
                 if (err.name !== 'AbortError') {
-                  console.error('Share failed:', err);
+                  toast?.('Could not share this campaign. Please try again.', 'error');
+                  Sentry.captureException(err);
                 }
               }
             }}

--- a/frontend/src/pages/Developer.jsx
+++ b/frontend/src/pages/Developer.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 import { useAuth } from '../context/AuthContext';
+import { useToast } from '../context/ToastContext';
 import { api } from '../services/api';
 
 const EVENT_OPTIONS = [
@@ -16,6 +18,7 @@ const V1_API_BASE = `${(import.meta.env.VITE_API_BASE_URL || '').replace(/\/+$/,
 
 export default function Developer() {
   const { user } = useAuth();
+  const toast = useToast();
   const [keys, setKeys] = useState([]);
   const [hooks, setHooks] = useState([]);
   const [deliveries, setDeliveries] = useState([]);
@@ -104,7 +107,8 @@ export default function Developer() {
         setExplorerEndpoint(endpoints[0].id);
       }
     } catch (err) {
-      console.error('Failed to load OpenAPI spec', err);
+      toast?.('Failed to load API spec. Please try again.', 'error');
+      Sentry.captureException(err);
     }
   }
 


### PR DESCRIPTION
## Summary

**#489 — rate limiting on webhook ingress**
`POST /api/webhooks/incoming/:id` is public (no auth) and had no rate limiting — a DoS vector. Added a 30 req/min per-IP limiter matching the existing pattern in `routes/auth.js`.

**#490 — query parameter validation**
- `wallets.js` — two `?limit=` params now use the shared `parsePagination()` utility (previously unbounded `parseInt` without radix)
- `contributions.js` — `campaign/:campaignId` now uses `parsePagination()` too, for consistency with `campaigns.js`/`admin.js`/`withdrawals.js`/`disputes.js`
- `stellarTransactions.js` — `campaign_id` now validated as a UUID before hitting the database; `limit` now uses `parsePagination()`
- `emails.js` — `campaign_id` now validated as a UUID before use. **This surfaced a real bug**: `campaign_id` is a UUID column (`campaign_update_unsubscribes.campaign_id` references `campaigns(id)`), but the unsubscribe handler and `verifyUnsubscribeToken()` both coerced it with `Number(campaignId)`, which is always `NaN` for a UUID string — silently breaking both signature verification and the insert for every campaign-scoped unsubscribe link. Fixed to pass the UUID through unchanged.
- `disputes.js` — `evidence_url` now validated as an http(s) URL before insert

**#494 — console.error cleanup**
Replaced `console.error` with a user-facing toast + Sentry capture in the 3 flagged files (`AdminDashboard.jsx`, `Campaign.jsx`, `Developer.jsx`), matching the existing `toast?.(message, type)` / `Sentry.captureException(err)` pattern already used elsewhere in the app.

**#487 — test coverage**
Most of the pages/components this issue originally flagged (CreateCampaign, Landing, AdminDashboard, Home, Profile, MyContributions, Developer, Pricing, HowItWorks, Resources, About, MilestoneTracker, WithdrawalsSection, TransactionHistory, NotificationDropdown) already have test coverage. Added tests for the two items the issue explicitly prioritizes among what's left uncovered:
- `DepositModal` — form validation, anchor selection, deposit start/poll/success/failure flows
- `AuthContext` — session validation on mount (401/404 vs. transient errors), login/logout/updateUser/exitImpersonation, Sentry identity sync

`DisputeModal`, `Toast`, `ThankYouModal`, `ApiKeysPanel`, `ContributorDashboard`, `DisputeResolveModal`, `api.js`, `recentlyViewed.js`, and `onboarding.js` remain untested and would be good candidates for a follow-up issue — bundling all of them into this PR felt like too much unrelated surface area for one review.

## Test plan
- [x] Backend: 89 tests across all touched files pass (`node --test src/routes/{wallets,contributions,emails,disputes,stellarTransactions,webhooks}.test.js src/utils/pagination.test.js`)
- [x] Frontend: new `DepositModal.test.jsx` (9 tests) and `AuthContext.test.jsx` (11 tests) pass; existing component/context suite re-run to confirm no regressions
- [x] `eslint` clean (0 errors) on all changed/new files in both backend and frontend

closes #489
closes #490
closes #494
closes #487