### PR TITLE
fix(routes): wrap all unprotected async handlers with asyncHandler or…

### DIFF
--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -19,6 +19,7 @@ const cache = require('../utils/cache');
 const { parsePagination } = require('../utils/pagination');
 const { revokeAndCloseCampaignWallet } = require('../services/stellarService');
 const { sendAlert } = require('../services/alerting');
+const asyncHandler = require('../utils/asyncHandler');
 
 const IMPERSONATION_TTL_SECONDS = 15 * 60;
 const { IMPERSONATION_TTL_SECONDS, ADMIN_AUDIT_LOG_MAX_LIMIT } = require('../config/constants');
@@ -807,7 +808,7 @@ router.patch('/users/:id/demote', async (req, res) => {
 });
 
 // Migrate old /milestones endpoint if needed
-router.get('/milestones', async (req, res) => {
+router.get('/milestones', asyncHandler(async (req, res) => {
   const status = req.query.status ? String(req.query.status) : null;
   const allowedStatuses = ['pending', 'pending_review', 'rejected', 'approved', 'released'];
   if (status && !allowedStatuses.includes(status)) {
@@ -839,7 +840,7 @@ router.get('/milestones', async (req, res) => {
     [...params, limit, offset]
   );
   res.json({ data: rows, total, limit, offset });
-});
+}));
 
 /**
  * POST /api/admin/campaigns/:id/reconcile

--- a/backend/src/routes/contributions.js
+++ b/backend/src/routes/contributions.js
@@ -164,7 +164,7 @@ router.get('/dashboard/export.csv', requireAuth, asyncHandler(async (req, res) =
   res.send(csv);
 }));
 
-router.get('/campaign/:campaignId', async (req, res) => {
+router.get('/campaign/:campaignId', asyncHandler(async (req, res) => {
   const { limit, offset } = parsePagination(req.query, { limit: 20, max: 100 });
 
   const { rows } = await db.query(
@@ -192,7 +192,7 @@ router.get('/campaign/:campaignId', async (req, res) => {
   const total = rows[0]?.total_count ?? 0;
   const cleanedRows = rows.map(({ total_count, ...rest }) => rest);
   res.json({ contributions: cleanedRows, total: Number(total), limit, offset });
-});
+}));
 
 router.get('/', requireAuth, asyncHandler(async (req, res) => {
   const rows = await listUserContributions(req.user.userId);

--- a/backend/src/routes/disputes.js
+++ b/backend/src/routes/disputes.js
@@ -10,6 +10,7 @@ const {
 const logger = require('../config/logger');
 const { emitWebhookEventForUser, emitWebhookEventForCampaign, WEBHOOK_EVENTS } = require('../services/webhookDispatcher');
 const { parsePagination } = require('../utils/pagination');
+const asyncHandler = require('../utils/asyncHandler');
 
 function frontendBaseUrl() {
   return (process.env.FRONTEND_URL || 'http://localhost:5173').replace(/\/$/, '');
@@ -159,7 +160,7 @@ router.post('/campaigns/:id/disputes', requireAuth, async (req, res) => {
 });
 
 // GET /campaigns/:id/disputes — admin only
-router.get('/campaigns/:id/disputes', requireAuth, requireRole('admin'), async (req, res) => {
+router.get('/campaigns/:id/disputes', requireAuth, requireRole('admin'), asyncHandler(async (req, res) => {
   const { limit, offset } = parsePagination(req.query, { limit: 20, max: 100 });
 
   const countResult = await db.query(
@@ -178,7 +179,7 @@ router.get('/campaigns/:id/disputes', requireAuth, requireRole('admin'), async (
     [req.params.id, limit, offset]
   );
   res.json({ data: rows, total, limit, offset });
-});
+}));
 
 // PATCH /disputes/:id — admin updates status + resolution note
 router.patch('/disputes/:id', requireAuth, requireRole('admin'), async (req, res) => {
@@ -357,7 +358,7 @@ router.patch('/disputes/:id', requireAuth, requireRole('admin'), async (req, res
 });
 
 // GET /disputes/:id/events — audit log (admin only)
-router.get('/disputes/:id/events', requireAuth, requireRole('admin'), async (req, res) => {
+router.get('/disputes/:id/events', requireAuth, requireRole('admin'), asyncHandler(async (req, res) => {
   const { rows } = await db.query(
     `SELECT de.*, u.name AS actor_name
      FROM dispute_events de
@@ -367,6 +368,6 @@ router.get('/disputes/:id/events', requireAuth, requireRole('admin'), async (req
     [req.params.id]
   );
   res.json(rows);
-});
+}));
 
 module.exports = router;

--- a/backend/src/routes/emails.js
+++ b/backend/src/routes/emails.js
@@ -2,8 +2,9 @@ const router = require('express').Router();
 const db = require('../config/database');
 const { verifyUnsubscribeToken } = require('../utils/unsubscribeToken');
 const { isUuid } = require('../utils/validation');
+const asyncHandler = require('../utils/asyncHandler');
 
-router.get('/unsubscribe', async (req, res) => {
+router.get('/unsubscribe', asyncHandler(async (req, res) => {
   const { email, category, sig, campaign_id: campaignId } = req.query;
 
   if (campaignId !== undefined && !isUuid(campaignId)) {
@@ -48,6 +49,6 @@ router.get('/unsubscribe', async (req, res) => {
   );
 
   res.send('You have been unsubscribed from these emails.');
-});
+}));
 
 module.exports = router;

--- a/backend/src/routes/kycWebhook.js
+++ b/backend/src/routes/kycWebhook.js
@@ -8,76 +8,81 @@ function frontendBaseUrl() {
 }
 
 async function handleKycWebhook(req, res) {
-  const rawBody = req.body;
-  const signatureHeader = req.headers['persona-signature'] || req.headers['Persona-Signature'];
-
-  if (!verifyPersonaWebhookSignature(rawBody, signatureHeader)) {
-    return res.status(401).json({ error: 'Invalid Persona webhook signature' });
-  }
-
-  let payload;
   try {
-    const bodyStr = Buffer.isBuffer(rawBody) ? rawBody.toString('utf8') : String(rawBody || '');
-    payload = JSON.parse(bodyStr);
-  } catch {
-    return res.status(400).json({ error: 'Invalid JSON payload' });
-  }
+    const rawBody = req.body;
+    const signatureHeader = req.headers['persona-signature'] || req.headers['Persona-Signature'];
 
-  const result = extractWebhookResult(payload);
-  if (!result.providerReference && !result.userId) {
-    return res.status(400).json({ error: 'KYC webhook payload missing provider reference' });
-  }
-
-  if (!['verified', 'rejected', 'pending'].includes(result.kycStatus)) {
-    return res.status(400).json({ error: 'Unsupported KYC status' });
-  }
-
-  const params = [result.kycStatus, result.providerReference || null];
-  let lookup = 'kyc_provider_reference = $2';
-  if (result.userId) {
-    params.push(result.userId);
-    lookup = `(kyc_provider_reference = $2 OR id = $3)`;
-  }
-
-  const { rows } = await db.query(
-    `UPDATE users
-     SET kyc_status = $1::kyc_status,
-         kyc_provider_reference = COALESCE($2, kyc_provider_reference),
-         kyc_completed_at = CASE WHEN $1::kyc_status = 'verified' THEN NOW() ELSE NULL END
-     WHERE ${lookup}
-     RETURNING id, email, name, kyc_status, kyc_completed_at`,
-    params
-  );
-
-  if (!rows.length) {
-    return res.status(404).json({ error: 'KYC subject not found' });
-  }
-
-  if (rows[0].email) {
-    if (rows[0].kyc_status === 'verified') {
-      sendKycApprovedEmail({
-        to: rows[0].email,
-        userId: rows[0].id,
-        name: rows[0].name,
-        dashboardUrl: `${frontendBaseUrl()}/dashboard`,
-      }).catch((err) => logger.error('KYC approved email failed', { error: err.message }));
-    } else if (rows[0].kyc_status === 'rejected') {
-      sendKycRejectedEmail({
-        to: rows[0].email,
-        userId: rows[0].id,
-        name: rows[0].name,
-        reason: result.reason,
-        retryUrl: `${frontendBaseUrl()}/dashboard?kyc=retry`,
-      }).catch((err) => logger.error('KYC rejected email failed', { error: err.message }));
+    if (!verifyPersonaWebhookSignature(rawBody, signatureHeader)) {
+      return res.status(401).json({ error: 'Invalid Persona webhook signature' });
     }
-  }
 
-  res.json({
-    received: true,
-    user_id: rows[0].id,
-    kyc_status: rows[0].kyc_status,
-    kyc_completed_at: rows[0].kyc_completed_at,
-  });
+    let payload;
+    try {
+      const bodyStr = Buffer.isBuffer(rawBody) ? rawBody.toString('utf8') : String(rawBody || '');
+      payload = JSON.parse(bodyStr);
+    } catch {
+      return res.status(400).json({ error: 'Invalid JSON payload' });
+    }
+
+    const result = extractWebhookResult(payload);
+    if (!result.providerReference && !result.userId) {
+      return res.status(400).json({ error: 'KYC webhook payload missing provider reference' });
+    }
+
+    if (!['verified', 'rejected', 'pending'].includes(result.kycStatus)) {
+      return res.status(400).json({ error: 'Unsupported KYC status' });
+    }
+
+    const params = [result.kycStatus, result.providerReference || null];
+    let lookup = 'kyc_provider_reference = $2';
+    if (result.userId) {
+      params.push(result.userId);
+      lookup = `(kyc_provider_reference = $2 OR id = $3)`;
+    }
+
+    const { rows } = await db.query(
+      `UPDATE users
+       SET kyc_status = $1::kyc_status,
+           kyc_provider_reference = COALESCE($2, kyc_provider_reference),
+           kyc_completed_at = CASE WHEN $1::kyc_status = 'verified' THEN NOW() ELSE NULL END
+       WHERE ${lookup}
+       RETURNING id, email, name, kyc_status, kyc_completed_at`,
+      params
+    );
+
+    if (!rows.length) {
+      return res.status(404).json({ error: 'KYC subject not found' });
+    }
+
+    if (rows[0].email) {
+      if (rows[0].kyc_status === 'verified') {
+        sendKycApprovedEmail({
+          to: rows[0].email,
+          userId: rows[0].id,
+          name: rows[0].name,
+          dashboardUrl: `${frontendBaseUrl()}/dashboard`,
+        }).catch((err) => logger.error('KYC approved email failed', { error: err.message }));
+      } else if (rows[0].kyc_status === 'rejected') {
+        sendKycRejectedEmail({
+          to: rows[0].email,
+          userId: rows[0].id,
+          name: rows[0].name,
+          reason: result.reason,
+          retryUrl: `${frontendBaseUrl()}/dashboard?kyc=retry`,
+        }).catch((err) => logger.error('KYC rejected email failed', { error: err.message }));
+      }
+    }
+
+    res.json({
+      received: true,
+      user_id: rows[0].id,
+      kyc_status: rows[0].kyc_status,
+      kyc_completed_at: rows[0].kyc_completed_at,
+    });
+  } catch (err) {
+    logger.error('KYC webhook handler failed', { error: err.message });
+    res.status(500).json({ error: 'Internal server error' });
+  }
 }
 
 module.exports = handleKycWebhook;

--- a/backend/src/routes/milestones.js
+++ b/backend/src/routes/milestones.js
@@ -29,6 +29,7 @@ const {
   sendMilestoneReleasedContributorEmail,
   sendMilestoneEvidenceSubmittedAdminEmail,
 } = require('../services/emailService');
+const asyncHandler = require('../utils/asyncHandler');
 
 function frontendBaseUrl() {
   return (process.env.FRONTEND_URL || 'http://localhost:5173').replace(/\/$/, '');
@@ -163,7 +164,7 @@ async function setCampaignStatusFromMilestoneProgress(client, campaignId) {
   return updated[0] || null;
 }
 
-router.get('/campaign/:campaignId', async (req, res) => {
+router.get('/campaign/:campaignId', asyncHandler(async (req, res) => {
   const { rows } = await db.query(
     `SELECT m.*, 
             (c.milestones_contract_id IS NOT NULL) AS on_chain
@@ -174,7 +175,7 @@ router.get('/campaign/:campaignId', async (req, res) => {
     [req.params.campaignId]
   );
   res.json(rows);
-});
+}));
 
 router.post('/', requireAuth, async (req, res) => {
   const {
@@ -414,7 +415,7 @@ router.post('/:id/upload-evidence', requireAuth, evidenceUpload.single('evidence
   }
 });
 
-router.get('/:id/events', requireAuth, async (req, res) => {
+router.get('/:id/events', requireAuth, asyncHandler(async (req, res) => {
   const { rows: milestones } = await db.query(
     `SELECT m.*, c.creator_id
      FROM milestones m
@@ -440,7 +441,7 @@ router.get('/:id/events', requireAuth, async (req, res) => {
     [req.params.id]
   );
   res.json(rows);
-});
+}));
 
 router.post('/:id/reject', requireAuth, async (req, res) => {
   if (!canPerformPlatformSignature(req.user.userId)) {

--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -2,10 +2,11 @@ const router = require('express').Router();
 const db = require('../config/database');
 const { requireAuth } = require('../middleware/auth');
 const { CHANNELS } = require('../services/notificationChannels');
+const asyncHandler = require('../utils/asyncHandler');
 
 const EXTERNAL_CHANNELS = CHANNELS.filter((c) => c !== 'in_app');
 
-router.get('/', requireAuth, async (req, res) => {
+router.get('/', requireAuth, asyncHandler(async (req, res) => {
   const { rows } = await db.query(
     `SELECT id, type, title, body, link, read_at, created_at
      FROM notifications
@@ -15,17 +16,17 @@ router.get('/', requireAuth, async (req, res) => {
     [req.user.userId]
   );
   res.json(rows);
-});
+}));
 
-router.patch('/read-all', requireAuth, async (req, res) => {
+router.patch('/read-all', requireAuth, asyncHandler(async (req, res) => {
   await db.query(
     `UPDATE notifications SET read_at = NOW() WHERE user_id = $1 AND read_at IS NULL`,
     [req.user.userId]
   );
   res.json({ ok: true });
-});
+}));
 
-router.patch('/:id/read', requireAuth, async (req, res) => {
+router.patch('/:id/read', requireAuth, asyncHandler(async (req, res) => {
   const { rows } = await db.query(
     `UPDATE notifications SET read_at = NOW()
      WHERE id = $1 AND user_id = $2 AND read_at IS NULL
@@ -34,12 +35,12 @@ router.patch('/:id/read', requireAuth, async (req, res) => {
   );
   if (!rows.length) return res.status(404).json({ error: 'Notification not found' });
   res.json({ ok: true });
-});
+}));
 
 // ── Multi-channel settings (issue #429) ────────────────────────────────────
 
 // Per-user channel destinations + quiet-hours window.
-router.get('/channel-settings', requireAuth, async (req, res) => {
+router.get('/channel-settings', requireAuth, asyncHandler(async (req, res) => {
   const { rows } = await db.query(
     `SELECT push_token, slack_webhook_url, discord_webhook_url, sms_phone_number,
             quiet_hours_start, quiet_hours_end
@@ -57,13 +58,13 @@ router.get('/channel-settings', requireAuth, async (req, res) => {
       quiet_hours_end: null,
     }
   );
-});
+}));
 
 function validQuietHour(value) {
   return value === null || (Number.isInteger(value) && value >= 0 && value <= 23);
 }
 
-router.put('/channel-settings', requireAuth, async (req, res) => {
+router.put('/channel-settings', requireAuth, asyncHandler(async (req, res) => {
   const {
     push_token = null,
     slack_webhook_url = null,
@@ -103,10 +104,10 @@ router.put('/channel-settings', requireAuth, async (req, res) => {
     ]
   );
   res.json(rows[0]);
-});
+}));
 
 // Per-event-type, per-channel enable/disable overrides.
-router.get('/preferences', requireAuth, async (req, res) => {
+router.get('/preferences', requireAuth, asyncHandler(async (req, res) => {
   const { rows } = await db.query(
     `SELECT event_type, channel, enabled
      FROM notification_preferences
@@ -115,9 +116,9 @@ router.get('/preferences', requireAuth, async (req, res) => {
     [req.user.userId]
   );
   res.json(rows);
-});
+}));
 
-router.put('/preferences', requireAuth, async (req, res) => {
+router.put('/preferences', requireAuth, asyncHandler(async (req, res) => {
   const { event_type, channel, enabled } = req.body || {};
   if (!event_type || typeof event_type !== 'string') {
     return res.status(400).json({ error: 'event_type is required' });
@@ -136,6 +137,6 @@ router.put('/preferences', requireAuth, async (req, res) => {
     [req.user.userId, event_type, channel, enabled]
   );
   res.json({ ok: true });
-});
+}));
 
 module.exports = router;

--- a/backend/src/routes/wallets.js
+++ b/backend/src/routes/wallets.js
@@ -11,6 +11,7 @@ const {
 } = require('../services/stellarService');
 const { decryptSecret } = require('../services/walletService');
 const { parsePagination } = require('../utils/pagination');
+const asyncHandler = require('../utils/asyncHandler');
 
 const isTest = process.env.NODE_ENV === 'test';
 const recoverLimiter = rateLimit({
@@ -23,7 +24,7 @@ const recoverLimiter = rateLimit({
 });
 
 // Get wallet configuration (signers, thresholds)
-router.get('/:campaignId/config', requireAuth, async (req, res) => {
+router.get('/:campaignId/config', requireAuth, asyncHandler(async (req, res) => {
   const { rows } = await db.query(
     'SELECT wallet_public_key, creator_id FROM campaigns WHERE id = $1',
     [req.params.campaignId]
@@ -35,10 +36,10 @@ router.get('/:campaignId/config', requireAuth, async (req, res) => {
 
   const config = await getAccountMultisigConfig(rows[0].wallet_public_key);
   res.json(config);
-});
+}));
 
 // Get wallet transaction history
-router.get('/:campaignId/transactions', requireAuth, async (req, res) => {
+router.get('/:campaignId/transactions', requireAuth, asyncHandler(async (req, res) => {
   const { rows } = await db.query(
     'SELECT wallet_public_key, creator_id FROM campaigns WHERE id = $1',
     [req.params.campaignId]
@@ -51,10 +52,10 @@ router.get('/:campaignId/transactions', requireAuth, async (req, res) => {
   const { limit } = parsePagination(req.query, { limit: 50, max: 100 });
   const txs = await getWalletTransactionHistory(rows[0].wallet_public_key, limit);
   res.json(txs);
-});
+}));
 
 // Get wallet payment history (audit trail)
-router.get('/:campaignId/payments', requireAuth, async (req, res) => {
+router.get('/:campaignId/payments', requireAuth, asyncHandler(async (req, res) => {
   const { rows } = await db.query(
     'SELECT wallet_public_key, creator_id FROM campaigns WHERE id = $1',
     [req.params.campaignId]
@@ -67,10 +68,10 @@ router.get('/:campaignId/payments', requireAuth, async (req, res) => {
   const { limit } = parsePagination(req.query, { limit: 100, max: 200 });
   const payments = await getWalletPayments(rows[0].wallet_public_key, limit);
   res.json(payments);
-});
+}));
 
 // Recover wallet keypair (owner or admin; requires encrypted secret)
-router.post('/:campaignId/recover', recoverLimiter, requireAuth, async (req, res) => {
+router.post('/:campaignId/recover', recoverLimiter, requireAuth, asyncHandler(async (req, res) => {
   const { rows } = await db.query(
     'SELECT wallet_secret_encrypted, creator_id FROM campaigns WHERE id = $1',
     [req.params.campaignId]
@@ -99,6 +100,6 @@ router.post('/:campaignId/recover', recoverLimiter, requireAuth, async (req, res
     requesterId: req.user.userId,
   });
   res.json({ publicKey: wallet.publicKey });
-});
+}));
 
 module.exports = router;

--- a/backend/src/routes/webhooks.js
+++ b/backend/src/routes/webhooks.js
@@ -15,6 +15,7 @@ const {
   verifyWebhookSignature,
   WebhookError,
 } = require('../services/webhookService');
+const asyncHandler = require('../utils/asyncHandler');
 
 const isTest = process.env.NODE_ENV === 'test';
 
@@ -108,7 +109,7 @@ router.post('/incoming/:id', incomingWebhookLimiter, express.raw({ type: 'applic
   }
 });
 
-router.get('/', requireAuth, async (req, res) => {
+router.get('/', requireAuth, asyncHandler(async (req, res) => {
   const { rows } = await db.query(
     `SELECT id, url, events,
             CONCAT(LEFT(secret, 10), '…', RIGHT(secret, 4)) AS secret_hint,
@@ -117,9 +118,9 @@ router.get('/', requireAuth, async (req, res) => {
     [req.user.userId]
   );
   res.json(rows);
-});
+}));
 
-router.post('/', requireAuth, async (req, res) => {
+router.post('/', requireAuth, asyncHandler(async (req, res) => {
   const { url, events, backoff_strategy } = req.body || {};
   if (!url || !events) {
     return res.status(400).json({ error: 'url and events array are required' });
@@ -150,9 +151,9 @@ router.post('/', requireAuth, async (req, res) => {
     secret,
     message: 'Store the signing secret; it is only shown once.',
   });
-});
+}));
 
-router.patch('/:id/backoff-strategy', requireAuth, async (req, res) => {
+router.patch('/:id/backoff-strategy', requireAuth, asyncHandler(async (req, res) => {
   const { backoff_strategy } = req.body || {};
   if (backoff_strategy !== null && !isValidBackoffStrategy(backoff_strategy)) {
     return res.status(400).json({
@@ -168,9 +169,9 @@ router.patch('/:id/backoff-strategy', requireAuth, async (req, res) => {
   );
   if (!rows.length) return res.status(404).json({ error: 'Webhook not found' });
   res.json(rows[0]);
-});
+}));
 
-router.delete('/:id', requireAuth, async (req, res) => {
+router.delete('/:id', requireAuth, asyncHandler(async (req, res) => {
   const { rows } = await db.query(
     `UPDATE webhooks SET revoked_at = NOW()
      WHERE id = $1 AND user_id = $2 AND revoked_at IS NULL
@@ -179,9 +180,9 @@ router.delete('/:id', requireAuth, async (req, res) => {
   );
   if (!rows.length) return res.status(404).json({ error: 'Webhook not found' });
   res.json({ revoked: true, id: rows[0].id });
-});
+}));
 
-router.get('/deliveries', requireAuth, async (req, res) => {
+router.get('/deliveries', requireAuth, asyncHandler(async (req, res) => {
   const limit = Math.min(parseInt(req.query.limit, 10) || 50, 200);
   const webhookId = req.query.webhook_id || null;
 
@@ -205,9 +206,9 @@ router.get('/deliveries', requireAuth, async (req, res) => {
     params
   );
   res.json(rows);
-});
+}));
 
-router.post('/deliveries/:id/replay', requireAuth, async (req, res) => {
+router.post('/deliveries/:id/replay', requireAuth, asyncHandler(async (req, res) => {
   const { rows } = await db.query(
     `UPDATE webhook_deliveries d
      SET status = 'pending', attempt_count = 0, last_error = NULL,
@@ -231,6 +232,6 @@ router.post('/deliveries/:id/replay', requireAuth, async (req, res) => {
   });
 
   res.json({ message: 'Replay queued', id: rows[0].id });
-});
+}));
 
 module.exports = router;

--- a/backend/src/routes/withdrawals.js
+++ b/backend/src/routes/withdrawals.js
@@ -23,6 +23,7 @@ const { emitWebhookEventForUser, WEBHOOK_EVENTS } = require('../services/webhook
 const { withDecryptedWalletSecret } = require('../services/walletSecrets');
 const { createNotification } = require('../services/notifications');
 const { parsePagination } = require('../utils/pagination');
+const asyncHandler = require('../utils/asyncHandler');
 
 const ALLOWED_CAMPAIGN_STATUS_FOR_REQUEST = ['active', 'funded'];
 
@@ -753,7 +754,7 @@ router.post('/:id/reject', requireAuth, requirePlatformApprover, async (req, res
   }
 });
 
-router.get('/campaign/:campaignId', requireAuth, async (req, res) => {
+router.get('/campaign/:campaignId', requireAuth, asyncHandler(async (req, res) => {
   const access = await assertWithdrawalAccess(req, req.params.campaignId);
   if (access.error) return res.status(access.status).json({ error: access.error });
 
@@ -775,10 +776,10 @@ router.get('/campaign/:campaignId', requireAuth, async (req, res) => {
     [req.params.campaignId, limit, offset]
   );
   res.json({ data: rows, total, limit, offset });
-});
+}));
 
 // Get a single withdrawal request (including unsigned_xdr) for authorized users
-router.get('/:id', requireAuth, async (req, res) => {
+router.get('/:id', requireAuth, asyncHandler(async (req, res) => {
   const { rows } = await db.query('SELECT * FROM withdrawal_requests WHERE id = $1', [req.params.id]);
   if (!rows.length) return res.status(404).json({ error: 'Withdrawal request not found' });
   const row = rows[0];
@@ -787,9 +788,9 @@ router.get('/:id', requireAuth, async (req, res) => {
 
   // Only return unsigned_xdr to owners/admins
   res.json(row);
-});
+}));
 
-const withdrawalAuditHandler = async (req, res) => {
+const withdrawalAuditHandler = asyncHandler(async (req, res) => {
   /**
    * @openapi
    * /api/withdrawals/{id}/audit:
@@ -830,7 +831,7 @@ const withdrawalAuditHandler = async (req, res) => {
     [req.params.id]
   );
   res.json(rows);
-};
+});
 
 router.get('/:id/events', requireAuth, withdrawalAuditHandler);
 // Alias for docs + issue acceptance criteria


### PR DESCRIPTION
… try/catch

Closes #485

Express 4 silently swallows rejections from async route handlers, leaving the client with a hanging response or crashing the process. This change protects every previously-unguarded async handler across 10 route files.

Changes per file:
- wallets.js      — asyncHandler on all 4 routes
- notifications.js — asyncHandler on all 7 routes
- webhooks.js     — asyncHandler on GET /, POST /, PATCH /:id/backoff-strategy,
                    DELETE /:id, GET /deliveries, POST /deliveries/:id/replay
- emails.js       — asyncHandler on GET /unsubscribe
- disputes.js     — asyncHandler on GET /campaigns/:id/disputes and
                    GET /disputes/:id/events
- milestones.js   — asyncHandler on GET /campaign/:campaignId and
                    GET /:id/events
- withdrawals.js  — asyncHandler on GET /campaign/:campaignId, GET /:id,
                    and withdrawalAuditHandler (GET /:id/events + /:id/audit)
- admin.js        — asyncHandler on GET /milestones
- contributions.js — asyncHandler on GET /campaign/:campaignId
- kycWebhook.js   — outer try/catch wrapping entire handleKycWebhook body