### PR TITLE
adds GeoIP service in sessionService

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -76,6 +76,28 @@ KYC_REQUIRED_FOR_CAMPAIGNS=false
 # PERSONA_WEBHOOK_SECRET=
 # APP_BASE_URL=http://localhost:3001
 
+# ── GeoIP (session locations, login alerts) ──────────────
+# Resolves login IPs to city/region/country for the session list and
+# new-location alerts. Disabled by default — locations stay null.
+# Lookups are best-effort: timeouts and provider outages never block a login.
+# Misconfiguring a provider below fails startup rather than silently
+# returning null locations forever.
+# GEOIP_PROVIDER=none            # none | maxmind | ip-api | ipinfo
+# GEOIP_TIMEOUT_MS=2000          # per-lookup network timeout
+# GEOIP_CACHE_TTL_MS=86400000    # how long a resolved IP stays cached (24h)
+# GEOIP_CACHE_MAX_ENTRIES=5000   # cap on cached IPs; oldest evicted first
+#
+# maxmind — local GeoLite2 DB, no network call, best privacy.
+#   Requires the optional package: npm install maxmind
+#   Download GeoLite2-City.mmdb (free account) from maxmind.com
+# GEOIP_MAXMIND_DB_PATH=/var/lib/geoip/GeoLite2-City.mmdb
+#
+# ip-api — no key needed, but the free tier is HTTP-only (login IPs cross the
+#   network in plaintext) and capped at 45 requests/minute per source IP.
+#
+# ipinfo — HTTPS, requires a token; sent as a bearer header, not a query param.
+# GEOIP_IPINFO_TOKEN=
+
 # ── Anchor / SEP-24 (fiat on-ramp) ───────────────────────
 # ANCHOR_WALLET_HOME_DOMAIN=
 # ANCHOR_WALLET_SIGNING_SECRET=

--- a/backend/db/migrations/20260727_session_location_region.sql
+++ b/backend/db/migrations/20260727_session_location_region.sql
@@ -1,0 +1,10 @@
+-- GeoIP region/subdivision for session and login records (Issue #493)
+--
+-- The GeoIP providers all return a subdivision (state/region) alongside city
+-- and country. Storing it lets the session UI disambiguate same-named cities
+-- and gives fraud review a coarser signal than city without dropping to
+-- country level.
+
+ALTER TABLE user_sessions ADD COLUMN IF NOT EXISTS location_region TEXT;
+ALTER TABLE login_attempts ADD COLUMN IF NOT EXISTS location_region TEXT;
+ALTER TABLE login_alerts ADD COLUMN IF NOT EXISTS location_region TEXT;

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -1,4 +1,5 @@
 const { validateWalletSecretConfig } = require('../services/walletSecrets');
+const { validateGeoipConfig } = require('../services/geoipService');
 
 const REQUIRED = [
   'DATABASE_URL',
@@ -79,6 +80,13 @@ function validateEnv() {
 
   try {
     validateWalletSecretConfig();
+  } catch (err) {
+    process.stderr.write(`\n[crowdpay] Cannot start: ${err.message}\n\n`);
+    process.exit(1);
+  }
+
+  try {
+    validateGeoipConfig();
   } catch (err) {
     process.stderr.write(`\n[crowdpay] Cannot start: ${err.message}\n\n`);
     process.exit(1);

--- a/backend/src/services/geoipService.js
+++ b/backend/src/services/geoipService.js
@@ -1,0 +1,475 @@
+const net = require('net');
+const fs = require('fs');
+const logger = require('../config/logger');
+
+/**
+ * IP geolocation with pluggable providers.
+ *
+ * Configured entirely through environment variables (see .env.example):
+ *   GEOIP_PROVIDER          none (default) | maxmind | ip-api | ipinfo
+ *   GEOIP_TIMEOUT_MS        per-lookup network timeout (default 2000)
+ *   GEOIP_CACHE_TTL_MS      how long a resolved IP stays cached (default 24h)
+ *   GEOIP_CACHE_MAX_ENTRIES cap on cached IPs (default 5000)
+ *   GEOIP_MAXMIND_DB_PATH   path to a GeoLite2-City.mmdb file (maxmind only)
+ *   GEOIP_IPINFO_TOKEN      ipinfo.io API token (ipinfo only)
+ *
+ * Every lookup is best-effort and fails open: an unset provider, a private IP,
+ * a timeout, or a provider outage all resolve to null fields rather than
+ * throwing, so geolocation can never block a login.
+ */
+
+const DEFAULT_TIMEOUT_MS = 2000;
+const DEFAULT_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_CACHE_MAX_ENTRIES = 5000;
+const MAX_FIELD_LENGTH = 100;
+
+// After this many consecutive failures the provider is skipped entirely for
+// COOLDOWN_MS, so a down or slow provider costs one timeout instead of one per
+// login.
+const FAILURE_THRESHOLD = 5;
+const COOLDOWN_MS = 60_000;
+
+const EMPTY_LOCATION = Object.freeze({ country: null, region: null, city: null });
+
+// A Map rather than an object literal: the provider name comes from the
+// environment, and an object would resolve inherited keys such as
+// "constructor" to a truthy value and skip the unknown-provider warning.
+const PROVIDER_ALIASES = new Map([
+  ['', 'none'],
+  ['none', 'none'],
+  ['off', 'none'],
+  ['disabled', 'none'],
+  ['maxmind', 'maxmind'],
+  ['geolite2', 'maxmind'],
+  ['ip-api', 'ip-api'],
+  ['ipapi', 'ip-api'],
+  ['ip-api.com', 'ip-api'],
+  ['ipinfo', 'ipinfo'],
+  ['ipinfo.io', 'ipinfo'],
+]);
+
+const SUPPORTED_PROVIDERS = ['none', 'maxmind', 'ip-api', 'ipinfo'];
+
+const MAXMIND_PACKAGE_MISSING =
+  "GEOIP_PROVIDER=maxmind requires the optional 'maxmind' package — install it with: npm install maxmind";
+
+let consecutiveFailures = 0;
+let cooldownUntil = 0;
+let maxmindReaderPromise = null;
+let maxmindReaderPath = null;
+const warnedProviders = new Set();
+
+/**
+ * Resolved locations, keyed by normalized IP.
+ *
+ * Deliberately local and bounded rather than the shared `utils/cache`: these
+ * keys come from unauthenticated login attempts, so an attacker rotating
+ * source addresses controls the key space. The shared cache has no ceiling
+ * and only drops expired entries when the same key is read again, which would
+ * let that Map grow without limit. Map preserves insertion order, so evicting
+ * the first key evicts the least recently used one.
+ */
+const locationCache = new Map();
+
+/** In-flight lookups, keyed by normalized IP, so bursts collapse to one call. */
+const inFlight = new Map();
+
+function cacheGet(ip) {
+  const entry = locationCache.get(ip);
+  if (!entry) return undefined;
+
+  if (Date.now() > entry.expiresAt) {
+    locationCache.delete(ip);
+    return undefined;
+  }
+
+  // Map iterates in insertion order, so re-inserting on read is what makes
+  // eviction least-recently-used rather than oldest-first.
+  locationCache.delete(ip);
+  locationCache.set(ip, entry);
+  return entry.location;
+}
+
+function cacheSet(ip, location, ttlMs, maxEntries) {
+  locationCache.delete(ip);
+  locationCache.set(ip, { location, expiresAt: Date.now() + ttlMs });
+
+  while (locationCache.size > maxEntries) {
+    const oldest = locationCache.keys().next().value;
+    locationCache.delete(oldest);
+  }
+}
+
+function positiveInt(raw, fallback) {
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+/**
+ * Read configuration on every lookup so env changes take effect without a
+ * restart and tests can flip providers between cases.
+ */
+function readConfig() {
+  const raw = String(process.env.GEOIP_PROVIDER || '').trim().toLowerCase();
+  const provider = PROVIDER_ALIASES.get(raw);
+
+  if (!provider && !warnedProviders.has(raw)) {
+    warnedProviders.add(raw);
+    logger.warn('Unknown GEOIP_PROVIDER — GeoIP lookups are disabled', {
+      provider: raw,
+      supported: SUPPORTED_PROVIDERS,
+    });
+  }
+
+  return {
+    provider: provider || 'none',
+    timeoutMs: positiveInt(process.env.GEOIP_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
+    cacheTtlMs: positiveInt(process.env.GEOIP_CACHE_TTL_MS, DEFAULT_CACHE_TTL_MS),
+    cacheMaxEntries: positiveInt(process.env.GEOIP_CACHE_MAX_ENTRIES, DEFAULT_CACHE_MAX_ENTRIES),
+    maxmindDbPath: String(process.env.GEOIP_MAXMIND_DB_PATH || '').trim(),
+    ipinfoToken: String(process.env.GEOIP_IPINFO_TOKEN || '').trim(),
+  };
+}
+
+/**
+ * Reduce an address to a bare IP literal, or null if it is not one.
+ * Handles the forms Express hands back: IPv4-mapped IPv6 on dual-stack
+ * sockets, bracketed IPv6, zone indexes, host:port pairs, and XFF chains.
+ * @param {string} value
+ * @returns {string|null}
+ */
+function normalizeIp(value) {
+  if (typeof value !== 'string') return null;
+  let ip = value.trim();
+  if (!ip) return null;
+
+  // X-Forwarded-For chain — the client is the left-most entry.
+  if (ip.includes(',')) ip = ip.split(',')[0].trim();
+
+  const bracketed = /^\[([^\]]+)\](?::\d+)?$/.exec(ip);
+  if (bracketed) ip = bracketed[1];
+
+  const zoneIndex = ip.indexOf('%');
+  if (zoneIndex !== -1) ip = ip.slice(0, zoneIndex);
+
+  const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(ip);
+  if (mapped) ip = mapped[1];
+
+  const withPort = /^(\d{1,3}(?:\.\d{1,3}){3}):\d+$/.exec(ip);
+  if (withPort) ip = withPort[1];
+
+  return net.isIP(ip) ? ip : null;
+}
+
+function isPrivateIpv4(ip) {
+  const [a, b] = ip.split('.').map(Number);
+  if (a === 0 || a === 10 || a === 127) return true; // this-network, private, loopback
+  if (a === 169 && b === 254) return true; // link-local
+  if (a === 172 && b >= 16 && b <= 31) return true; // private
+  if (a === 192 && b === 168) return true; // private
+  if (a === 100 && b >= 64 && b <= 127) return true; // carrier-grade NAT
+  if (a >= 224) return true; // multicast, reserved, broadcast
+  return false;
+}
+
+function isPrivateIpv6(ip) {
+  const lower = ip.toLowerCase();
+  if (lower === '::' || lower === '::1') return true; // unspecified, loopback
+  if (/^f[cd]/.test(lower)) return true; // fc00::/7 unique local
+  if (/^fe[89ab]/.test(lower)) return true; // fe80::/10 link-local
+  if (lower.startsWith('ff')) return true; // ff00::/8 multicast
+  return false;
+}
+
+/**
+ * True only for globally routable addresses. Reserved ranges are never sent to
+ * an external provider — it wastes a round trip and leaks internal topology.
+ * @param {string} ip - A normalized IP literal
+ * @returns {boolean}
+ */
+function isPublicIp(ip) {
+  const family = net.isIP(ip);
+  if (family === 4) return !isPrivateIpv4(ip);
+  if (family === 6) return !isPrivateIpv6(ip);
+  return false;
+}
+
+/**
+ * Provider responses are untrusted input bound for TEXT columns and the
+ * session UI: strip control characters, collapse whitespace, cap length.
+ */
+function cleanField(value) {
+  if (typeof value !== 'string') return null;
+  // eslint-disable-next-line no-control-regex
+  const cleaned = value.replace(/[\u0000-\u001f\u007f]/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!cleaned) return null;
+  return cleaned.slice(0, MAX_FIELD_LENGTH);
+}
+
+function toLocation({ country, region, city }) {
+  return {
+    country: cleanField(country),
+    region: cleanField(region),
+    city: cleanField(city),
+  };
+}
+
+async function fetchJson(url, { timeoutMs, headers = {} }) {
+  const response = await fetch(url, {
+    headers: { Accept: 'application/json', ...headers },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * ip-api.com — free tier needs no key but is HTTP-only and capped at
+ * 45 requests/minute per source IP. See https://ip-api.com/docs/api:json
+ */
+async function lookupWithIpApi(ip, config) {
+  const body = await fetchJson(
+    `http://ip-api.com/json/${encodeURIComponent(ip)}?fields=status,message,countryCode,regionName,city`,
+    { timeoutMs: config.timeoutMs }
+  );
+
+  // A `fail` status is a definitive answer from a healthy provider (unknown or
+  // reserved address), not an outage — return empty rather than counting it
+  // against the circuit breaker.
+  if (body?.status !== 'success') {
+    logger.debug('GeoIP lookup returned no result', { provider: 'ip-api', reason: body?.message });
+    return EMPTY_LOCATION;
+  }
+
+  return toLocation({ country: body.countryCode, region: body.regionName, city: body.city });
+}
+
+/**
+ * ipinfo.io — token sent as a bearer header rather than a query parameter so
+ * it stays out of proxy and access logs.
+ */
+async function lookupWithIpinfo(ip, config) {
+  if (!config.ipinfoToken) {
+    throw new Error('GEOIP_IPINFO_TOKEN is not set');
+  }
+
+  const body = await fetchJson(`https://ipinfo.io/${encodeURIComponent(ip)}/json`, {
+    timeoutMs: config.timeoutMs,
+    headers: { Authorization: `Bearer ${config.ipinfoToken}` },
+  });
+
+  // ipinfo flags reserved ranges as bogons and omits the location fields.
+  if (body?.bogon) return EMPTY_LOCATION;
+
+  return toLocation({ country: body?.country, region: body?.region, city: body?.city });
+}
+
+/**
+ * Map a MaxMind GeoLite2-City record to a location.
+ * @param {object|null} record - Raw record from the mmdb reader
+ * @returns {{country: string|null, region: string|null, city: string|null}}
+ */
+function mapMaxmindRecord(record) {
+  if (!record) return EMPTY_LOCATION;
+
+  return toLocation({
+    country: record.country?.iso_code || record.registered_country?.iso_code,
+    region: record.subdivisions?.[0]?.names?.en,
+    city: record.city?.names?.en,
+  });
+}
+
+/**
+ * The `maxmind` package is an optional peer: it is only required when the
+ * provider is actually selected, so installs that use a hosted provider (or
+ * none) do not pay for it. The opened reader is memoized per database path.
+ */
+function getMaxmindReader(dbPath) {
+  if (maxmindReaderPromise && maxmindReaderPath === dbPath) {
+    return maxmindReaderPromise;
+  }
+
+  maxmindReaderPath = dbPath;
+  maxmindReaderPromise = (async () => {
+    let maxmind;
+    try {
+      maxmind = require('maxmind');
+    } catch {
+      throw new Error(MAXMIND_PACKAGE_MISSING);
+    }
+    return maxmind.open(dbPath);
+  })();
+
+  // Allow a later lookup to retry a failed open (missing package, bad path).
+  maxmindReaderPromise.catch(() => {
+    maxmindReaderPromise = null;
+    maxmindReaderPath = null;
+  });
+
+  return maxmindReaderPromise;
+}
+
+async function lookupWithMaxmind(ip, config) {
+  if (!config.maxmindDbPath) {
+    throw new Error('GEOIP_MAXMIND_DB_PATH is not set');
+  }
+
+  const reader = await getMaxmindReader(config.maxmindDbPath);
+  return mapMaxmindRecord(reader.get(ip));
+}
+
+const PROVIDERS = {
+  maxmind: lookupWithMaxmind,
+  'ip-api': lookupWithIpApi,
+  ipinfo: lookupWithIpinfo,
+};
+
+function noteFailure(provider, err) {
+  consecutiveFailures += 1;
+
+  if (consecutiveFailures >= FAILURE_THRESHOLD) {
+    cooldownUntil = Date.now() + COOLDOWN_MS;
+    consecutiveFailures = 0;
+    logger.warn('GeoIP provider paused after repeated failures', {
+      provider,
+      cooldownMs: COOLDOWN_MS,
+      error: err.message,
+    });
+    return;
+  }
+
+  logger.warn('GeoIP lookup failed', { provider, error: err.message });
+}
+
+/**
+ * Ask the provider and cache the answer. Never rejects — callers sharing this
+ * promise through `inFlight` all receive the fail-open result.
+ */
+async function resolveAndCache(ip, config) {
+  try {
+    const location = await PROVIDERS[config.provider](ip, config);
+    consecutiveFailures = 0;
+    cacheSet(ip, location, config.cacheTtlMs, config.cacheMaxEntries);
+    return location;
+  } catch (err) {
+    noteFailure(config.provider, err);
+    return EMPTY_LOCATION;
+  }
+}
+
+/**
+ * Resolve an IP address to a coarse location.
+ * @param {string} rawIp - IP address, in any form Express reports
+ * @returns {Promise<{country: string|null, region: string|null, city: string|null}>}
+ */
+function lookupIp(rawIp) {
+  const config = readConfig();
+  if (config.provider === 'none') return Promise.resolve(EMPTY_LOCATION);
+
+  const ip = normalizeIp(rawIp);
+  if (!ip || !isPublicIp(ip)) return Promise.resolve(EMPTY_LOCATION);
+
+  const cached = cacheGet(ip);
+  if (cached) return Promise.resolve(cached);
+
+  if (Date.now() < cooldownUntil) return Promise.resolve(EMPTY_LOCATION);
+
+  // Collapse concurrent lookups of the same address into a single provider
+  // call — a login burst from one NAT would otherwise blow a rate limit.
+  const pending = inFlight.get(ip);
+  if (pending) return pending;
+
+  const promise = resolveAndCache(ip, config).finally(() => inFlight.delete(ip));
+  inFlight.set(ip, promise);
+  return promise;
+}
+
+/**
+ * Whether a GeoIP provider is configured.
+ * @returns {boolean}
+ */
+function isGeoipEnabled() {
+  return readConfig().provider !== 'none';
+}
+
+/**
+ * Validate GeoIP configuration at startup.
+ *
+ * Lookups fail open by design, which means a misconfigured provider is
+ * invisible at runtime — it just returns nulls forever. Failing at boot
+ * instead surfaces the mistake while someone is still watching.
+ *
+ * @throws {Error} when a provider is selected but cannot possibly work
+ */
+function validateGeoipConfig() {
+  const raw = String(process.env.GEOIP_PROVIDER || '').trim().toLowerCase();
+  if (!PROVIDER_ALIASES.has(raw)) {
+    throw new Error(
+      `Unsupported GEOIP_PROVIDER: ${JSON.stringify(raw)} (supported: ${SUPPORTED_PROVIDERS.join(', ')})`
+    );
+  }
+
+  for (const key of ['GEOIP_TIMEOUT_MS', 'GEOIP_CACHE_TTL_MS', 'GEOIP_CACHE_MAX_ENTRIES']) {
+    const value = process.env[key];
+    if (value && value.length > 0) {
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error(`${key} must be a positive number (received: ${JSON.stringify(value)})`);
+      }
+    }
+  }
+
+  const provider = PROVIDER_ALIASES.get(raw);
+  if (provider === 'none') return;
+
+  if (provider === 'maxmind') {
+    const dbPath = String(process.env.GEOIP_MAXMIND_DB_PATH || '').trim();
+    if (!dbPath) {
+      throw new Error('GEOIP_MAXMIND_DB_PATH is required for GEOIP_PROVIDER=maxmind');
+    }
+    if (!fs.existsSync(dbPath)) {
+      throw new Error(`GEOIP_MAXMIND_DB_PATH does not exist: ${dbPath}`);
+    }
+    try {
+      require('maxmind');
+    } catch {
+      throw new Error(MAXMIND_PACKAGE_MISSING);
+    }
+    return;
+  }
+
+  if (provider === 'ipinfo' && !String(process.env.GEOIP_IPINFO_TOKEN || '').trim()) {
+    throw new Error('GEOIP_IPINFO_TOKEN is required for GEOIP_PROVIDER=ipinfo');
+  }
+}
+
+/**
+ * Drop cached lookups, the failure counter, and any open MaxMind reader.
+ * Used by tests and available for operational recovery after reconfiguring.
+ */
+function resetGeoipState() {
+  locationCache.clear();
+  inFlight.clear();
+  consecutiveFailures = 0;
+  cooldownUntil = 0;
+  maxmindReaderPromise = null;
+  maxmindReaderPath = null;
+  warnedProviders.clear();
+}
+
+module.exports = {
+  lookupIp,
+  isGeoipEnabled,
+  validateGeoipConfig,
+  normalizeIp,
+  isPublicIp,
+  mapMaxmindRecord,
+  resetGeoipState,
+  EMPTY_LOCATION,
+  FAILURE_THRESHOLD,
+  DEFAULT_CACHE_MAX_ENTRIES,
+};

--- a/backend/src/services/geoipService.test.js
+++ b/backend/src/services/geoipService.test.js
@@ -1,0 +1,462 @@
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const geoip = require('./geoipService');
+const {
+  lookupIp,
+  isGeoipEnabled,
+  validateGeoipConfig,
+  normalizeIp,
+  isPublicIp,
+  mapMaxmindRecord,
+  resetGeoipState,
+  FAILURE_THRESHOLD,
+} = geoip;
+
+const PUBLIC_IP = '203.0.113.5';
+const GEOIP_VARS = [
+  'GEOIP_PROVIDER',
+  'GEOIP_TIMEOUT_MS',
+  'GEOIP_CACHE_TTL_MS',
+  'GEOIP_CACHE_MAX_ENTRIES',
+  'GEOIP_MAXMIND_DB_PATH',
+  'GEOIP_IPINFO_TOKEN',
+];
+
+const originalEnv = {};
+const originalFetch = global.fetch;
+
+/** Replace global fetch with a recording stub. */
+function stubFetch(impl) {
+  const calls = [];
+  global.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return impl(url, options);
+  };
+  return calls;
+}
+
+function jsonResponse(body, { ok = true, status = 200 } = {}) {
+  return { ok, status, statusText: 'stubbed', json: async () => body };
+}
+
+beforeEach(() => {
+  for (const key of GEOIP_VARS) {
+    originalEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  resetGeoipState();
+});
+
+afterEach(() => {
+  for (const key of GEOIP_VARS) {
+    if (originalEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = originalEnv[key];
+  }
+  global.fetch = originalFetch;
+  resetGeoipState();
+});
+
+test('normalizeIp reduces the address forms Express reports', () => {
+  assert.equal(normalizeIp('203.0.113.5'), '203.0.113.5');
+  assert.equal(normalizeIp('  203.0.113.5  '), '203.0.113.5');
+  assert.equal(normalizeIp('::ffff:203.0.113.5'), '203.0.113.5', 'IPv4-mapped IPv6');
+  assert.equal(normalizeIp('203.0.113.5:44321'), '203.0.113.5', 'host:port');
+  assert.equal(normalizeIp('[2001:db8::1]:443'), '2001:db8::1', 'bracketed IPv6 with port');
+  assert.equal(normalizeIp('fe80::1%eth0'), 'fe80::1', 'zone index');
+  assert.equal(normalizeIp('203.0.113.5, 70.41.3.18'), '203.0.113.5', 'XFF chain takes the client');
+});
+
+test('normalizeIp rejects anything that is not an IP literal', () => {
+  assert.equal(normalizeIp('not-an-ip'), null);
+  assert.equal(normalizeIp('999.999.999.999'), null);
+  assert.equal(normalizeIp(''), null);
+  assert.equal(normalizeIp(null), null);
+  assert.equal(normalizeIp(undefined), null);
+  assert.equal(normalizeIp(12345), null);
+});
+
+test('isPublicIp excludes reserved IPv4 and IPv6 ranges', () => {
+  for (const ip of [
+    '127.0.0.1',
+    '10.1.2.3',
+    '172.16.0.1',
+    '172.31.255.255',
+    '192.168.1.1',
+    '169.254.10.1',
+    '100.64.0.1',
+    '0.0.0.0',
+    '239.1.1.1',
+    '::1',
+    '::',
+    'fd00::1',
+    'fe80::1',
+    'ff02::1',
+  ]) {
+    assert.equal(isPublicIp(ip), false, `${ip} should be private`);
+  }
+
+  for (const ip of ['203.0.113.5', '8.8.8.8', '172.32.0.1', '2001:db8::1']) {
+    assert.equal(isPublicIp(ip), true, `${ip} should be public`);
+  }
+});
+
+test('lookups are disabled unless a provider is configured', async () => {
+  const calls = stubFetch(() => jsonResponse({}));
+
+  assert.equal(isGeoipEnabled(), false);
+  assert.deepEqual(await lookupIp(PUBLIC_IP), { country: null, region: null, city: null });
+  assert.equal(calls.length, 0, 'no provider should be contacted');
+});
+
+test('an unrecognized provider disables lookups instead of throwing', async () => {
+  process.env.GEOIP_PROVIDER = 'not-a-provider';
+  const calls = stubFetch(() => jsonResponse({}));
+
+  assert.equal(isGeoipEnabled(), false);
+  assert.deepEqual(await lookupIp(PUBLIC_IP), { country: null, region: null, city: null });
+  assert.equal(calls.length, 0);
+});
+
+test('provider names inherited from Object.prototype are not treated as providers', async () => {
+  const calls = stubFetch(() => jsonResponse({}));
+
+  // A plain object would resolve these to inherited members and report the
+  // provider as configured while every lookup silently failed.
+  for (const value of ['constructor', 'toString', 'valueOf', 'hasOwnProperty', '__proto__']) {
+    process.env.GEOIP_PROVIDER = value;
+    resetGeoipState();
+
+    assert.equal(isGeoipEnabled(), false, `${value} should not enable lookups`);
+    assert.deepEqual(await lookupIp(PUBLIC_IP), { country: null, region: null, city: null });
+    assert.throws(() => validateGeoipConfig(), /Unsupported GEOIP_PROVIDER/);
+  }
+
+  assert.equal(calls.length, 0);
+});
+
+test('private and malformed IPs never reach the provider', async () => {
+  process.env.GEOIP_PROVIDER = 'ip-api';
+  const calls = stubFetch(() => jsonResponse({ status: 'success', countryCode: 'US' }));
+
+  for (const ip of ['127.0.0.1', '::1', '192.168.0.10', '::ffff:10.0.0.1', 'garbage', null]) {
+    assert.deepEqual(await lookupIp(ip), { country: null, region: null, city: null });
+  }
+
+  assert.equal(calls.length, 0);
+});
+
+test('ip-api response maps to country/region/city', async () => {
+  process.env.GEOIP_PROVIDER = 'ip-api';
+  const calls = stubFetch(() =>
+    jsonResponse({
+      status: 'success',
+      countryCode: 'US',
+      regionName: 'California',
+      city: 'San Francisco',
+    })
+  );
+
+  assert.deepEqual(await lookupIp(PUBLIC_IP), {
+    country: 'US',
+    region: 'California',
+    city: 'San Francisco',
+  });
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].url, /^http:\/\/ip-api\.com\/json\/203\.0\.113\.5\?/);
+});
+
+test('ip-api failure status resolves to nulls without tripping the breaker', async () => {
+  process.env.GEOIP_PROVIDER = 'ip-api';
+  stubFetch(() => jsonResponse({ status: 'fail', message: 'reserved range' }));
+
+  assert.deepEqual(await lookupIp(PUBLIC_IP), { country: null, region: null, city: null });
+});
+
+test('ipinfo sends its token as a bearer header, never in the URL', async () => {
+  process.env.GEOIP_PROVIDER = 'ipinfo';
+  process.env.GEOIP_IPINFO_TOKEN = 'secret-token';
+  const calls = stubFetch(() =>
+    jsonResponse({ country: 'DE', region: 'Berlin', city: 'Berlin' })
+  );
+
+  assert.deepEqual(await lookupIp(PUBLIC_IP), {
+    country: 'DE',
+    region: 'Berlin',
+    city: 'Berlin',
+  });
+  assert.equal(calls[0].url, 'https://ipinfo.io/203.0.113.5/json');
+  assert.doesNotMatch(calls[0].url, /secret-token/);
+  assert.equal(calls[0].options.headers.Authorization, 'Bearer secret-token');
+});
+
+test('ipinfo bogon responses resolve to nulls', async () => {
+  process.env.GEOIP_PROVIDER = 'ipinfo';
+  process.env.GEOIP_IPINFO_TOKEN = 'secret-token';
+  stubFetch(() => jsonResponse({ ip: PUBLIC_IP, bogon: true }));
+
+  assert.deepEqual(await lookupIp(PUBLIC_IP), { country: null, region: null, city: null });
+});
+
+test('ipinfo without a token fails open rather than calling the API', async () => {
+  process.env.GEOIP_PROVIDER = 'ipinfo';
+  const calls = stubFetch(() => jsonResponse({ country: 'DE' }));
+
+  assert.deepEqual(await lookupIp(PUBLIC_IP), { country: null, region: null, city: null });
+  assert.equal(calls.length, 0);
+});
+
+test('provider fields are trimmed, stripped of control characters, and capped', async () => {
+  process.env.GEOIP_PROVIDER = 'ip-api';
+  stubFetch(() =>
+    jsonResponse({
+      status: 'success',
+      countryCode: '  US \n',
+      regionName: `Cali${String.fromCharCode(7)}fornia`,
+      city: 'x'.repeat(250),
+    })
+  );
+
+  const location = await lookupIp(PUBLIC_IP);
+  assert.equal(location.country, 'US');
+  assert.equal(location.region, 'Cali fornia');
+  assert.equal(location.city.length, 100);
+});
+
+test('missing provider fields become null rather than undefined', async () => {
+  process.env.GEOIP_PROVIDER = 'ip-api';
+  stubFetch(() => jsonResponse({ status: 'success', countryCode: 'JP' }));
+
+  assert.deepEqual(await lookupIp(PUBLIC_IP), { country: 'JP', region: null, city: null });
+});
+
+test('resolved IPs are cached, so repeat logins cost one lookup', async () => {
+  process.env.GEOIP_PROVIDER = 'ip-api';
+  const calls = stubFetch(() =>
+    jsonResponse({ status: 'success', countryCode: 'US', city: 'Denver' })
+  );
+
+  const first = await lookupIp(PUBLIC_IP);
+  const second = await lookupIp(`::ffff:${PUBLIC_IP}`);
+
+  assert.deepEqual(second, first);
+  assert.equal(calls.length, 1, 'the second lookup should be served from cache');
+});
+
+test('HTTP errors fail open', async () => {
+  process.env.GEOIP_PROVIDER = 'ip-api';
+  stubFetch(() => jsonResponse({}, { ok: false, status: 429 }));
+
+  assert.deepEqual(await lookupIp(PUBLIC_IP), { country: null, region: null, city: null });
+});
+
+test('network errors and timeouts fail open', async () => {
+  process.env.GEOIP_PROVIDER = 'ip-api';
+  stubFetch(() => {
+    throw Object.assign(new Error('The operation was aborted'), { name: 'TimeoutError' });
+  });
+
+  assert.deepEqual(await lookupIp(PUBLIC_IP), { country: null, region: null, city: null });
+});
+
+test('the circuit breaker stops calling a provider that keeps failing', async () => {
+  process.env.GEOIP_PROVIDER = 'ip-api';
+  const calls = stubFetch(() => {
+    throw new Error('connect ECONNREFUSED');
+  });
+
+  // Distinct IPs so the cache never short-circuits the call.
+  for (let i = 0; i < FAILURE_THRESHOLD; i += 1) {
+    await lookupIp(`203.0.113.${i + 10}`);
+  }
+  assert.equal(calls.length, FAILURE_THRESHOLD);
+
+  await lookupIp('198.51.100.7');
+  assert.equal(calls.length, FAILURE_THRESHOLD, 'further lookups should be skipped during cooldown');
+});
+
+test('a success resets the failure count before the breaker trips', async () => {
+  process.env.GEOIP_PROVIDER = 'ip-api';
+  let shouldFail = true;
+  const calls = stubFetch(() => {
+    if (shouldFail) throw new Error('transient');
+    return jsonResponse({ status: 'success', countryCode: 'FR' });
+  });
+
+  for (let i = 0; i < FAILURE_THRESHOLD - 1; i += 1) {
+    await lookupIp(`203.0.113.${i + 10}`);
+  }
+
+  shouldFail = false;
+  assert.deepEqual(await lookupIp('198.51.100.7'), { country: 'FR', region: null, city: null });
+
+  shouldFail = true;
+  await lookupIp('198.51.100.8');
+  assert.equal(calls.length, FAILURE_THRESHOLD + 1, 'breaker should not have tripped');
+});
+
+test('maxmind records map country, first subdivision, and city', () => {
+  assert.deepEqual(
+    mapMaxmindRecord({
+      country: { iso_code: 'GB' },
+      subdivisions: [{ names: { en: 'England' } }, { names: { en: 'Greater London' } }],
+      city: { names: { en: 'London' } },
+    }),
+    { country: 'GB', region: 'England', city: 'London' }
+  );
+});
+
+test('maxmind records fall back to registered country and tolerate gaps', () => {
+  assert.deepEqual(mapMaxmindRecord({ registered_country: { iso_code: 'NG' } }), {
+    country: 'NG',
+    region: null,
+    city: null,
+  });
+  assert.deepEqual(mapMaxmindRecord(null), { country: null, region: null, city: null });
+  assert.deepEqual(mapMaxmindRecord({}), { country: null, region: null, city: null });
+});
+
+test('maxmind without a database path fails open', async () => {
+  process.env.GEOIP_PROVIDER = 'maxmind';
+
+  assert.equal(isGeoipEnabled(), true);
+  assert.deepEqual(await lookupIp(PUBLIC_IP), { country: null, region: null, city: null });
+});
+
+test('maxmind with an unreadable database fails open', async () => {
+  process.env.GEOIP_PROVIDER = 'maxmind';
+  process.env.GEOIP_MAXMIND_DB_PATH = '/nonexistent/GeoLite2-City.mmdb';
+
+  assert.deepEqual(await lookupIp(PUBLIC_IP), { country: null, region: null, city: null });
+});
+
+test('concurrent lookups of one IP collapse into a single provider call', async () => {
+  process.env.GEOIP_PROVIDER = 'ip-api';
+  const calls = stubFetch(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    return jsonResponse({ status: 'success', countryCode: 'US', city: 'Denver' });
+  });
+
+  const results = await Promise.all(Array.from({ length: 25 }, () => lookupIp(PUBLIC_IP)));
+
+  assert.equal(calls.length, 1, '25 concurrent lookups should share one call');
+  for (const result of results) {
+    assert.deepEqual(result, { country: 'US', region: null, city: 'Denver' });
+  }
+});
+
+test('concurrent lookups of different IPs are not collapsed', async () => {
+  process.env.GEOIP_PROVIDER = 'ip-api';
+  const calls = stubFetch(async (url) => {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    return jsonResponse({ status: 'success', countryCode: url.includes('198.51.100') ? 'FR' : 'US' });
+  });
+
+  const [a, b] = await Promise.all([lookupIp(PUBLIC_IP), lookupIp('198.51.100.7')]);
+
+  assert.equal(calls.length, 2);
+  assert.equal(a.country, 'US');
+  assert.equal(b.country, 'FR');
+});
+
+test('a shared in-flight lookup is released so later lookups still work', async () => {
+  process.env.GEOIP_PROVIDER = 'ip-api';
+  let failNext = true;
+  const calls = stubFetch(async () => {
+    if (failNext) throw new Error('transient');
+    return jsonResponse({ status: 'success', countryCode: 'US' });
+  });
+
+  // Two concurrent callers share one failing lookup; nothing is cached.
+  const failed = await Promise.all([lookupIp(PUBLIC_IP), lookupIp(PUBLIC_IP)]);
+  assert.equal(calls.length, 1);
+  for (const result of failed) {
+    assert.deepEqual(result, { country: null, region: null, city: null });
+  }
+
+  failNext = false;
+  assert.deepEqual(await lookupIp(PUBLIC_IP), { country: 'US', region: null, city: null });
+  assert.equal(calls.length, 2, 'a failed lookup must not be cached or stuck in flight');
+});
+
+test('the cache is bounded, evicting the least recently used IP', async () => {
+  process.env.GEOIP_PROVIDER = 'ip-api';
+  process.env.GEOIP_CACHE_MAX_ENTRIES = '3';
+  const calls = stubFetch((url) =>
+    jsonResponse({ status: 'success', countryCode: 'US', city: url })
+  );
+
+  // Fill the cache to its limit.
+  await lookupIp('198.51.100.1');
+  await lookupIp('198.51.100.2');
+  await lookupIp('198.51.100.3');
+  assert.equal(calls.length, 3);
+
+  // Touch .1 so .2 becomes the least recently used entry.
+  await lookupIp('198.51.100.1');
+  assert.equal(calls.length, 3, 'that lookup should have been a cache hit');
+
+  // A fourth distinct IP evicts .2, not .1.
+  await lookupIp('198.51.100.4');
+  assert.equal(calls.length, 4);
+
+  await lookupIp('198.51.100.1');
+  assert.equal(calls.length, 4, '.1 should still be cached');
+
+  await lookupIp('198.51.100.2');
+  assert.equal(calls.length, 5, '.2 should have been evicted');
+});
+
+test('cache growth stays bounded under rotating attacker-controlled IPs', async () => {
+  process.env.GEOIP_PROVIDER = 'ip-api';
+  process.env.GEOIP_CACHE_MAX_ENTRIES = '50';
+  stubFetch(() => jsonResponse({ status: 'success', countryCode: 'US' }));
+
+  for (let i = 0; i < 500; i += 1) {
+    await lookupIp(`198.51.${Math.floor(i / 256)}.${i % 256}`);
+  }
+
+  // The 51st distinct IP evicted the 1st, so the earliest entries are gone
+  // and must be re-fetched rather than served from an ever-growing map.
+  const recheck = stubFetch(() => jsonResponse({ status: 'success', countryCode: 'US' }));
+  await lookupIp('198.51.0.0');
+  assert.equal(recheck.length, 1, 'the oldest entry should have been evicted');
+});
+
+test('validateGeoipConfig accepts an unset or disabled provider', () => {
+  assert.doesNotThrow(() => validateGeoipConfig());
+
+  process.env.GEOIP_PROVIDER = 'none';
+  assert.doesNotThrow(() => validateGeoipConfig());
+});
+
+test('validateGeoipConfig rejects a provider that cannot work', () => {
+  process.env.GEOIP_PROVIDER = 'ipinfo';
+  assert.throws(() => validateGeoipConfig(), /GEOIP_IPINFO_TOKEN is required/);
+
+  process.env.GEOIP_IPINFO_TOKEN = 'a-token';
+  assert.doesNotThrow(() => validateGeoipConfig());
+
+  process.env.GEOIP_PROVIDER = 'maxmind';
+  assert.throws(() => validateGeoipConfig(), /GEOIP_MAXMIND_DB_PATH is required/);
+
+  process.env.GEOIP_MAXMIND_DB_PATH = '/nonexistent/GeoLite2-City.mmdb';
+  assert.throws(() => validateGeoipConfig(), /does not exist/);
+});
+
+test('validateGeoipConfig rejects unparseable numeric settings', () => {
+  process.env.GEOIP_PROVIDER = 'ip-api';
+  assert.doesNotThrow(() => validateGeoipConfig());
+
+  for (const key of ['GEOIP_TIMEOUT_MS', 'GEOIP_CACHE_TTL_MS', 'GEOIP_CACHE_MAX_ENTRIES']) {
+    process.env[key] = 'soon';
+    assert.throws(() => validateGeoipConfig(), new RegExp(`${key} must be a positive number`));
+
+    process.env[key] = '0';
+    assert.throws(() => validateGeoipConfig(), new RegExp(`${key} must be a positive number`));
+
+    process.env[key] = '1000';
+    assert.doesNotThrow(() => validateGeoipConfig());
+    delete process.env[key];
+  }
+});

--- a/backend/src/services/sessionService.js
+++ b/backend/src/services/sessionService.js
@@ -1,5 +1,6 @@
 const db = require('../config/database');
 const crypto = require('crypto');
+const { lookupIp } = require('./geoipService');
 
 const MAX_SESSIONS_PER_USER = 5;
 
@@ -18,14 +19,13 @@ function generateDeviceFingerprint(req) {
 }
 
 /**
- * Get location info from IP address (stub - would integrate with GeoIP service).
- * @param {string} _ip - IP address (unused in stub)
- * @returns {Promise<{country: string|null, city: string|null}>}
+ * Format the location columns of a session/alert row for display.
+ * @param {object} row - Row with location_city / location_region / location_country
+ * @returns {string|null} - e.g. "San Francisco, California, US"
  */
-async function getLocationFromIp(_ip) {
-  // In production, this would integrate with a GeoIP service like MaxMind
-  // For now, return null values
-  return { country: null, city: null };
+function formatLocation(row) {
+  const parts = [row.location_city, row.location_region, row.location_country].filter(Boolean);
+  return parts.length ? parts.join(', ') : null;
 }
 
 /**
@@ -39,7 +39,7 @@ async function createUserSession(userId, refreshTokenId, req) {
   const deviceFingerprint = generateDeviceFingerprint(req);
   const ip = req.ip || req.connection?.remoteAddress || null;
   const userAgent = req.headers['user-agent'] || null;
-  const { country, city } = await getLocationFromIp(ip);
+  const { country, region, city } = await lookupIp(ip);
 
   // Check concurrent session limit
   const { rows: existingSessions } = await db.query(
@@ -60,10 +60,10 @@ async function createUserSession(userId, refreshTokenId, req) {
 
   const { rows } = await db.query(
     `INSERT INTO user_sessions
-     (user_id, refresh_token_id, device_fingerprint, ip_address, user_agent, location_country, location_city)
-     VALUES ($1, $2, $3, $4, $5, $6, $7)
-     RETURNING id, user_id, device_fingerprint, ip_address, user_agent, location_country, location_city, created_at, last_seen_at`,
-    [userId, refreshTokenId, deviceFingerprint, ip, userAgent, country, city]
+     (user_id, refresh_token_id, device_fingerprint, ip_address, user_agent, location_country, location_region, location_city)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING id, user_id, device_fingerprint, ip_address, user_agent, location_country, location_region, location_city, created_at, last_seen_at`,
+    [userId, refreshTokenId, deviceFingerprint, ip, userAgent, country, region, city]
   );
 
   return rows[0];
@@ -76,7 +76,7 @@ async function createUserSession(userId, refreshTokenId, req) {
  */
 async function listUserSessions(userId) {
   const { rows } = await db.query(
-    `SELECT id, device_fingerprint, ip_address, user_agent, location_country, location_city,
+    `SELECT id, device_fingerprint, ip_address, user_agent, location_country, location_region, location_city,
             created_at, last_seen_at
      FROM user_sessions
      WHERE user_id = $1 AND revoked_at IS NULL
@@ -87,9 +87,7 @@ async function listUserSessions(userId) {
   return rows.map(session => ({
     id: session.id,
     device: session.device_fingerprint ? `Device ${session.device_fingerprint.substring(0, 8)}` : 'Unknown Device',
-    location: session.location_city && session.location_country
-      ? `${session.location_city}, ${session.location_country}`
-      : session.ip_address || 'Unknown Location',
+    location: formatLocation(session) || session.ip_address || 'Unknown Location',
     lastSeen: session.last_seen_at,
     userAgent: session.user_agent,
     ip: session.ip_address,
@@ -137,14 +135,33 @@ async function recordLoginAttempt(options) {
     success,
     failureReason,
     locationCountry,
+    locationRegion,
     locationCity,
   } = options;
 
+  // Resolve the location when the caller did not supply one, so failed
+  // attempts carry the same geo context as sessions do.
+  const location =
+    locationCountry === undefined && locationRegion === undefined && locationCity === undefined
+      ? await lookupIp(ip)
+      : { country: locationCountry ?? null, region: locationRegion ?? null, city: locationCity ?? null };
+
   await db.query(
     `INSERT INTO login_attempts
-     (user_id, email, ip_address, user_agent, device_fingerprint, success, failure_reason, location_country, location_city)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
-    [userId, email, ip, userAgent, deviceFingerprint, success, failureReason, locationCountry, locationCity]
+     (user_id, email, ip_address, user_agent, device_fingerprint, success, failure_reason, location_country, location_region, location_city)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+    [
+      userId,
+      email,
+      ip,
+      userAgent,
+      deviceFingerprint,
+      success,
+      failureReason,
+      location.country,
+      location.region,
+      location.city,
+    ]
   );
 }
 
@@ -159,7 +176,7 @@ async function checkLoginAnomalies(userId, email, req) {
   const ip = req.ip || req.connection?.remoteAddress;
   const userAgent = req.headers['user-agent'] || null;
   const deviceFingerprint = generateDeviceFingerprint(req);
-  const { country, city } = await getLocationFromIp(ip);
+  const { country, region, city } = await lookupIp(ip);
 
   const alerts = [];
 
@@ -172,9 +189,9 @@ async function checkLoginAnomalies(userId, email, req) {
   if (existingDevices.length === 0) {
     await db.query(
       `INSERT INTO login_alerts
-       (user_id, alert_type, ip_address, device_fingerprint, location_country, location_city, details)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-      [userId, 'new_device', ip, deviceFingerprint, country, city, JSON.stringify({ userAgent })]
+       (user_id, alert_type, ip_address, device_fingerprint, location_country, location_region, location_city, details)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [userId, 'new_device', ip, deviceFingerprint, country, region, city, JSON.stringify({ userAgent })]
     );
     alerts.push('new_device');
   }
@@ -189,9 +206,9 @@ async function checkLoginAnomalies(userId, email, req) {
     if (existingLocations.length === 0) {
       await db.query(
         `INSERT INTO login_alerts
-         (user_id, alert_type, ip_address, device_fingerprint, location_country, location_city, details)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-        [userId, 'new_location', ip, deviceFingerprint, country, city, JSON.stringify({ userAgent })]
+         (user_id, alert_type, ip_address, device_fingerprint, location_country, location_region, location_city, details)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+        [userId, 'new_location', ip, deviceFingerprint, country, region, city, JSON.stringify({ userAgent })]
       );
       alerts.push('new_location');
     }
@@ -217,7 +234,7 @@ async function getUserLoginAlerts(userId, options = {}) {
   }
 
   const { rows: alerts } = await db.query(
-    `SELECT id, alert_type, ip_address, location_country, location_city, details, created_at, acknowledged
+    `SELECT id, alert_type, ip_address, location_country, location_region, location_city, details, created_at, acknowledged
      FROM login_alerts
      ${whereClause}
      ORDER BY created_at DESC
@@ -256,7 +273,7 @@ async function getUserLoginAttempts(userId, options = {}) {
   const { limit = 50, offset = 0 } = options;
 
   const { rows: attempts } = await db.query(
-    `SELECT id, email, ip_address, user_agent, success, failure_reason, location_country, location_city, created_at
+    `SELECT id, email, ip_address, user_agent, success, failure_reason, location_country, location_region, location_city, created_at
      FROM login_attempts
      WHERE user_id = $1
      ORDER BY created_at DESC

--- a/backend/src/services/sessionService.test.js
+++ b/backend/src/services/sessionService.test.js
@@ -1,0 +1,186 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const proxyquire = require('proxyquire').noCallThru();
+
+const SAN_FRANCISCO = { country: 'US', region: 'California', city: 'San Francisco' };
+const NO_LOCATION = { country: null, region: null, city: null };
+
+function buildSessionService(queryImpl, location = SAN_FRANCISCO) {
+  const lookups = [];
+  const service = proxyquire('./sessionService', {
+    '../config/database': { query: queryImpl },
+    './geoipService': {
+      lookupIp: async (ip) => {
+        lookups.push(ip);
+        return location;
+      },
+    },
+  });
+  return { ...service, lookups };
+}
+
+function buildRequest(overrides = {}) {
+  return {
+    headers: { 'user-agent': 'Mozilla/5.0', 'accept-language': 'en-US' },
+    ip: '203.0.113.5',
+    ...overrides,
+  };
+}
+
+test('createUserSession stores the resolved country, region, and city', async () => {
+  const calls = [];
+  const queryImpl = async (text, params) => {
+    calls.push({ text, params });
+    if (text.includes('SELECT COUNT(*)')) return { rows: [{ count: 0 }] };
+    return { rows: [{ id: 'session-1' }] };
+  };
+
+  const { createUserSession, lookups } = buildSessionService(queryImpl);
+  await createUserSession('user-1', 'token-1', buildRequest());
+
+  assert.deepEqual(lookups, ['203.0.113.5']);
+
+  const insert = calls.find((call) => call.text.includes('INSERT INTO user_sessions'));
+  assert.ok(insert, 'expected a user_sessions insert');
+  assert.match(insert.text, /location_country, location_region, location_city/);
+  assert.deepEqual(insert.params.slice(-3), ['US', 'California', 'San Francisco']);
+});
+
+test('createUserSession stores nulls when the IP cannot be located', async () => {
+  const calls = [];
+  const queryImpl = async (text, params) => {
+    calls.push({ text, params });
+    if (text.includes('SELECT COUNT(*)')) return { rows: [{ count: 0 }] };
+    return { rows: [{ id: 'session-1' }] };
+  };
+
+  const { createUserSession } = buildSessionService(queryImpl, NO_LOCATION);
+  await createUserSession('user-1', 'token-1', buildRequest({ ip: '127.0.0.1' }));
+
+  const insert = calls.find((call) => call.text.includes('INSERT INTO user_sessions'));
+  assert.deepEqual(insert.params.slice(-3), [null, null, null]);
+});
+
+test('listUserSessions renders city, region, and country', async () => {
+  const queryImpl = async () => ({
+    rows: [
+      {
+        id: 'session-1',
+        device_fingerprint: 'abcdef1234567890',
+        ip_address: '203.0.113.5',
+        user_agent: 'Mozilla/5.0',
+        location_country: 'US',
+        location_region: 'California',
+        location_city: 'San Francisco',
+        last_seen_at: '2026-07-27T00:00:00Z',
+      },
+    ],
+  });
+
+  const { listUserSessions } = buildSessionService(queryImpl);
+  const [session] = await listUserSessions('user-1');
+
+  assert.equal(session.location, 'San Francisco, California, US');
+  assert.equal(session.device, 'Device abcdef12');
+});
+
+test('listUserSessions renders whichever location parts resolved', async () => {
+  const queryImpl = async () => ({
+    rows: [
+      {
+        id: 'session-1',
+        ip_address: '203.0.113.5',
+        location_country: 'US',
+        location_region: null,
+        location_city: null,
+      },
+    ],
+  });
+
+  const { listUserSessions } = buildSessionService(queryImpl);
+  const [session] = await listUserSessions('user-1');
+
+  assert.equal(session.location, 'US');
+});
+
+test('listUserSessions falls back to the IP when no location resolved', async () => {
+  const queryImpl = async () => ({
+    rows: [
+      {
+        id: 'session-1',
+        ip_address: '203.0.113.5',
+        location_country: null,
+        location_region: null,
+        location_city: null,
+      },
+    ],
+  });
+
+  const { listUserSessions } = buildSessionService(queryImpl);
+  const [session] = await listUserSessions('user-1');
+
+  assert.equal(session.location, '203.0.113.5');
+});
+
+test('recordLoginAttempt resolves the location from the IP by default', async () => {
+  const calls = [];
+  const queryImpl = async (text, params) => {
+    calls.push({ text, params });
+    return { rows: [] };
+  };
+
+  const { recordLoginAttempt, lookups } = buildSessionService(queryImpl);
+  await recordLoginAttempt({
+    email: 'someone@example.com',
+    ip: '203.0.113.5',
+    userAgent: 'Mozilla/5.0',
+    success: false,
+    failureReason: 'Invalid credentials',
+  });
+
+  assert.deepEqual(lookups, ['203.0.113.5']);
+  assert.match(calls[0].text, /INSERT INTO login_attempts/);
+  assert.deepEqual(calls[0].params.slice(-3), ['US', 'California', 'San Francisco']);
+});
+
+test('recordLoginAttempt honours an explicitly supplied location', async () => {
+  const calls = [];
+  const queryImpl = async (text, params) => {
+    calls.push({ text, params });
+    return { rows: [] };
+  };
+
+  const { recordLoginAttempt, lookups } = buildSessionService(queryImpl);
+  await recordLoginAttempt({
+    email: 'someone@example.com',
+    ip: '203.0.113.5',
+    success: true,
+    locationCountry: 'NG',
+    locationCity: 'Lagos',
+  });
+
+  assert.deepEqual(lookups, [], 'a supplied location should not trigger a lookup');
+  assert.deepEqual(calls[0].params.slice(-3), ['NG', null, 'Lagos']);
+});
+
+test('checkLoginAnomalies records the region on new-device and new-location alerts', async () => {
+  const calls = [];
+  const queryImpl = async (text, params) => {
+    calls.push({ text, params });
+    // No prior devices and no prior sessions in this country.
+    if (text.includes('SELECT 1 FROM user_sessions')) return { rows: [] };
+    return { rows: [] };
+  };
+
+  const { checkLoginAnomalies } = buildSessionService(queryImpl);
+  const alerts = await checkLoginAnomalies('user-1', 'someone@example.com', buildRequest());
+
+  assert.deepEqual(alerts, ['new_device', 'new_location']);
+
+  const inserts = calls.filter((call) => call.text.includes('INSERT INTO login_alerts'));
+  assert.equal(inserts.length, 2);
+  for (const insert of inserts) {
+    assert.match(insert.text, /location_country, location_region, location_city/);
+    assert.deepEqual(insert.params.slice(4, 7), ['US', 'California', 'San Francisco']);
+  }
+});


### PR DESCRIPTION
# feat: implement GeoIP service in sessionService (closes #493)

## What this does

`getLocationFromIp` in `sessionService.js` was a stub that always returned nulls, so session locations and new-location alerts never worked. This implements it.

The new service is `backend/src/services/geoipService.js`. You choose a provider with `GEOIP_PROVIDER`:

| Value | Notes |
|---|---|
| `none` (default) | Off, so nothing changes until someone turns it on |
| `maxmind` | Local GeoLite2 file, no network call. Needs the optional `maxmind` package |
| `ip-api` | No key. Free tier is HTTP only and limited to 45 requests a minute |
| `ipinfo` | HTTPS. Token goes in a bearer header, not the URL |

There are also `GEOIP_TIMEOUT_MS`, `GEOIP_CACHE_TTL_MS` and `GEOIP_CACHE_MAX_ENTRIES`, all documented in `.env.example`.

Because lookups happen during login, nothing throws. Private and reserved IPs never reach a provider. Lookups time out after 2 seconds, results cache for 24 hours, concurrent lookups of the same IP share a single call, and five failures in a row pause the provider for a minute.

## Decisions

The issue asks for city, region and country, but the schema only had city and country. I added `location_region` to `user_sessions`, `login_attempts` and `login_alerts` in a new migration. Sessions now read "San Francisco, California, US".

`recordLoginAttempt` already accepted location arguments, but no caller ever passed them, so those columns were always null. It now resolves the location itself when the caller does not supply one.

The `maxmind` package is not in `package.json`. It loads lazily and only when you select that provider, so nobody pays for it otherwise.

The lookup cache is local to the service instead of the shared `utils/cache`. Its keys are IPs from unauthenticated login attempts, and the shared cache has no size limit, so it would grow without bound under IP rotation. This one is a bounded LRU.

`validateGeoipConfig()` runs at startup from `config/env.js`, the same way `validateWalletSecretConfig` does. Lookups fail open by design, so without this check a broken provider would quietly return nulls forever.

## Testing it

Apply the migration:

```bash
cd backend && npm run migrate
```

Resolve a public IP:

```bash
GEOIP_PROVIDER=ip-api node -e "require('./src/services/geoipService').lookupIp('8.8.8.8').then(console.log)"
```

Check that bad config stops the server:

```bash
GEOIP_PROVIDER=ipinfo npm run dev
```

That should exit with `GEOIP_IPINFO_TOKEN is required for GEOIP_PROVIDER=ipinfo`.

Logging in locally reports `127.0.0.1`, which is correctly skipped as a reserved range, so the session list will show the IP rather than a city. Seeing the whole path work needs a request from a public address.

## Tests

31 for `geoipService`, covering provider mapping, reserved ranges, IP normalization, caching and eviction, shared lookups, timeouts, the failure pause and config validation. 8 for `sessionService`, which had none before.



Closes #493
