### PR TITLE
feat: campaign follow, draft auto-save, milestone embed, badges & leaderboard

### DIFF
--- a/backend/db/migrations/20260728_campaign_followers.sql
+++ b/backend/db/migrations/20260728_campaign_followers.sql
@@ -1,0 +1,21 @@
+-- Campaign follow/watch (#592)
+CREATE TABLE IF NOT EXISTS campaign_followers (
+  user_id           UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  campaign_id       UUID NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  notify_updates    BOOLEAN NOT NULL DEFAULT TRUE,
+  notify_milestones BOOLEAN NOT NULL DEFAULT TRUE,
+  notify_funding    BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, campaign_id)
+);
+
+CREATE INDEX IF NOT EXISTS campaign_followers_campaign_idx ON campaign_followers (campaign_id);
+
+-- One row per funding threshold announced, so a campaign that crosses 50% only
+-- ever notifies its followers once even if raised_amount is recalculated.
+CREATE TABLE IF NOT EXISTS campaign_funding_milestones (
+  campaign_id UUID NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  threshold   INT NOT NULL,
+  reached_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (campaign_id, threshold)
+);

--- a/backend/db/migrations/20260728_contributor_badges.sql
+++ b/backend/db/migrations/20260728_contributor_badges.sql
@@ -1,0 +1,10 @@
+-- Earned contributor badges (#597). Badges are derived from contribution
+-- history, but they are recorded here so a badge is only announced once.
+CREATE TABLE IF NOT EXISTS contributor_badges (
+  user_id   UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  badge_id  TEXT NOT NULL,
+  earned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, badge_id)
+);
+
+CREATE INDEX IF NOT EXISTS contributor_badges_user_idx ON contributor_badges (user_id);

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -256,6 +256,7 @@ app.use("/api/users", require("./routes/users"));
 app.use("/api/invites", require("./routes/invites"));
 app.use("/api/campaigns", require("./routes/campaignUpdates"));
 app.use("/api/campaigns", require("./routes/campaignComments"));
+app.use("/api/campaigns", require("./routes/campaignFollowers"));
 app.use("/api/campaigns", require("./routes/campaigns"));
 app.use("/api/anchor", require("./routes/anchor"));
 app.use("/api/contributions", require("./routes/contributions"));

--- a/backend/src/routes/campaignFollowers.js
+++ b/backend/src/routes/campaignFollowers.js
@@ -1,0 +1,79 @@
+const router = require('express').Router();
+const db = require('../config/database');
+const { requireAuth } = require('../middleware/auth');
+const asyncHandler = require('../utils/asyncHandler');
+const {
+  followCampaign,
+  unfollowCampaign,
+  updateFollowPreferences,
+  getFollowState,
+  countFollowers,
+} = require('../services/campaignFollowService');
+
+const PREFERENCE_KEYS = ['notify_updates', 'notify_milestones', 'notify_funding'];
+
+async function loadCampaign(req, res, next) {
+  const { rows } = await db.query(
+    'SELECT id FROM campaigns WHERE id = $1 AND deleted_at IS NULL',
+    [req.params.id]
+  );
+  if (!rows.length) return res.status(404).json({ error: 'Campaign not found' });
+  next();
+}
+
+// Follow state for the current user, plus the public follower count.
+router.get(
+  '/:id/follow',
+  requireAuth,
+  asyncHandler(loadCampaign),
+  asyncHandler(async (req, res) => {
+    const [state, followerCount] = await Promise.all([
+      getFollowState(req.user.userId, req.params.id),
+      countFollowers(req.params.id),
+    ]);
+    res.json({ ...state, follower_count: followerCount });
+  })
+);
+
+router.post(
+  '/:id/follow',
+  requireAuth,
+  asyncHandler(loadCampaign),
+  asyncHandler(async (req, res) => {
+    const follow = await followCampaign(req.user.userId, req.params.id, req.body || {});
+    res.status(201).json({ ...follow, follower_count: await countFollowers(req.params.id) });
+  })
+);
+
+// Change which events a followed campaign notifies about.
+router.patch(
+  '/:id/follow',
+  requireAuth,
+  asyncHandler(loadCampaign),
+  asyncHandler(async (req, res) => {
+    const body = req.body || {};
+    const provided = PREFERENCE_KEYS.filter((key) => typeof body[key] === 'boolean');
+    if (!provided.length) {
+      return res.status(422).json({
+        error: `Provide at least one boolean preference: ${PREFERENCE_KEYS.join(', ')}`,
+      });
+    }
+
+    const follow = await updateFollowPreferences(req.user.userId, req.params.id, body);
+    if (!follow) {
+      return res.status(404).json({ error: 'You are not following this campaign' });
+    }
+    res.json(follow);
+  })
+);
+
+router.delete(
+  '/:id/follow',
+  requireAuth,
+  asyncHandler(async (req, res) => {
+    await unfollowCampaign(req.user.userId, req.params.id);
+    res.status(204).send();
+  })
+);
+
+module.exports = router;

--- a/backend/src/routes/campaignFollowers.test.js
+++ b/backend/src/routes/campaignFollowers.test.js
@@ -1,0 +1,173 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const proxyquire = require('proxyquire').noCallThru();
+
+const CAMPAIGN_ID = '11111111-1111-1111-1111-111111111111';
+
+function buildApp(queryImpl) {
+  const followService = proxyquire('../services/campaignFollowService', {
+    '../config/database': { query: queryImpl },
+    '../config/logger': { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} },
+    './notifications': { createNotification: async () => {} },
+  });
+
+  const router = proxyquire('./campaignFollowers', {
+    '../config/database': { query: queryImpl },
+    '../middleware/auth': {
+      requireAuth: (req, _res, next) => {
+        req.user = { userId: 'user-1', role: 'contributor' };
+        next();
+      },
+    },
+    '../services/campaignFollowService': followService,
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/campaigns', router);
+  return app;
+}
+
+function followRow(overrides = {}) {
+  return {
+    campaign_id: CAMPAIGN_ID,
+    notify_updates: true,
+    notify_milestones: true,
+    notify_funding: true,
+    created_at: '2026-07-28T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+test('POST /:id/follow records the follow and returns the follower count', async () => {
+  const calls = [];
+  const app = buildApp(async (text, params) => {
+    calls.push({ text, params });
+    if (text.includes('SELECT id FROM campaigns')) return { rows: [{ id: CAMPAIGN_ID }] };
+    if (text.includes('INSERT INTO campaign_followers')) return { rows: [followRow()] };
+    if (text.includes('COUNT(*)::int AS total')) return { rows: [{ total: 3 }] };
+    return { rows: [] };
+  });
+
+  const res = await request(app).post(`/api/campaigns/${CAMPAIGN_ID}/follow`).send({});
+
+  assert.equal(res.status, 201);
+  assert.equal(res.body.following, true);
+  assert.equal(res.body.follower_count, 3);
+  const insert = calls.find((call) => call.text.includes('INSERT INTO campaign_followers'));
+  assert.deepEqual(insert.params, ['user-1', CAMPAIGN_ID]);
+});
+
+test('POST /:id/follow stores the notification preferences it is given', async () => {
+  const calls = [];
+  const app = buildApp(async (text, params) => {
+    calls.push({ text, params });
+    if (text.includes('SELECT id FROM campaigns')) return { rows: [{ id: CAMPAIGN_ID }] };
+    if (text.includes('INSERT INTO campaign_followers')) {
+      return { rows: [followRow({ notify_funding: false })] };
+    }
+    if (text.includes('COUNT(*)::int AS total')) return { rows: [{ total: 1 }] };
+    return { rows: [] };
+  });
+
+  const res = await request(app)
+    .post(`/api/campaigns/${CAMPAIGN_ID}/follow`)
+    .send({ notify_funding: false, unknown_field: 'ignored' });
+
+  assert.equal(res.status, 201);
+  assert.equal(res.body.notify_funding, false);
+  const insert = calls.find((call) => call.text.includes('INSERT INTO campaign_followers'));
+  assert.deepEqual(insert.params, ['user-1', CAMPAIGN_ID, false]);
+  assert.match(insert.text, /notify_funding = EXCLUDED\.notify_funding/);
+  assert.doesNotMatch(insert.text, /notify_updates = EXCLUDED/);
+});
+
+test('POST /:id/follow 404s for an unknown campaign', async () => {
+  const app = buildApp(async () => ({ rows: [] }));
+
+  const res = await request(app).post(`/api/campaigns/${CAMPAIGN_ID}/follow`).send({});
+
+  assert.equal(res.status, 404);
+});
+
+test('GET /:id/follow reports the default preferences when not following', async () => {
+  const app = buildApp(async (text) => {
+    if (text.includes('SELECT id FROM campaigns')) return { rows: [{ id: CAMPAIGN_ID }] };
+    if (text.includes('COUNT(*)::int AS total')) return { rows: [{ total: 0 }] };
+    return { rows: [] };
+  });
+
+  const res = await request(app).get(`/api/campaigns/${CAMPAIGN_ID}/follow`);
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body, {
+    following: false,
+    notify_updates: true,
+    notify_milestones: true,
+    notify_funding: true,
+    follower_count: 0,
+  });
+});
+
+test('PATCH /:id/follow updates only the preferences supplied', async () => {
+  const calls = [];
+  const app = buildApp(async (text, params) => {
+    calls.push({ text, params });
+    if (text.includes('SELECT id FROM campaigns')) return { rows: [{ id: CAMPAIGN_ID }] };
+    if (text.includes('UPDATE campaign_followers')) {
+      return { rows: [followRow({ notify_updates: false })] };
+    }
+    return { rows: [] };
+  });
+
+  const res = await request(app)
+    .patch(`/api/campaigns/${CAMPAIGN_ID}/follow`)
+    .send({ notify_updates: false });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.notify_updates, false);
+  const update = calls.find((call) => call.text.includes('UPDATE campaign_followers'));
+  assert.deepEqual(update.params, ['user-1', CAMPAIGN_ID, false]);
+});
+
+test('PATCH /:id/follow rejects a body with no boolean preference', async () => {
+  const app = buildApp(async (text) => {
+    if (text.includes('SELECT id FROM campaigns')) return { rows: [{ id: CAMPAIGN_ID }] };
+    return { rows: [] };
+  });
+
+  const res = await request(app)
+    .patch(`/api/campaigns/${CAMPAIGN_ID}/follow`)
+    .send({ notify_updates: 'yes' });
+
+  assert.equal(res.status, 422);
+});
+
+test('PATCH /:id/follow 404s when the user does not follow the campaign', async () => {
+  const app = buildApp(async (text) => {
+    if (text.includes('SELECT id FROM campaigns')) return { rows: [{ id: CAMPAIGN_ID }] };
+    return { rows: [] };
+  });
+
+  const res = await request(app)
+    .patch(`/api/campaigns/${CAMPAIGN_ID}/follow`)
+    .send({ notify_updates: false });
+
+  assert.equal(res.status, 404);
+});
+
+test('DELETE /:id/follow removes the follow', async () => {
+  const calls = [];
+  const app = buildApp(async (text, params) => {
+    calls.push({ text, params });
+    return { rows: [], rowCount: 1 };
+  });
+
+  const res = await request(app).delete(`/api/campaigns/${CAMPAIGN_ID}/follow`);
+
+  assert.equal(res.status, 204);
+  const del = calls.find((call) => call.text.includes('DELETE FROM campaign_followers'));
+  assert.deepEqual(del.params, ['user-1', CAMPAIGN_ID]);
+});

--- a/backend/src/routes/campaignUpdates.js
+++ b/backend/src/routes/campaignUpdates.js
@@ -5,6 +5,7 @@ const asyncHandler = require("../utils/asyncHandler");
 const logger = require("../config/logger");
 const { sendCampaignUpdatePostedEmail } = require("../services/emailService");
 const { createNotification } = require("../services/notifications");
+const { notifyFollowers } = require("../services/campaignFollowService");
 
 function frontendBaseUrl() {
   return (process.env.FRONTEND_URL || "http://localhost:5173").replace(/\/$/, "");
@@ -95,8 +96,25 @@ router.post(
          ORDER BY u.id, c.created_at ASC`,
         [req.params.id],
       )
-        .then(({ rows: contributors }) =>
-          Promise.all(
+        .then(({ rows: contributors }) => {
+          notifyFollowers(
+            req.params.id,
+            "notify_updates",
+            {
+              type: "campaign_update",
+              title: `${req.campaign.title}: ${update.title}`,
+              body: updateExcerpt,
+              link: `/campaigns/${req.params.id}`,
+            },
+            [req.user.userId, ...contributors.map((contributor) => contributor.id)],
+          ).catch((err) =>
+            logger.error("Campaign update follower notification failed", {
+              campaignId: req.params.id,
+              error: err.message,
+            }),
+          );
+
+          return Promise.all(
             contributors.map((contributor) => {
               createNotification(contributor.id, {
                 type: "campaign_update",
@@ -122,8 +140,8 @@ router.post(
                 updateBody: update.body,
               });
             }),
-          ),
-        )
+          );
+        })
         .catch((err) => logger.error("Campaign update email failed", { error: err.message }));
     });
 

--- a/backend/src/routes/campaigns.embed.test.js
+++ b/backend/src/routes/campaigns.embed.test.js
@@ -1,0 +1,205 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const request = require('supertest');
+const proxyquire = require('proxyquire').noCallThru();
+const { Keypair } = require('@stellar/stellar-sdk');
+
+if (!process.env.PLATFORM_SECRET_KEY) {
+  process.env.PLATFORM_SECRET_KEY = Keypair.random().secret();
+}
+if (!process.env.USDC_ISSUER) {
+  process.env.USDC_ISSUER = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+}
+
+function buildApp({ queryImpl, authUser }) {
+  const router = proxyquire('./campaigns', {
+    '../services/campaignStatusService': {
+      refreshCampaignStatus: async () => ({ failed: null, funded: null }),
+      refreshActiveCampaignStatuses: async () => ({ failed: [], funded: [] }),
+    },
+    '../services/campaignStatusActions': {
+      queueFailedCampaignRefunds: async () => ({ refundsCreated: 0, refunds: [] }),
+    },
+    '../config/database': {
+      query: queryImpl,
+      connect: async () => ({ query: queryImpl, release: async () => {} }),
+    },
+    '../services/stellarService': {
+      createCampaignWallet: async () => ({ publicKey: 'GPK', secret: 'S' }),
+      getCampaignBalance: async () => ({}),
+      getSupportedAssetCodes: () => ['XLM', 'USDC'],
+      buildWithdrawalTransaction: async () => '',
+    },
+    '../services/ledgerMonitor': { watchCampaignWallet: async () => {} },
+    '../services/stellarTransactionService': {
+      insertWithdrawalPendingSignatures: async () => 'tx-row',
+    },
+    '../config/logger': { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} },
+    '../services/sorobanService': {
+      deployCampaignContracts: async () => ({
+        escrowContractId: 'C' + 'A'.repeat(55),
+        milestonesContractId: 'C' + 'B'.repeat(55),
+      }),
+      invokeContract: async () => null,
+      encodeMilestone: () => ({
+        title_hash: Buffer.alloc(32),
+        release_bps: 1000,
+        status: 0,
+        evidence_hash: null,
+      }),
+      nativeToScVal: (v) => v,
+      scvAddressFromString: (s) => s,
+    },
+    '../services/emailService': { sendEmail: async () => {} },
+    '../services/alerting': { sendAlert: () => {} },
+    '../services/walletService': { encryptSecret: () => 'encrypted-secret' },
+    '../services/webhookDispatcher': {
+      emitWebhookEventForUser: async () => {},
+      WEBHOOK_EVENTS: {
+        CAMPAIGN_CREATED: 'campaign.created',
+        CAMPAIGN_FUNDED: 'campaign.funded',
+        CAMPAIGN_FAILED: 'campaign.failed',
+      },
+    },
+    '../services/storage': { uploadCampaignCoverImage: async () => '/images/cover.jpg' },
+    '../services/kycProvider': {
+      isKycRequiredForCampaigns: () => false,
+    },
+    '../services/userDashboardService': { listCreatorCampaigns: async () => [] },
+    '../services/campaignAnalyticsService': {
+      getCampaignAnalytics: async () => ({}),
+      getCampaignContributors: async () => ({}),
+    },
+    '../middleware/validation': {
+      createCampaignValidation: [],
+      createCampaignUpdateValidation: [],
+      getCampaignsValidation: [],
+      validateRequest: (_req, _res, next) => next(),
+    },
+    '../utils/asyncHandler': (fn) => (req, res, next) => fn(req, res, next).catch(next),
+    '../middleware/auth': {
+      requireAuth: (req, _res, next) => {
+        req.user = authUser || { userId: 'user-1', role: 'creator' };
+        next();
+      },
+      requireRole: () => (_req, _res, next) => next(),
+    },
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use(cookieParser());
+  app.use('/api/campaigns', router);
+  return app;
+}
+
+const CAMPAIGN_ID = '11111111-1111-1111-1111-111111111111';
+
+const CAMPAIGN_ROW = {
+  id: CAMPAIGN_ID,
+  title: 'Solar grid',
+  description: 'Community owned solar',
+  target_amount: '1000',
+  raised_amount: '400',
+  asset_type: 'USDC',
+  status: 'active',
+  deadline: null,
+  backer_count: 12,
+};
+
+const MILESTONE_ROWS = [
+  { id: 'm-1', title: 'Design', release_percentage: '25', sort_order: 0, status: 'released' },
+  { id: 'm-2', title: 'Build', release_percentage: '25', sort_order: 1, status: 'approved' },
+  { id: 'm-3', title: 'Install', release_percentage: '25', sort_order: 2, status: 'pending_review' },
+  { id: 'm-4', title: 'Handover', release_percentage: '25', sort_order: 3, status: 'rejected' },
+];
+
+function embedQuery({ campaignRows = [CAMPAIGN_ROW], milestoneRows = MILESTONE_ROWS } = {}) {
+  const calls = [];
+  const queryImpl = async (text, params) => {
+    calls.push({ text, params });
+    if (text.includes('FROM milestones')) return { rows: milestoneRows };
+    if (text.includes('FROM campaigns WHERE id = $1')) return { rows: campaignRows };
+    return { rows: [] };
+  };
+  return { queryImpl, calls };
+}
+
+test('GET /api/campaigns/:id/embed includes milestones with public statuses', async () => {
+  const { queryImpl, calls } = embedQuery();
+  const app = buildApp({ queryImpl });
+
+  const res = await request(app).get(`/api/campaigns/${CAMPAIGN_ID}/embed`);
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(
+    res.body.milestones.map((milestone) => milestone.status),
+    ['released', 'approved', 'submitted', 'pending']
+  );
+  assert.deepEqual(res.body.milestones[0], {
+    id: 'm-1',
+    title: 'Design',
+    release_percentage: 25,
+    sort_order: 0,
+    status: 'released',
+  });
+  // The campaign id must reach the query untouched — it is a UUID, not an int.
+  const campaignLookup = calls.find((call) => call.text.includes('FROM campaigns WHERE id = $1'));
+  assert.deepEqual(campaignLookup.params, [CAMPAIGN_ID]);
+});
+
+test('GET /api/campaigns/:id/embed summarises milestone progress', async () => {
+  const { queryImpl } = embedQuery();
+  const app = buildApp({ queryImpl });
+
+  const res = await request(app).get(`/api/campaigns/${CAMPAIGN_ID}/embed`);
+
+  assert.deepEqual(res.body.milestone_summary, {
+    total: 4,
+    released: 1,
+    approved: 1,
+    submitted: 1,
+    pending: 1,
+    released_percentage: 25,
+  });
+});
+
+test('GET /api/campaigns/:id/widget carries the same milestone payload', async () => {
+  const { queryImpl } = embedQuery();
+  const app = buildApp({ queryImpl });
+
+  const res = await request(app).get(`/api/campaigns/${CAMPAIGN_ID}/widget`);
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.milestones.length, 4);
+  assert.equal(res.body.milestone_summary.released, 1);
+  assert.equal(res.body.contributor_count, 12);
+});
+
+test('GET /api/campaigns/:id/embed returns an empty milestone list for campaigns without a plan', async () => {
+  const { queryImpl } = embedQuery({ milestoneRows: [] });
+  const app = buildApp({ queryImpl });
+
+  const res = await request(app).get(`/api/campaigns/${CAMPAIGN_ID}/embed`);
+
+  assert.deepEqual(res.body.milestones, []);
+  assert.deepEqual(res.body.milestone_summary, {
+    total: 0,
+    released: 0,
+    approved: 0,
+    submitted: 0,
+    pending: 0,
+    released_percentage: 0,
+  });
+});
+
+test('GET /api/campaigns/:id/embed 404s for a hidden or missing campaign', async () => {
+  const { queryImpl } = embedQuery({ campaignRows: [] });
+  const app = buildApp({ queryImpl });
+
+  const res = await request(app).get(`/api/campaigns/${CAMPAIGN_ID}/embed`);
+
+  assert.equal(res.status, 404);
+});

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -879,6 +879,52 @@ async function loadPublicCampaignSummary(campaignId) {
   };
 }
 
+// The embed widget speaks in four milestone states (#596). Internally a
+// milestone awaiting platform review is `pending_review`, and a rejected one is
+// back in the creator's hands, so both collapse to a public-facing state.
+const EMBED_MILESTONE_STATUS = {
+  pending: 'pending',
+  rejected: 'pending',
+  pending_review: 'submitted',
+  approved: 'approved',
+  released: 'released',
+};
+
+async function loadPublicCampaignMilestones(campaignId) {
+  const { rows } = await db.query(
+    `SELECT id, title, release_percentage, sort_order, status
+     FROM milestones
+     WHERE campaign_id = $1
+     ORDER BY sort_order ASC, created_at ASC`,
+    [campaignId]
+  );
+
+  return rows.map((milestone) => ({
+    id: milestone.id,
+    title: milestone.title,
+    release_percentage: Number(milestone.release_percentage),
+    sort_order: milestone.sort_order,
+    status: EMBED_MILESTONE_STATUS[milestone.status] || 'pending',
+  }));
+}
+
+function summariseMilestones(milestones) {
+  const released = milestones.filter((milestone) => milestone.status === 'released');
+  const releasedPercentage = released.reduce(
+    (total, milestone) => total + milestone.release_percentage,
+    0
+  );
+
+  return {
+    total: milestones.length,
+    released: released.length,
+    approved: milestones.filter((milestone) => milestone.status === 'approved').length,
+    submitted: milestones.filter((milestone) => milestone.status === 'submitted').length,
+    pending: milestones.filter((milestone) => milestone.status === 'pending').length,
+    released_percentage: Math.round(releasedPercentage * 10) / 10,
+  };
+}
+
 function escapeXml(value) {
   return String(value)
     .replace(/&/g, '&amp;')
@@ -913,14 +959,18 @@ router.get('/:id/embed', asyncHandler(async (req, res) => {
   res.header('Access-Control-Allow-Methods', 'GET');
   res.header('Access-Control-Allow-Headers', 'Content-Type');
 
-  const campaignId = parseInt(req.params.id, 10);
+  const campaignId = req.params.id;
   const summary = await loadPublicCampaignSummary(campaignId);
   if (!summary) return res.status(404).json({ error: 'Campaign not found' });
+
+  const milestones = await loadPublicCampaignMilestones(campaignId);
 
   res.json({
     ...summary,
     description:
       summary.description?.slice(0, 200) + (summary.description?.length > 200 ? '...' : ''),
+    milestones,
+    milestone_summary: summariseMilestones(milestones),
   });
 }));
 
@@ -930,9 +980,11 @@ router.get('/:id/widget', asyncHandler(async (req, res) => {
   res.header('Access-Control-Allow-Methods', 'GET');
   res.header('Access-Control-Allow-Headers', 'Content-Type');
 
-  const campaignId = parseInt(req.params.id, 10);
+  const campaignId = req.params.id;
   const summary = await loadPublicCampaignSummary(campaignId);
   if (!summary) return res.status(404).json({ error: 'Campaign not found' });
+
+  const milestones = await loadPublicCampaignMilestones(campaignId);
 
   res.json({
     id: summary.id,
@@ -945,6 +997,8 @@ router.get('/:id/widget', asyncHandler(async (req, res) => {
     days_remaining: summary.days_remaining,
     progress_percentage: summary.progress_percentage,
     contribution_url: summary.contribution_url,
+    milestones,
+    milestone_summary: summariseMilestones(milestones),
   });
 }));
 

--- a/backend/src/routes/milestones.js
+++ b/backend/src/routes/milestones.js
@@ -23,6 +23,7 @@ const { emitWebhookEventForUser, WEBHOOK_EVENTS } = require('../services/webhook
 const { invokeContract, nativeToScVal, releaseMilestone } = require('../services/sorobanService');
 const { uploadMilestoneEvidence } = require('../services/storage');
 const { createNotification } = require('../services/notifications');
+const { notifyFollowers } = require('../services/campaignFollowService');
 const { evaluateCampaign } = require('../services/fraudService');
 const {
   sendMilestoneReleasedCreatorEmail,
@@ -375,6 +376,18 @@ router.post('/:id/submit', requireAuth, async (req, res) => {
         })
       )
       .catch((err) => logger.error('Milestone evidence admin notify failed', { error: err.message }));
+
+    notifyFollowers(
+      milestone.campaign_id,
+      'notify_milestones',
+      {
+        type: 'milestone_evidence_submitted',
+        title: `${milestone.campaign_title}: evidence submitted for "${milestone.title}"`,
+        body: 'The milestone is awaiting platform review.',
+        link: `/campaigns/${milestone.campaign_id}`,
+      },
+      req.user.userId
+    ).catch((err) => logger.error('Milestone follower notify failed', { error: err.message }));
   });
 
   evaluateCampaign(milestone.campaign_id).catch(err => logger.error('Fraud evaluate failed in milestone submit', { error: err.message }));
@@ -766,8 +779,20 @@ const approveMilestoneReleaseHandler = async (req, res) => {
          WHERE c.campaign_id = $1 AND u.email IS NOT NULL
          ORDER BY u.id, c.created_at ASC`,
         [milestone.campaign_id]
-      ).then(({ rows: contributors }) =>
-        Promise.all(
+      ).then(({ rows: contributors }) => {
+        notifyFollowers(
+          milestone.campaign_id,
+          'notify_milestones',
+          {
+            type: 'milestone_released',
+            title: `${milestone.campaign_title}: "${milestone.title}" released`,
+            body: `${releaseAmount} ${milestone.asset_type} has been released to the creator.`,
+            link: `/campaigns/${milestone.campaign_id}`,
+          },
+          [req.user.userId, ...contributors.map((contributor) => contributor.id)]
+        ).catch((e) => logger.error('Milestone follower notify failed', { error: e.message }));
+
+        return Promise.all(
           contributors.map((contributor) =>
             sendMilestoneReleasedContributorEmail({
               to: contributor.email,
@@ -778,8 +803,8 @@ const approveMilestoneReleaseHandler = async (req, res) => {
               milestoneTitle: milestone.title,
             })
           )
-        )
-      ).catch((e) => logger.error('Milestone contributor email failed', { error: e.message }));
+        );
+      }).catch((e) => logger.error('Milestone contributor email failed', { error: e.message }));
     });
 
     evaluateCampaign(milestone.campaign_id).catch(err => logger.error('Fraud evaluate failed in milestone approve', { error: err.message }));

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -5,6 +5,8 @@ const { requireAuth } = require('../middleware/auth');
 const { isKycRequiredForCampaigns } = require('../services/kycProvider');
 const { startKycForUser } = require('../services/kycService');
 const { listCreatorCampaigns, listUserContributions } = require('../services/userDashboardService');
+const { listFollowedCampaigns } = require('../services/campaignFollowService');
+const { evaluateBadges, getLeaderboard } = require('../services/badgeService');
 const { ensureCustodialAccountFundedAndTrusted } = require('../services/stellarService');
 const { withDecryptedWalletSecret } = require('../services/walletSecrets');
 const { sendWalletFundingFailedEmail } = require('../services/emailService');
@@ -180,6 +182,23 @@ router.get('/me/favorites', requireAuth, asyncHandler(async (req, res) => {
     [req.user.userId]
   );
   res.json(rows);
+}));
+
+// Public contributor leaderboard (#597). Declared before /me routes so the
+// literal path is not shadowed by a parameterised one.
+router.get('/leaderboard', asyncHandler(async (req, res) => {
+  const leaderboard = await getLeaderboard({ limit: req.query.limit });
+  res.json(leaderboard);
+}));
+
+router.get('/me/badges', requireAuth, asyncHandler(async (req, res) => {
+  const badges = await evaluateBadges(req.user.userId);
+  res.json(badges);
+}));
+
+router.get('/me/following', requireAuth, asyncHandler(async (req, res) => {
+  const campaigns = await listFollowedCampaigns(req.user.userId);
+  res.json(campaigns);
 }));
 
 router.get('/me/notification-preferences', requireAuth, asyncHandler(async (req, res) => {

--- a/backend/src/services/badgeService.js
+++ b/backend/src/services/badgeService.js
@@ -1,0 +1,266 @@
+const db = require('../config/database');
+const logger = require('../config/logger');
+const { createNotification } = require('./notifications');
+
+// Contributor badges and leaderboard (#597).
+//
+// Badge criteria are evaluated from contribution history on demand. Earned
+// badges are also written to `contributor_badges` so each one is announced to
+// the contributor exactly once, no matter how often the dashboard reloads.
+
+const EARLY_BACKER_RANK = 10;
+const HIGH_VALUE_CONTRIBUTION = 500;
+
+const COMPLETED_CAMPAIGN_STATUSES = ['completed', 'funded', 'withdrawn'];
+
+const BADGE_DEFINITIONS = [
+  {
+    id: 'first_contribution',
+    label: 'First contribution',
+    description: 'Backed your first campaign.',
+    earned: (stats) => stats.campaigns_backed >= 1,
+  },
+  {
+    id: 'backed_5_campaigns',
+    label: 'Backed 5 campaigns',
+    description: 'Backed five different campaigns.',
+    earned: (stats) => stats.campaigns_backed >= 5,
+  },
+  {
+    id: 'backed_10_campaigns',
+    label: 'Backed 10 campaigns',
+    description: 'Backed ten different campaigns.',
+    earned: (stats) => stats.campaigns_backed >= 10,
+  },
+  {
+    id: 'contributed_1000',
+    label: 'Contributed 1,000+',
+    description: 'Contributed 1,000 or more across all campaigns.',
+    earned: (stats) => stats.total_contributed >= 1000,
+  },
+  {
+    id: 'backed_completed_campaign',
+    label: 'Backed a completed campaign',
+    description: 'Backed a campaign that reached its goal.',
+    earned: (stats) => stats.campaigns_completed >= 1,
+  },
+  {
+    id: 'early_backer',
+    label: 'Early backer',
+    description: `Among the first ${EARLY_BACKER_RANK} backers of a campaign.`,
+    earned: (stats) => stats.early_backings >= 1,
+  },
+  {
+    id: 'high_value_backer',
+    label: 'High-value backer',
+    description: `Made a single contribution of ${HIGH_VALUE_CONTRIBUTION.toLocaleString()} or more.`,
+    earned: (stats) => stats.largest_contribution >= HIGH_VALUE_CONTRIBUTION,
+  },
+  {
+    id: 'milestone_witness',
+    label: 'Milestone witness',
+    description: 'Backed a campaign that has released a milestone.',
+    earned: (stats) => stats.campaigns_with_released_milestone >= 1,
+  },
+];
+
+const EMPTY_STATS = {
+  campaigns_backed: 0,
+  contribution_count: 0,
+  total_contributed: 0,
+  largest_contribution: 0,
+  early_backings: 0,
+  campaigns_completed: 0,
+  campaigns_with_released_milestone: 0,
+};
+
+/**
+ * Aggregate everything the badge criteria need for one contributor.
+ */
+async function getContributorBadgeStats(userId) {
+  const { rows: contributionRows } = await db.query(
+    `WITH backer AS (
+       SELECT wallet_public_key AS key FROM users WHERE id = $1
+     ),
+     my_contributions AS (
+       SELECT ctr.id, ctr.campaign_id, ctr.amount, ctr.created_at
+       FROM contributions ctr, backer
+       WHERE ctr.sender_public_key = backer.key
+     ),
+     ranked AS (
+       SELECT mc.id,
+              (SELECT COUNT(*)
+               FROM contributions earlier
+               WHERE earlier.campaign_id = mc.campaign_id
+                 AND earlier.created_at < mc.created_at) AS earlier_count
+       FROM my_contributions mc
+     )
+     SELECT
+       (SELECT COUNT(DISTINCT campaign_id) FROM my_contributions)::int AS campaigns_backed,
+       (SELECT COUNT(*) FROM my_contributions)::int AS contribution_count,
+       (SELECT COALESCE(SUM(amount), 0) FROM my_contributions) AS total_contributed,
+       (SELECT COALESCE(MAX(amount), 0) FROM my_contributions) AS largest_contribution,
+       (SELECT COUNT(*) FROM ranked WHERE earlier_count < $2)::int AS early_backings`,
+    [userId, EARLY_BACKER_RANK]
+  );
+
+  const { rows: campaignRows } = await db.query(
+    `SELECT
+       COUNT(*) FILTER (WHERE c.status = ANY($2::text[]))::int AS campaigns_completed,
+       COUNT(*) FILTER (
+         WHERE EXISTS (
+           SELECT 1 FROM milestones m WHERE m.campaign_id = c.id AND m.status = 'released'
+         )
+       )::int AS campaigns_with_released_milestone
+     FROM campaigns c
+     WHERE c.id IN (
+       SELECT ctr.campaign_id
+       FROM contributions ctr
+       JOIN users u ON u.wallet_public_key = ctr.sender_public_key
+       WHERE u.id = $1
+     )`,
+    [userId, COMPLETED_CAMPAIGN_STATUSES]
+  );
+
+  return {
+    ...EMPTY_STATS,
+    ...contributionRows[0],
+    ...campaignRows[0],
+    total_contributed: Number(contributionRows[0]?.total_contributed || 0),
+    largest_contribution: Number(contributionRows[0]?.largest_contribution || 0),
+  };
+}
+
+function computeBadges(stats, earnedAtById = {}) {
+  return BADGE_DEFINITIONS.map((definition) => ({
+    id: definition.id,
+    label: definition.label,
+    description: definition.description,
+    earned: definition.earned(stats),
+    earned_at: earnedAtById[definition.id] || null,
+  }));
+}
+
+async function loadEarnedBadges(userId) {
+  const { rows } = await db.query(
+    'SELECT badge_id, earned_at FROM contributor_badges WHERE user_id = $1',
+    [userId]
+  );
+  const byId = {};
+  for (const row of rows) byId[row.badge_id] = row.earned_at;
+  return byId;
+}
+
+/**
+ * Persist any badge the contributor has newly qualified for and notify them
+ * about it. Returns the ids that were recorded for the first time.
+ */
+async function recordEarnedBadges(userId, badges) {
+  const newlyEarned = [];
+
+  for (const badge of badges.filter((entry) => entry.earned && !entry.earned_at)) {
+    const { rows } = await db.query(
+      `INSERT INTO contributor_badges (user_id, badge_id)
+       VALUES ($1, $2)
+       ON CONFLICT (user_id, badge_id) DO NOTHING
+       RETURNING earned_at`,
+      [userId, badge.id]
+    );
+    if (!rows.length) continue;
+
+    badge.earned_at = rows[0].earned_at;
+    newlyEarned.push(badge.id);
+
+    try {
+      await createNotification(userId, {
+        type: 'badge_earned',
+        title: `Badge earned: ${badge.label}`,
+        body: badge.description,
+        link: '/profile',
+      });
+    } catch (err) {
+      logger.error('Badge notification failed', {
+        user_id: userId,
+        badge_id: badge.id,
+        error: err.message,
+      });
+    }
+  }
+
+  return newlyEarned;
+}
+
+/**
+ * Evaluate every badge for a contributor, recording and announcing the ones
+ * they have just earned.
+ */
+async function evaluateBadges(userId) {
+  const [stats, earnedAtById] = await Promise.all([
+    getContributorBadgeStats(userId),
+    loadEarnedBadges(userId),
+  ]);
+
+  const badges = computeBadges(stats, earnedAtById);
+  await recordEarnedBadges(userId, badges);
+  return badges;
+}
+
+/**
+ * Same as evaluateBadges but never throws — for call sites (such as ledger
+ * indexing) where badge bookkeeping must not break the primary flow.
+ */
+async function syncBadgesForContributor(userId) {
+  try {
+    return await evaluateBadges(userId);
+  } catch (err) {
+    logger.error('Badge sync failed', { user_id: userId, error: err.message });
+    return [];
+  }
+}
+
+async function syncBadgesForWallet(walletPublicKey) {
+  const { rows } = await db.query('SELECT id FROM users WHERE wallet_public_key = $1', [
+    walletPublicKey,
+  ]);
+  if (!rows.length) return [];
+  return syncBadgesForContributor(rows[0].id);
+}
+
+/**
+ * Public contributor leaderboard, ranked by total contributed.
+ */
+async function getLeaderboard({ limit = 20 } = {}) {
+  const safeLimit = Math.min(Math.max(1, parseInt(limit, 10) || 20), 100);
+
+  const { rows } = await db.query(
+    `SELECT u.id, u.name,
+            COALESCE(SUM(ctr.amount), 0) AS total_contributed,
+            COUNT(DISTINCT ctr.campaign_id)::int AS campaigns_backed,
+            (SELECT COUNT(*)::int FROM contributor_badges b WHERE b.user_id = u.id) AS badge_count
+     FROM users u
+     JOIN contributions ctr ON ctr.sender_public_key = u.wallet_public_key
+     GROUP BY u.id, u.name
+     ORDER BY total_contributed DESC, campaigns_backed DESC, u.name ASC
+     LIMIT $1`,
+    [safeLimit]
+  );
+
+  return rows.map((row, index) => ({
+    rank: index + 1,
+    user_id: row.id,
+    name: row.name,
+    total_contributed: Number(row.total_contributed),
+    campaigns_backed: row.campaigns_backed,
+    badge_count: row.badge_count,
+  }));
+}
+
+module.exports = {
+  BADGE_DEFINITIONS,
+  computeBadges,
+  getContributorBadgeStats,
+  evaluateBadges,
+  syncBadgesForContributor,
+  syncBadgesForWallet,
+  getLeaderboard,
+};

--- a/backend/src/services/badgeService.test.js
+++ b/backend/src/services/badgeService.test.js
@@ -1,0 +1,214 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const proxyquire = require('proxyquire').noCallThru();
+
+function buildService({ queryImpl, onNotification = () => {} }) {
+  return proxyquire('./badgeService', {
+    '../config/database': { query: queryImpl },
+    '../config/logger': { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} },
+    './notifications': {
+      createNotification: async (userId, message) => onNotification(userId, message),
+    },
+  });
+}
+
+const NO_BADGES = {
+  campaigns_backed: 0,
+  contribution_count: 0,
+  total_contributed: 0,
+  largest_contribution: 0,
+  early_backings: 0,
+  campaigns_completed: 0,
+  campaigns_with_released_milestone: 0,
+};
+
+function statsQuery(overrides = {}) {
+  const stats = { ...NO_BADGES, ...overrides };
+  return async (text) => {
+    if (text.includes('my_contributions')) {
+      return {
+        rows: [
+          {
+            campaigns_backed: stats.campaigns_backed,
+            contribution_count: stats.contribution_count,
+            total_contributed: String(stats.total_contributed),
+            largest_contribution: String(stats.largest_contribution),
+            early_backings: stats.early_backings,
+          },
+        ],
+      };
+    }
+    if (text.includes('campaigns_with_released_milestone')) {
+      return {
+        rows: [
+          {
+            campaigns_completed: stats.campaigns_completed,
+            campaigns_with_released_milestone: stats.campaigns_with_released_milestone,
+          },
+        ],
+      };
+    }
+    if (text.includes('FROM contributor_badges')) return { rows: [] };
+    if (text.includes('INSERT INTO contributor_badges')) {
+      return { rows: [{ earned_at: '2026-07-28T00:00:00.000Z' }] };
+    }
+    return { rows: [] };
+  };
+}
+
+function earnedIds(badges) {
+  return badges.filter((badge) => badge.earned).map((badge) => badge.id);
+}
+
+test('computeBadges awards nothing to a contributor with no history', () => {
+  const service = buildService({ queryImpl: async () => ({ rows: [] }) });
+
+  assert.deepEqual(earnedIds(service.computeBadges(NO_BADGES)), []);
+});
+
+test('computeBadges covers the new achievement types', () => {
+  const service = buildService({ queryImpl: async () => ({ rows: [] }) });
+
+  assert.deepEqual(earnedIds(service.computeBadges({ ...NO_BADGES, early_backings: 1 })), [
+    'early_backer',
+  ]);
+  assert.deepEqual(
+    earnedIds(service.computeBadges({ ...NO_BADGES, largest_contribution: 500 })),
+    ['high_value_backer']
+  );
+  assert.deepEqual(
+    earnedIds(service.computeBadges({ ...NO_BADGES, campaigns_with_released_milestone: 2 })),
+    ['milestone_witness']
+  );
+});
+
+test('computeBadges keeps the original contribution-count badges', () => {
+  const service = buildService({ queryImpl: async () => ({ rows: [] }) });
+
+  const badges = service.computeBadges({
+    ...NO_BADGES,
+    campaigns_backed: 10,
+    total_contributed: 1000,
+    campaigns_completed: 1,
+  });
+
+  assert.deepEqual(earnedIds(badges), [
+    'first_contribution',
+    'backed_5_campaigns',
+    'backed_10_campaigns',
+    'contributed_1000',
+    'backed_completed_campaign',
+  ]);
+});
+
+test('getContributorBadgeStats returns numeric totals', async () => {
+  const service = buildService({
+    queryImpl: statsQuery({
+      campaigns_backed: 3,
+      contribution_count: 4,
+      total_contributed: 1250.5,
+      largest_contribution: 600,
+      early_backings: 2,
+      campaigns_completed: 1,
+      campaigns_with_released_milestone: 1,
+    }),
+  });
+
+  const stats = await service.getContributorBadgeStats('user-1');
+
+  assert.equal(stats.total_contributed, 1250.5);
+  assert.equal(stats.largest_contribution, 600);
+  assert.equal(stats.early_backings, 2);
+  assert.equal(stats.campaigns_with_released_milestone, 1);
+});
+
+test('evaluateBadges records and announces each newly earned badge once', async () => {
+  const notifications = [];
+  const inserted = [];
+  const stats = statsQuery({ campaigns_backed: 1, largest_contribution: 500 });
+  let alreadyEarned = [];
+
+  const service = buildService({
+    queryImpl: async (text, params) => {
+      if (text.includes('FROM contributor_badges')) {
+        return { rows: alreadyEarned.map((id) => ({ badge_id: id, earned_at: 'earlier' })) };
+      }
+      if (text.includes('INSERT INTO contributor_badges')) {
+        inserted.push(params[1]);
+        return { rows: [{ earned_at: '2026-07-28T00:00:00.000Z' }] };
+      }
+      return stats(text, params);
+    },
+    onNotification: (userId, message) => notifications.push(message.title),
+  });
+
+  const badges = await service.evaluateBadges('user-1');
+
+  assert.deepEqual(earnedIds(badges), ['first_contribution', 'high_value_backer']);
+  assert.deepEqual(inserted, ['first_contribution', 'high_value_backer']);
+  assert.deepEqual(notifications, [
+    'Badge earned: First contribution',
+    'Badge earned: High-value backer',
+  ]);
+
+  // A second pass over the same history announces nothing new.
+  alreadyEarned = ['first_contribution', 'high_value_backer'];
+  inserted.length = 0;
+  notifications.length = 0;
+  await service.evaluateBadges('user-1');
+
+  assert.deepEqual(inserted, []);
+  assert.deepEqual(notifications, []);
+});
+
+test('syncBadgesForContributor swallows database failures', async () => {
+  const service = buildService({
+    queryImpl: async () => {
+      throw new Error('database is down');
+    },
+  });
+
+  assert.deepEqual(await service.syncBadgesForContributor('user-1'), []);
+});
+
+test('getLeaderboard ranks contributors and caps the page size', async () => {
+  let limitParam = null;
+  const service = buildService({
+    queryImpl: async (text, params) => {
+      limitParam = params[0];
+      return {
+        rows: [
+          { id: 'user-1', name: 'Ada', total_contributed: '900', campaigns_backed: 4, badge_count: 3 },
+          { id: 'user-2', name: 'Grace', total_contributed: '400', campaigns_backed: 2, badge_count: 1 },
+        ],
+      };
+    },
+  });
+
+  const leaderboard = await service.getLeaderboard({ limit: 500 });
+
+  assert.equal(limitParam, 100);
+  assert.deepEqual(leaderboard[0], {
+    rank: 1,
+    user_id: 'user-1',
+    name: 'Ada',
+    total_contributed: 900,
+    campaigns_backed: 4,
+    badge_count: 3,
+  });
+  assert.equal(leaderboard[1].rank, 2);
+});
+
+test('getLeaderboard defaults to 20 entries', async () => {
+  let limitParam = null;
+  const service = buildService({
+    queryImpl: async (_text, params) => {
+      limitParam = params[0];
+      return { rows: [] };
+    },
+  });
+
+  await service.getLeaderboard();
+
+  assert.equal(limitParam, 20);
+});

--- a/backend/src/services/campaignFollowService.js
+++ b/backend/src/services/campaignFollowService.js
@@ -1,0 +1,209 @@
+const db = require('../config/database');
+const logger = require('../config/logger');
+const { createNotification } = require('./notifications');
+
+// Campaign follow/watch (#592). Followers are users who want updates about a
+// campaign without necessarily contributing to it. Each follow row carries its
+// own notification preferences so a follower can, for example, hear about
+// milestone releases but not every funding threshold.
+
+const PREFERENCE_COLUMNS = ['notify_updates', 'notify_milestones', 'notify_funding'];
+
+// Percentages of the funding goal that are worth telling followers about.
+const FUNDING_THRESHOLDS = [25, 50, 75, 100];
+
+function pickPreferences(input = {}) {
+  const prefs = {};
+  for (const column of PREFERENCE_COLUMNS) {
+    if (typeof input[column] === 'boolean') prefs[column] = input[column];
+  }
+  return prefs;
+}
+
+async function followCampaign(userId, campaignId, input = {}) {
+  const prefs = pickPreferences(input);
+  const columns = ['user_id', 'campaign_id', ...Object.keys(prefs)];
+  const values = [userId, campaignId, ...Object.values(prefs)];
+  const placeholders = values.map((_value, index) => `$${index + 1}`);
+
+  // Re-following only rewrites the preferences the caller actually sent, so a
+  // bare follow never clobbers choices the user made earlier.
+  const conflictAction = Object.keys(prefs).length
+    ? `DO UPDATE SET ${Object.keys(prefs)
+        .map((column) => `${column} = EXCLUDED.${column}`)
+        .join(', ')}`
+    : 'DO UPDATE SET user_id = campaign_followers.user_id';
+
+  const { rows } = await db.query(
+    `INSERT INTO campaign_followers (${columns.join(', ')})
+     VALUES (${placeholders.join(', ')})
+     ON CONFLICT (user_id, campaign_id) ${conflictAction}
+     RETURNING campaign_id, notify_updates, notify_milestones, notify_funding, created_at`,
+    values
+  );
+  return { following: true, ...rows[0] };
+}
+
+async function unfollowCampaign(userId, campaignId) {
+  const { rowCount } = await db.query(
+    'DELETE FROM campaign_followers WHERE user_id = $1 AND campaign_id = $2',
+    [userId, campaignId]
+  );
+  return rowCount > 0;
+}
+
+async function updateFollowPreferences(userId, campaignId, input = {}) {
+  const prefs = pickPreferences(input);
+  if (!Object.keys(prefs).length) return null;
+
+  const assignments = Object.keys(prefs).map((column, index) => `${column} = $${index + 3}`);
+  const { rows } = await db.query(
+    `UPDATE campaign_followers
+     SET ${assignments.join(', ')}
+     WHERE user_id = $1 AND campaign_id = $2
+     RETURNING campaign_id, notify_updates, notify_milestones, notify_funding, created_at`,
+    [userId, campaignId, ...Object.values(prefs)]
+  );
+  if (!rows.length) return null;
+  return { following: true, ...rows[0] };
+}
+
+async function getFollowState(userId, campaignId) {
+  const { rows } = await db.query(
+    `SELECT campaign_id, notify_updates, notify_milestones, notify_funding, created_at
+     FROM campaign_followers
+     WHERE user_id = $1 AND campaign_id = $2`,
+    [userId, campaignId]
+  );
+  if (!rows.length) {
+    return {
+      following: false,
+      notify_updates: true,
+      notify_milestones: true,
+      notify_funding: true,
+    };
+  }
+  return { following: true, ...rows[0] };
+}
+
+async function countFollowers(campaignId) {
+  const { rows } = await db.query(
+    'SELECT COUNT(*)::int AS total FROM campaign_followers WHERE campaign_id = $1',
+    [campaignId]
+  );
+  return rows[0]?.total || 0;
+}
+
+async function listFollowedCampaigns(userId) {
+  const { rows } = await db.query(
+    `SELECT c.id, c.title, c.status, c.asset_type, c.target_amount, c.raised_amount, c.deadline,
+            f.notify_updates, f.notify_milestones, f.notify_funding,
+            f.created_at AS followed_at
+     FROM campaign_followers f
+     JOIN campaigns c ON c.id = f.campaign_id
+     WHERE f.user_id = $1 AND c.deleted_at IS NULL
+     ORDER BY f.created_at DESC`,
+    [userId]
+  );
+  return rows;
+}
+
+/**
+ * Fan a campaign event out to its followers.
+ *
+ * @param {string} campaignId
+ * @param {'notify_updates'|'notify_milestones'|'notify_funding'} preference
+ *   Follow-row column that gates this event.
+ * @param {{type: string, title: string, body?: string, link?: string}} message
+ * @param {string|string[]} [exclude] Users already notified through another
+ *   path (the actor, or contributors who get their own alert).
+ * @returns {Promise<number>} number of followers notified
+ */
+async function notifyFollowers(campaignId, preference, message, exclude) {
+  if (!PREFERENCE_COLUMNS.includes(preference)) {
+    throw new Error(`Unknown follower notification preference: ${preference}`);
+  }
+
+  const excluded = (Array.isArray(exclude) ? exclude : [exclude]).filter(Boolean);
+  const { rows: followers } = await db.query(
+    `SELECT user_id
+     FROM campaign_followers
+     WHERE campaign_id = $1 AND ${preference} = TRUE AND NOT (user_id = ANY($2::uuid[]))`,
+    [campaignId, excluded]
+  );
+
+  let notified = 0;
+  for (const follower of followers) {
+    try {
+      await createNotification(follower.user_id, message);
+      notified += 1;
+    } catch (err) {
+      logger.error('Follower notification failed', {
+        campaign_id: campaignId,
+        user_id: follower.user_id,
+        error: err.message,
+      });
+    }
+  }
+  return notified;
+}
+
+function highestThresholdReached(raisedAmount, targetAmount) {
+  if (!targetAmount || Number(targetAmount) <= 0) return null;
+  const pct = (Number(raisedAmount) / Number(targetAmount)) * 100;
+  let reached = null;
+  for (const threshold of FUNDING_THRESHOLDS) {
+    if (pct >= threshold) reached = threshold;
+  }
+  return reached;
+}
+
+/**
+ * Announce a newly crossed funding threshold (25/50/75/100%) to followers.
+ * Claiming the threshold row first makes this safe to call on every
+ * contribution — only the call that inserts the row sends notifications.
+ */
+async function announceFundingProgress(campaignId) {
+  const { rows } = await db.query(
+    'SELECT title, raised_amount, target_amount FROM campaigns WHERE id = $1',
+    [campaignId]
+  );
+  if (!rows.length) return null;
+
+  const campaign = rows[0];
+  const threshold = highestThresholdReached(campaign.raised_amount, campaign.target_amount);
+  if (!threshold) return null;
+
+  const { rowCount } = await db.query(
+    `INSERT INTO campaign_funding_milestones (campaign_id, threshold)
+     VALUES ($1, $2)
+     ON CONFLICT (campaign_id, threshold) DO NOTHING`,
+    [campaignId, threshold]
+  );
+  if (!rowCount) return null;
+
+  await notifyFollowers(campaignId, 'notify_funding', {
+    type: 'campaign_funding_milestone',
+    title: `${campaign.title} reached ${threshold}% funded`,
+    body:
+      threshold === 100
+        ? 'This campaign hit its funding goal.'
+        : `${Number(campaign.raised_amount).toLocaleString()} of ${Number(campaign.target_amount).toLocaleString()} raised so far.`,
+    link: `/campaigns/${campaignId}`,
+  });
+
+  return threshold;
+}
+
+module.exports = {
+  followCampaign,
+  unfollowCampaign,
+  updateFollowPreferences,
+  getFollowState,
+  countFollowers,
+  listFollowedCampaigns,
+  notifyFollowers,
+  announceFundingProgress,
+  highestThresholdReached,
+  FUNDING_THRESHOLDS,
+};

--- a/backend/src/services/campaignFollowService.test.js
+++ b/backend/src/services/campaignFollowService.test.js
@@ -1,0 +1,113 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const proxyquire = require('proxyquire').noCallThru();
+
+const CAMPAIGN_ID = '11111111-1111-1111-1111-111111111111';
+
+function buildService({ queryImpl, onNotification = () => {} }) {
+  return proxyquire('./campaignFollowService', {
+    '../config/database': { query: queryImpl },
+    '../config/logger': { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} },
+    './notifications': {
+      createNotification: async (userId, message) => onNotification(userId, message),
+    },
+  });
+}
+
+test('notifyFollowers skips users already notified through another path', async () => {
+  const calls = [];
+  const notified = [];
+  const service = buildService({
+    queryImpl: async (text, params) => {
+      calls.push({ text, params });
+      return { rows: [{ user_id: 'follower-1' }, { user_id: 'follower-2' }] };
+    },
+    onNotification: (userId) => notified.push(userId),
+  });
+
+  const count = await service.notifyFollowers(
+    CAMPAIGN_ID,
+    'notify_updates',
+    { type: 'campaign_update', title: 'Update' },
+    ['creator-1', 'contributor-1']
+  );
+
+  assert.equal(count, 2);
+  assert.deepEqual(notified, ['follower-1', 'follower-2']);
+  assert.deepEqual(calls[0].params, [CAMPAIGN_ID, ['creator-1', 'contributor-1']]);
+  assert.match(calls[0].text, /notify_updates = TRUE/);
+});
+
+test('notifyFollowers rejects a preference column that does not exist', async () => {
+  const service = buildService({ queryImpl: async () => ({ rows: [] }) });
+
+  await assert.rejects(
+    () => service.notifyFollowers(CAMPAIGN_ID, 'notify_everything', { type: 't', title: 'T' }),
+    /Unknown follower notification preference/
+  );
+});
+
+test('notifyFollowers keeps going when one follower notification fails', async () => {
+  const notified = [];
+  const service = buildService({
+    queryImpl: async () => ({ rows: [{ user_id: 'follower-1' }, { user_id: 'follower-2' }] }),
+    onNotification: (userId) => {
+      if (userId === 'follower-1') throw new Error('channel down');
+      notified.push(userId);
+    },
+  });
+
+  const count = await service.notifyFollowers(CAMPAIGN_ID, 'notify_funding', {
+    type: 'campaign_funding_milestone',
+    title: '50%',
+  });
+
+  assert.equal(count, 1);
+  assert.deepEqual(notified, ['follower-2']);
+});
+
+test('highestThresholdReached picks the largest threshold crossed', () => {
+  const service = buildService({ queryImpl: async () => ({ rows: [] }) });
+
+  assert.equal(service.highestThresholdReached(10, 100), null);
+  assert.equal(service.highestThresholdReached(25, 100), 25);
+  assert.equal(service.highestThresholdReached(74, 100), 50);
+  assert.equal(service.highestThresholdReached(120, 100), 100);
+  assert.equal(service.highestThresholdReached(50, 0), null);
+});
+
+test('announceFundingProgress notifies followers once per threshold', async () => {
+  const notified = [];
+  let thresholdClaimed = false;
+  const service = buildService({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns')) {
+        return { rows: [{ title: 'Solar grid', raised_amount: '600', target_amount: '1000' }] };
+      }
+      if (text.includes('INSERT INTO campaign_funding_milestones')) {
+        const rowCount = thresholdClaimed ? 0 : 1;
+        thresholdClaimed = true;
+        return { rows: [], rowCount };
+      }
+      return { rows: [{ user_id: 'follower-1' }] };
+    },
+    onNotification: (userId, message) => notified.push(message.title),
+  });
+
+  assert.equal(await service.announceFundingProgress(CAMPAIGN_ID), 50);
+  assert.equal(await service.announceFundingProgress(CAMPAIGN_ID), null);
+  assert.deepEqual(notified, ['Solar grid reached 50% funded']);
+});
+
+test('announceFundingProgress stays quiet below the first threshold', async () => {
+  const service = buildService({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns')) {
+        return { rows: [{ title: 'Solar grid', raised_amount: '10', target_amount: '1000' }] };
+      }
+      throw new Error('should not reach the threshold table');
+    },
+  });
+
+  assert.equal(await service.announceFundingProgress(CAMPAIGN_ID), null);
+});

--- a/backend/src/services/ledgerMonitor.js
+++ b/backend/src/services/ledgerMonitor.js
@@ -395,6 +395,24 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
         }),
       );
 
+      // Award any badge this contribution has just unlocked
+      const { syncBadgesForWallet } = require('./badgeService');
+      syncBadgesForWallet(postCommitHooks.receiptPayload.senderPublicKey).catch((e) =>
+        logger.error("[badges] Sync failed", {
+          campaign_id: postCommitHooks.campaignId,
+          error: e.message,
+        }),
+      );
+
+      // Tell followers when the campaign crosses a funding threshold
+      const { announceFundingProgress } = require('./campaignFollowService');
+      announceFundingProgress(postCommitHooks.campaignId).catch((e) =>
+        logger.error("[follow] Funding progress announcement failed", {
+          campaign_id: postCommitHooks.campaignId,
+          error: e.message,
+        }),
+      );
+
       // Bust public caches — contribution changes raised_amount and contributor_count
       cache.invalidate(`campaigns:id:${postCommitHooks.campaignId}`);
       cache.invalidatePrefix('campaigns:list:');

--- a/backend/src/services/userDashboard.test.js
+++ b/backend/src/services/userDashboard.test.js
@@ -61,6 +61,12 @@ test('listUserContributions returns null when user missing', async () => {
   assert.equal(rows, null);
 });
 
+// Badge criteria live in badgeService and are covered by badgeService.test.js;
+// the dashboard only has to surface whatever that service returns.
+function badgeServiceStub(badges = [{ id: 'first_contribution', label: 'First contribution', earned: true }]) {
+  return { evaluateBadges: async () => badges };
+}
+
 // Builds a mocked database whose query() routes by SQL text and records every
 // milestone query it receives. `campaignCount` controls how many distinct
 // campaigns the contributor has backed.
@@ -118,6 +124,7 @@ test('getContributorDashboard batches milestones into a single query (no N+1)', 
   const { db, milestoneQueries } = buildDashboardDb(100);
   const { getContributorDashboard } = proxyquire('./userDashboardService', {
     '../config/database': db,
+    './badgeService': badgeServiceStub(),
   });
 
   const dashboard = await getContributorDashboard('user-1');
@@ -136,9 +143,11 @@ test('getContributorDashboard milestone query count is fixed regardless of campa
 
   const { getContributorDashboard: dashSmall } = proxyquire('./userDashboardService', {
     '../config/database': small.db,
+    './badgeService': badgeServiceStub(),
   });
   const { getContributorDashboard: dashLarge } = proxyquire('./userDashboardService', {
     '../config/database': large.db,
+    './badgeService': badgeServiceStub(),
   });
 
   await dashSmall('user-1');
@@ -152,6 +161,7 @@ test('getContributorDashboard maps batched milestones onto the right campaigns',
   const { db } = buildDashboardDb(3);
   const { getContributorDashboard } = proxyquire('./userDashboardService', {
     '../config/database': db,
+    './badgeService': badgeServiceStub(),
   });
 
   const dashboard = await getContributorDashboard('user-1');
@@ -172,6 +182,9 @@ test('getContributorDashboard returns empty shape when there are no contribution
         return { rows: [] };
       },
     },
+    './badgeService': badgeServiceStub([
+      { id: 'first_contribution', label: 'First contribution', earned: false },
+    ]),
   });
 
   const dashboard = await getContributorDashboard('user-1');
@@ -190,6 +203,11 @@ test('getContributorDashboard computes campaigns_backed, avg_contribution, and b
   const { db } = buildDashboardDb(5);
   const { getContributorDashboard } = proxyquire('./userDashboardService', {
     '../config/database': db,
+    './badgeService': badgeServiceStub([
+      { id: 'first_contribution', label: 'First contribution', earned: true },
+      { id: 'backed_5_campaigns', label: 'Backed 5 campaigns', earned: true },
+      { id: 'backed_10_campaigns', label: 'Backed 10 campaigns', earned: false },
+    ]),
   });
 
   const dashboard = await getContributorDashboard('user-1');
@@ -200,13 +218,13 @@ test('getContributorDashboard computes campaigns_backed, avg_contribution, and b
   assert.equal(dashboard.stats.badges.find((b) => b.id === 'first_contribution').earned, true);
   assert.equal(dashboard.stats.badges.find((b) => b.id === 'backed_5_campaigns').earned, true);
   assert.equal(dashboard.stats.badges.find((b) => b.id === 'backed_10_campaigns').earned, false);
-  assert.equal(dashboard.stats.badges.find((b) => b.id === 'contributed_1000').earned, false);
 });
 
 test('getContributorDashboardCsv builds a CSV with one row per contribution', async () => {
   const { db } = buildDashboardDb(2);
   const { getContributorDashboardCsv } = proxyquire('./userDashboardService', {
     '../config/database': db,
+    './badgeService': badgeServiceStub(),
   });
 
   const csv = await getContributorDashboardCsv('user-1');

--- a/backend/src/services/userDashboardService.js
+++ b/backend/src/services/userDashboardService.js
@@ -1,4 +1,5 @@
 const db = require('../config/database');
+const { evaluateBadges } = require('./badgeService');
 
 async function listCreatorCampaigns(userId, options = {}) {
   const page = Math.max(1, parseInt(options.page, 10) || 1);
@@ -63,42 +64,6 @@ async function listUserContributions(userId) {
 const ACTIVE_CAMPAIGN_STATUSES = new Set(['active', 'funded']);
 const COMPLETED_CAMPAIGN_STATUSES = new Set(['completed', 'funded', 'withdrawn']);
 
-const BADGE_DEFINITIONS = [
-  {
-    id: 'first_contribution',
-    label: 'First contribution',
-    earned: (stats) => stats.campaigns_backed >= 1,
-  },
-  {
-    id: 'backed_5_campaigns',
-    label: 'Backed 5 campaigns',
-    earned: (stats) => stats.campaigns_backed >= 5,
-  },
-  {
-    id: 'backed_10_campaigns',
-    label: 'Backed 10 campaigns',
-    earned: (stats) => stats.campaigns_backed >= 10,
-  },
-  {
-    id: 'contributed_1000',
-    label: 'Contributed 1,000+',
-    earned: (stats) => stats.total_contributed >= 1000,
-  },
-  {
-    id: 'backed_completed_campaign',
-    label: 'Backed a completed campaign',
-    earned: (stats) => stats.campaigns_completed >= 1,
-  },
-];
-
-function computeBadges(stats) {
-  return BADGE_DEFINITIONS.map((def) => ({
-    id: def.id,
-    label: def.label,
-    earned: def.earned(stats),
-  }));
-}
-
 async function getContributorDashboard(userId) {
   const { rows: userRows } = await db.query(
     'SELECT wallet_public_key FROM users WHERE id = $1',
@@ -130,7 +95,7 @@ async function getContributorDashboard(userId) {
       avg_contribution: 0,
     };
     return {
-      stats: { ...emptyStats, badges: computeBadges(emptyStats) },
+      stats: { ...emptyStats, badges: await evaluateBadges(userId) },
       campaigns: [],
     };
   }
@@ -218,7 +183,7 @@ async function getContributorDashboard(userId) {
   };
 
   return {
-    stats: { ...stats, badges: computeBadges(stats) },
+    stats: { ...stats, badges: await evaluateBadges(userId) },
     campaigns: allCampaigns,
   };
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -30,6 +30,7 @@ const HowItWorks = lazy(() => import('./pages/HowItWorks'));
 const Pricing = lazy(() => import('./pages/Pricing'));
 const About = lazy(() => import('./pages/About'));
 const Resources = lazy(() => import('./pages/Resources'));
+const Leaderboard = lazy(() => import('./pages/Leaderboard'));
 const NotFound = lazy(() => import('./pages/NotFound'));
 
 function PrivateRoute({ children }) {
@@ -60,6 +61,7 @@ export default function App() {
                 <Route path="/pricing" element={<Pricing />} />
                 <Route path="/about" element={<About />} />
                 <Route path="/resources" element={<Resources />} />
+                <Route path="/leaderboard" element={<Leaderboard />} />
                 <Route
                   path="/campaigns/new"
                   element={

--- a/frontend/src/components/ContributorBadges.jsx
+++ b/frontend/src/components/ContributorBadges.jsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { api } from '../services/api';
+
+export function BadgeChip({ badge }) {
+  const title = badge.earned_at
+    ? `${badge.description} Earned ${new Date(badge.earned_at).toLocaleDateString()}.`
+    : badge.description;
+
+  return (
+    <span
+      title={title}
+      style={{
+        fontSize: '0.78rem',
+        fontWeight: 600,
+        padding: '0.3rem 0.65rem',
+        borderRadius: '99px',
+        border: '1px solid var(--color-border-lighter)',
+        color: badge.earned ? 'var(--color-accent)' : 'var(--color-text-hint)',
+        background: badge.earned ? 'var(--color-accent-bg, rgba(99,102,241,0.1))' : 'transparent',
+        opacity: badge.earned ? 1 : 0.5,
+      }}
+    >
+      {badge.label}
+    </span>
+  );
+}
+
+export default function ContributorBadges() {
+  const [badges, setBadges] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    api
+      .getMyBadges()
+      .then(setBadges)
+      .catch((err) => setError(err.message || 'Could not load badges'));
+  }, []);
+
+  const earnedCount = badges?.filter((badge) => badge.earned).length || 0;
+
+  return (
+    <div className="campaign-card" style={{ marginBottom: '2rem' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: '0.75rem',
+          flexWrap: 'wrap',
+          marginBottom: '0.75rem',
+        }}
+      >
+        <h2 style={{ fontSize: '1.15rem', fontWeight: 700 }}>
+          Badges {badges && `(${earnedCount}/${badges.length})`}
+        </h2>
+        <Link to="/leaderboard" style={{ color: 'var(--color-accent)', fontWeight: 600, fontSize: '0.85rem' }}>
+          View leaderboard
+        </Link>
+      </div>
+
+      {error && <p className="alert alert--error">{error}</p>}
+      {!badges && !error && <p style={{ color: 'var(--color-text-hint)' }}>Loading badges…</p>}
+
+      {badges && (
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+          {badges.map((badge) => (
+            <BadgeChip key={badge.id} badge={badge} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ContributorDashboard.jsx
+++ b/frontend/src/components/ContributorDashboard.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { api } from '../services/api';
 import { stellarExpertTxUrl } from '../config/stellar';
 import CampaignStatusBadge from './CampaignStatusBadge';
+import { BadgeChip } from './ContributorBadges';
 import { useToast } from '../context/ToastContext';
 
 function milestoneStatusLabel(status) {
@@ -275,23 +276,14 @@ function BadgesRow({ badges }) {
   return (
     <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1.25rem' }}>
       {badges.map((badge) => (
-        <span
-          key={badge.id}
-          title={badge.label}
-          style={{
-            fontSize: '0.78rem',
-            fontWeight: 600,
-            padding: '0.3rem 0.65rem',
-            borderRadius: '99px',
-            border: '1px solid var(--color-border-lighter)',
-            color: badge.earned ? 'var(--color-accent)' : 'var(--color-text-hint)',
-            background: badge.earned ? 'var(--color-accent-bg, rgba(99,102,241,0.1))' : 'transparent',
-            opacity: badge.earned ? 1 : 0.5,
-          }}
-        >
-          {badge.label}
-        </span>
+        <BadgeChip key={badge.id} badge={badge} />
       ))}
+      <Link
+        to="/leaderboard"
+        style={{ alignSelf: 'center', color: 'var(--color-accent)', fontWeight: 600, fontSize: '0.78rem' }}
+      >
+        Leaderboard
+      </Link>
     </div>
   );
 }

--- a/frontend/src/components/FollowCampaignButton.jsx
+++ b/frontend/src/components/FollowCampaignButton.jsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from 'react';
+import { api } from '../services/api';
+
+export const FOLLOW_PREFERENCES = [
+  { key: 'notify_updates', label: 'Campaign updates' },
+  { key: 'notify_milestones', label: 'Milestone progress' },
+  { key: 'notify_funding', label: 'Funding milestones' },
+];
+
+export default function FollowCampaignButton({ campaignId }) {
+  const [follow, setFollow] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [showPreferences, setShowPreferences] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let active = true;
+    api
+      .getCampaignFollow(campaignId)
+      .then((state) => {
+        if (active) setFollow(state);
+      })
+      .catch(() => {
+        if (active) setFollow({ following: false, follower_count: 0 });
+      });
+    return () => {
+      active = false;
+    };
+  }, [campaignId]);
+
+  async function toggleFollow() {
+    setBusy(true);
+    setError('');
+    try {
+      if (follow?.following) {
+        await api.unfollowCampaign(campaignId);
+        setFollow((prev) => ({
+          ...prev,
+          following: false,
+          follower_count: Math.max(0, (prev?.follower_count || 1) - 1),
+        }));
+        setShowPreferences(false);
+      } else {
+        const next = await api.followCampaign(campaignId);
+        setFollow(next);
+      }
+    } catch (err) {
+      setError(err.message || 'Could not update follow status');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function togglePreference(key) {
+    const next = !follow[key];
+    setFollow((prev) => ({ ...prev, [key]: next }));
+    try {
+      await api.updateCampaignFollow(campaignId, { [key]: next });
+    } catch (err) {
+      setFollow((prev) => ({ ...prev, [key]: !next }));
+      setError(err.message || 'Could not save notification preference');
+    }
+  }
+
+  if (!follow) return null;
+
+  return (
+    <span style={{ display: 'inline-flex', flexDirection: 'column', gap: '0.35rem' }}>
+      <span style={{ display: 'inline-flex', gap: '0.35rem', alignItems: 'center' }}>
+        <button
+          type="button"
+          onClick={toggleFollow}
+          disabled={busy}
+          aria-pressed={follow.following}
+          title={follow.following ? 'Stop following this campaign' : 'Follow this campaign'}
+          style={{
+            background: 'none',
+            border: '1px solid var(--color-border-lighter)',
+            borderRadius: '999px',
+            fontSize: '0.85rem',
+            padding: '0.2rem 0.6rem',
+            cursor: 'pointer',
+            color: follow.following ? 'var(--color-accent)' : 'var(--color-text-hint)',
+          }}
+        >
+          {follow.following ? '🔔 Following' : '🔕 Follow'}
+          {follow.follower_count > 0 && ` (${follow.follower_count})`}
+        </button>
+        {follow.following && (
+          <button
+            type="button"
+            onClick={() => setShowPreferences((open) => !open)}
+            aria-expanded={showPreferences}
+            aria-label="Notification preferences for this campaign"
+            style={{
+              background: 'none',
+              border: '1px solid var(--color-border-lighter)',
+              borderRadius: '999px',
+              fontSize: '0.85rem',
+              padding: '0.2rem 0.5rem',
+              cursor: 'pointer',
+              color: 'var(--color-text-hint)',
+            }}
+          >
+            ⚙
+          </button>
+        )}
+      </span>
+
+      {follow.following && showPreferences && (
+        <span
+          style={{
+            display: 'grid',
+            gap: '0.25rem',
+            padding: '0.5rem 0.65rem',
+            border: '1px solid var(--color-border-lighter)',
+            borderRadius: '8px',
+            fontSize: '0.8rem',
+          }}
+        >
+          <strong style={{ fontSize: '0.78rem' }}>Notify me about</strong>
+          {FOLLOW_PREFERENCES.map((preference) => (
+            <label
+              key={preference.key}
+              style={{ display: 'flex', gap: '0.4rem', alignItems: 'center', cursor: 'pointer' }}
+            >
+              <input
+                type="checkbox"
+                checked={Boolean(follow[preference.key])}
+                onChange={() => togglePreference(preference.key)}
+                style={{ width: 'auto', margin: 0 }}
+              />
+              {preference.label}
+            </label>
+          ))}
+        </span>
+      )}
+
+      {error && (
+        <span style={{ fontSize: '0.75rem', color: 'var(--color-status-error)' }}>{error}</span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/components/FollowedCampaigns.jsx
+++ b/frontend/src/components/FollowedCampaigns.jsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { api } from '../services/api';
+import CampaignStatusBadge from './CampaignStatusBadge';
+import { FOLLOW_PREFERENCES } from './FollowCampaignButton';
+
+function progressPct(campaign) {
+  if (!Number(campaign.target_amount)) return 0;
+  return Math.min(100, (Number(campaign.raised_amount) / Number(campaign.target_amount)) * 100);
+}
+
+export default function FollowedCampaigns() {
+  const [campaigns, setCampaigns] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    api
+      .getFollowedCampaigns()
+      .then(setCampaigns)
+      .catch((err) => setError(err.message || 'Could not load followed campaigns'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function togglePreference(campaignId, key, value) {
+    setCampaigns((prev) =>
+      prev.map((campaign) => (campaign.id === campaignId ? { ...campaign, [key]: value } : campaign))
+    );
+    try {
+      await api.updateCampaignFollow(campaignId, { [key]: value });
+    } catch (err) {
+      setCampaigns((prev) =>
+        prev.map((campaign) =>
+          campaign.id === campaignId ? { ...campaign, [key]: !value } : campaign
+        )
+      );
+      setError(err.message || 'Could not save notification preference');
+    }
+  }
+
+  async function unfollow(campaignId) {
+    const previous = campaigns;
+    setCampaigns((prev) => prev.filter((campaign) => campaign.id !== campaignId));
+    try {
+      await api.unfollowCampaign(campaignId);
+    } catch (err) {
+      setCampaigns(previous);
+      setError(err.message || 'Could not unfollow campaign');
+    }
+  }
+
+  if (loading) {
+    return <p style={{ color: 'var(--color-text-hint)' }}>Loading followed campaigns…</p>;
+  }
+
+  if (!campaigns.length) {
+    return (
+      <div>
+        {error && <p className="alert alert--error">{error}</p>}
+        <p className="alert alert--info">
+          You are not following any campaigns yet. Follow a campaign to get updates without
+          contributing.{' '}
+          <Link to="/discover" style={{ color: 'var(--color-accent)', fontWeight: 600 }}>
+            Browse campaigns
+          </Link>
+          .
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {error && <p className="alert alert--error">{error}</p>}
+      <div style={{ display: 'grid', gap: '0.85rem' }}>
+        {campaigns.map((campaign) => {
+          const pct = progressPct(campaign);
+          return (
+            <article key={campaign.id} className="campaign-card" style={{ minHeight: 'auto' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  gap: '0.5rem',
+                  flexWrap: 'wrap',
+                  alignItems: 'center',
+                }}
+              >
+                <Link
+                  to={`/campaigns/${campaign.id}`}
+                  style={{ color: 'var(--color-accent)', fontWeight: 700, fontSize: '1rem' }}
+                >
+                  {campaign.title}
+                </Link>
+                <CampaignStatusBadge status={campaign.status} />
+              </div>
+
+              <div style={{ marginTop: '0.6rem', fontSize: '0.85rem' }}>
+                {Number(campaign.raised_amount).toLocaleString()} /{' '}
+                {Number(campaign.target_amount).toLocaleString()} {campaign.asset_type} ·{' '}
+                {pct.toFixed(1)}%
+              </div>
+              <div
+                style={{
+                  height: '8px',
+                  marginTop: '0.35rem',
+                  borderRadius: '99px',
+                  background: 'var(--color-border-lighter)',
+                  overflow: 'hidden',
+                }}
+                role="progressbar"
+                aria-valuenow={Math.round(pct)}
+                aria-valuemin={0}
+                aria-valuemax={100}
+              >
+                <div
+                  style={{
+                    height: '100%',
+                    width: `${pct}%`,
+                    background: 'var(--color-accent)',
+                    borderRadius: '99px',
+                  }}
+                />
+              </div>
+
+              <div
+                style={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  gap: '0.75rem',
+                  alignItems: 'center',
+                  marginTop: '0.75rem',
+                  fontSize: '0.8rem',
+                }}
+              >
+                {FOLLOW_PREFERENCES.map((preference) => (
+                  <label
+                    key={preference.key}
+                    style={{ display: 'flex', gap: '0.35rem', alignItems: 'center', cursor: 'pointer' }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={Boolean(campaign[preference.key])}
+                      onChange={(e) =>
+                        togglePreference(campaign.id, preference.key, e.target.checked)
+                      }
+                      style={{ width: 'auto', margin: 0 }}
+                    />
+                    {preference.label}
+                  </label>
+                ))}
+                <button
+                  type="button"
+                  className="btn-secondary"
+                  style={{ fontSize: '0.78rem', marginLeft: 'auto' }}
+                  onClick={() => unfollow(campaign.id)}
+                >
+                  Unfollow
+                </button>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MilestoneProgressBar.jsx
+++ b/frontend/src/components/MilestoneProgressBar.jsx
@@ -1,0 +1,116 @@
+// Milestone progress for embeds (#596). Inline styles only — this renders
+// inside the standalone embed bundle, which does not load the app stylesheet.
+
+export const MILESTONE_STATUS_META = {
+  released: { label: 'Released', color: '#10b981' },
+  approved: { label: 'Approved', color: '#3b82f6' },
+  submitted: { label: 'Submitted', color: '#f59e0b' },
+  pending: { label: 'Pending', color: '#9ca3af' },
+};
+
+export const WIDGET_SIZES = ['small', 'medium', 'large'];
+
+export function normalizeWidgetSize(size) {
+  return WIDGET_SIZES.includes(size) ? size : 'medium';
+}
+
+function statusMeta(status) {
+  return MILESTONE_STATUS_META[status] || MILESTONE_STATUS_META.pending;
+}
+
+export default function MilestoneProgressBar({ milestones, summary, size = 'medium' }) {
+  const resolvedSize = normalizeWidgetSize(size);
+  if (resolvedSize === 'small' || !milestones?.length) return null;
+
+  const totalPercentage = milestones.reduce(
+    (total, milestone) => total + (Number(milestone.release_percentage) || 0),
+    0
+  );
+
+  return (
+    <div style={{ marginBottom: '0.85rem' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'baseline',
+          gap: '0.5rem',
+          marginBottom: '0.35rem',
+          fontSize: '0.75rem',
+          color: 'var(--color-text-hint, #6b7280)',
+        }}
+      >
+        <span style={{ fontWeight: 700 }}>Milestones</span>
+        <span>
+          {summary?.released ?? 0} of {summary?.total ?? milestones.length} released
+        </span>
+      </div>
+
+      <div
+        style={{ display: 'flex', gap: '2px', height: '8px' }}
+        role="img"
+        aria-label={`${summary?.released ?? 0} of ${summary?.total ?? milestones.length} milestones released`}
+      >
+        {milestones.map((milestone) => {
+          const share = totalPercentage
+            ? (Number(milestone.release_percentage) || 0) / totalPercentage
+            : 1 / milestones.length;
+          return (
+            <div
+              key={milestone.id}
+              title={`${milestone.title} — ${statusMeta(milestone.status).label}`}
+              style={{
+                flexGrow: Math.max(share, 0.05),
+                flexBasis: 0,
+                borderRadius: '99px',
+                background: statusMeta(milestone.status).color,
+                opacity: milestone.status === 'pending' ? 0.45 : 1,
+              }}
+            />
+          );
+        })}
+      </div>
+
+      {resolvedSize === 'large' && (
+        <ul
+          style={{
+            listStyle: 'none',
+            margin: '0.55rem 0 0',
+            padding: 0,
+            display: 'grid',
+            gap: '0.3rem',
+          }}
+        >
+          {milestones.map((milestone) => (
+            <li
+              key={milestone.id}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                gap: '0.5rem',
+                fontSize: '0.78rem',
+              }}
+            >
+              <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                {milestone.title}
+                <span style={{ color: 'var(--color-text-hint, #6b7280)' }}>
+                  {' '}
+                  · {Number(milestone.release_percentage)}%
+                </span>
+              </span>
+              <span
+                style={{
+                  flexShrink: 0,
+                  fontWeight: 600,
+                  color: statusMeta(milestone.status).color,
+                }}
+              >
+                {statusMeta(milestone.status).label}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/embed-widget/index.js
+++ b/frontend/src/embed-widget/index.js
@@ -1,15 +1,24 @@
+// Widget sizes control how much detail the embed renders (#596): `small` is the
+// bare funding bar, `medium` adds milestone status indicators, `large` lists
+// every milestone with its status.
+const SIZES = ['small', 'medium', 'large'];
+const MIN_HEIGHTS = { small: 140, medium: 220, large: 300 };
+
 export function initCrowdPayEmbed(script) {
   if (!script) return;
   const campaignId = script.getAttribute('data-campaign');
   const theme = script.getAttribute('data-theme') || 'light';
+  const requestedSize = script.getAttribute('data-size');
+  const size = SIZES.includes(requestedSize) ? requestedSize : 'medium';
   if (!campaignId) {
     console.error('CrowdPay embed: data-campaign attribute is required');
     return;
   }
 
   const iframe = document.createElement('iframe');
-  const params = new URLSearchParams({ theme });
+  const params = new URLSearchParams({ theme, size });
   iframe.src = `${window.location.origin}/embed/campaigns/${campaignId}?${params.toString()}`;
+  iframe.style.minHeight = `${MIN_HEIGHTS[size]}px`;
   iframe.style.width = '100%';
   iframe.style.border = 'none';
   iframe.style.borderRadius = '8px';

--- a/frontend/src/lib/campaignDraft.js
+++ b/frontend/src/lib/campaignDraft.js
@@ -1,0 +1,61 @@
+const STORAGE_KEY = 'crowdpay:campaign_draft';
+
+// Drafts are a convenience, not a record — anything older than a week is more
+// likely to confuse a creator than help them.
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+const IGNORED_FIELDS = new Set(['asset_type', 'show_backer_amounts']);
+
+/**
+ * Whether a form holds anything worth restoring. Defaults the creator never
+ * touched (asset type, backer visibility) do not count.
+ */
+export function hasDraftContent(form) {
+  if (!form) return false;
+  return Object.entries(form).some(([field, value]) => {
+    if (IGNORED_FIELDS.has(field)) return false;
+    if (Array.isArray(value)) return value.length > 0;
+    return typeof value === 'string' ? value.trim() !== '' : Boolean(value);
+  });
+}
+
+export function saveDraft(form, step) {
+  if (!hasDraftContent(form)) return null;
+  const draft = { form, step, saved_at: new Date().toISOString() };
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(draft));
+    return draft;
+  } catch {
+    // storage unavailable (private browsing, quota) — skip silently
+    return null;
+  }
+}
+
+export function loadDraft() {
+  let draft;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    draft = raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+
+  if (!draft || typeof draft !== 'object' || !draft.form) return null;
+  if (!hasDraftContent(draft.form)) return null;
+
+  const savedAt = Date.parse(draft.saved_at);
+  if (Number.isNaN(savedAt) || Date.now() - savedAt > MAX_AGE_MS) {
+    clearDraft();
+    return null;
+  }
+
+  return draft;
+}
+
+export function clearDraft() {
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // storage unavailable — nothing to clean up
+  }
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -496,6 +496,7 @@
     "tabs": {
       "campaigns": "My Campaigns",
       "contributions": "My Contributions",
+      "following": "Following",
       "analytics": "Analytics",
       "apiKeys": "API Keys",
       "referrals": "Referrals"

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -493,6 +493,7 @@
     "tabs": {
       "campaigns": "Mes campagnes",
       "contributions": "Mes contributions",
+      "following": "Suivis",
       "analytics": "Analytique",
       "apiKeys": "Clés API",
       "referrals": "Parrainages"

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -21,6 +21,7 @@ import { getNetwork, signTransaction } from '@stellar/freighter-api';
 import { isConnected, getPublicKey } from '@stellar/freighter-api';
 import BackerInsightsCard from '../components/BackerInsightsCard';
 import CampaignComments from '../components/CampaignComments';
+import FollowCampaignButton from '../components/FollowCampaignButton';
 import { addRecentlyViewed } from '../lib/recentlyViewed';
 
 
@@ -1171,6 +1172,7 @@ export default function Campaign() {
           <CampaignStatusBadge status={campaign.status} />
           <VerificationBadge status={campaign.creator_kyc_status} />
           {user && <FavoriteToggle campaignId={campaign.id} />}
+          {user && <FollowCampaignButton campaignId={campaign.id} />}
           {campaign.contract_address && (
             <span
               title="This campaign is backed by a Soroban smart contract"

--- a/frontend/src/pages/CampaignEmbed.jsx
+++ b/frontend/src/pages/CampaignEmbed.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import MilestoneProgressBar, { normalizeWidgetSize } from '../components/MilestoneProgressBar';
 
 const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || '').replace(/\/+$/, '');
 const BASE_URL = import.meta.env.VITE_API_URL || `${API_BASE_URL}/api`;
@@ -12,6 +13,7 @@ export default function CampaignEmbed() {
   // Extract campaign ID from URL path: /embed/campaigns/:id
   const pathParts = window.location.pathname.split('/');
   const campaignId = pathParts[pathParts.length - 1];
+  const size = normalizeWidgetSize(new URLSearchParams(window.location.search).get('size'));
 
   useEffect(() => {
     if (!campaignId) {
@@ -119,7 +121,9 @@ export default function CampaignEmbed() {
 
       <h1 style={styles.title}>{campaign.title}</h1>
 
-      {campaign.description && <p style={styles.description}>{campaign.description}</p>}
+      {size !== 'small' && campaign.description && (
+        <p style={styles.description}>{campaign.description}</p>
+      )}
 
       <div style={styles.progressSection}>
         <div style={styles.amounts}>
@@ -157,6 +161,12 @@ export default function CampaignEmbed() {
           )}
         </div>
       </div>
+
+      <MilestoneProgressBar
+        milestones={campaign.milestones}
+        summary={campaign.milestone_summary}
+        size={size}
+      />
 
       <a
         href={campaign.contribution_url}

--- a/frontend/src/pages/CreateCampaign.jsx
+++ b/frontend/src/pages/CreateCampaign.jsx
@@ -8,6 +8,9 @@ import { useAuth } from '../context/AuthContext';
 import OnboardingCallout from '../components/OnboardingCallout';
 import KycPrompt from '../components/KycPrompt';
 import { isCreatorOnboardingVisible, dismissCreatorOnboarding } from '../lib/onboarding';
+import { saveDraft, loadDraft, clearDraft, hasDraftContent } from '../lib/campaignDraft';
+
+const DRAFT_SAVE_DEBOUNCE_MS = 800;
 
 const ASSETS = [
   {
@@ -77,6 +80,61 @@ export default function CreateCampaign() {
   const [duplicateWarning, setDuplicateWarning] = useState(null);
   const today = new Date().toISOString().split('T')[0];
   const [showCreatorTips, setShowCreatorTips] = useState(isCreatorOnboardingVisible);
+  // A draft found in storage on load. Auto-save stays paused until the creator
+  // restores or discards it, so an untouched form cannot overwrite it.
+  const [pendingDraft, setPendingDraft] = useState(() =>
+    location.state?.prefill ? null : loadDraft()
+  );
+  const [draftSavedAt, setDraftSavedAt] = useState(null);
+  const [draftSaving, setDraftSaving] = useState(false);
+
+  useEffect(() => {
+    if (pendingDraft) return undefined;
+    if (!hasDraftContent(form)) return undefined;
+
+    setDraftSaving(true);
+    const timer = setTimeout(() => {
+      const draft = saveDraft(form, step);
+      setDraftSaving(false);
+      if (draft) setDraftSavedAt(draft.saved_at);
+    }, DRAFT_SAVE_DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [form, step, pendingDraft]);
+
+  function restoreDraft() {
+    setForm(pendingDraft.form);
+    setStep(pendingDraft.step || 1);
+    setDraftSavedAt(pendingDraft.saved_at);
+    setPendingDraft(null);
+  }
+
+  function discardDraft() {
+    clearDraft();
+    setPendingDraft(null);
+    setDraftSavedAt(null);
+  }
+
+  function discardCurrentDraft() {
+    clearDraft();
+    setDraftSavedAt(null);
+    setForm({
+      title: '',
+      description: '',
+      target_amount: '',
+      asset_type: 'USDC',
+      deadline: '',
+      category: '',
+      min_contribution: '',
+      max_contribution: '',
+      max_per_user: '',
+      show_backer_amounts: true,
+      milestones: [],
+      reward_tiers: [],
+    });
+    setStep(1);
+    setError('');
+  }
 
   useEffect(() => {
     if (ready && !user) {
@@ -360,6 +418,8 @@ export default function CreateCampaign() {
           : undefined,
       });
 
+      clearDraft();
+
       let coverUploadError = '';
       if (coverImageFile) {
         try {
@@ -481,6 +541,62 @@ export default function CreateCampaign() {
             <li>{t('createCampaign.tip3')}</li>
           </ul>
         </OnboardingCallout>
+      )}
+
+      {pendingDraft && (
+        <div className="alert alert--info" style={{ marginBottom: '1.25rem' }} role="status">
+          <p>
+            You have an unsaved draft from{' '}
+            <strong>{new Date(pendingDraft.saved_at).toLocaleString()}</strong>.
+          </p>
+          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginTop: '0.65rem' }}>
+            <button type="button" className="btn-primary" onClick={restoreDraft}>
+              Restore draft
+            </button>
+            <button type="button" className="btn-secondary" onClick={discardDraft}>
+              Discard draft
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!pendingDraft && (draftSaving || draftSavedAt) && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.65rem',
+            flexWrap: 'wrap',
+            marginBottom: '1rem',
+            fontSize: '0.8rem',
+            color: 'var(--color-text-hint)',
+          }}
+          role="status"
+          aria-live="polite"
+        >
+          <span>
+            {draftSaving
+              ? 'Saving draft…'
+              : `Draft saved ${new Date(draftSavedAt).toLocaleTimeString()}`}
+          </span>
+          {draftSavedAt && (
+            <button
+              type="button"
+              onClick={discardCurrentDraft}
+              style={{
+                background: 'none',
+                border: 'none',
+                padding: 0,
+                color: 'var(--color-accent)',
+                fontWeight: 600,
+                cursor: 'pointer',
+                fontSize: '0.8rem',
+              }}
+            >
+              Discard draft
+            </button>
+          )}
+        </div>
       )}
 
       <form onSubmit={handleSubmit}>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -7,6 +7,7 @@ import KycPrompt from '../components/KycPrompt';
 import VerificationBadge from '../components/VerificationBadge';
 import CampaignStatusBadge from '../components/CampaignStatusBadge';
 import ContributorDashboard from '../components/ContributorDashboard';
+import FollowedCampaigns from '../components/FollowedCampaigns';
 import DepositModal from '../components/DepositModal';
 import ApiKeysPanel from '../components/ApiKeysPanel';
 import BackerInsightsCard from '../components/BackerInsightsCard';
@@ -25,6 +26,7 @@ import {
 const TABS = [
   { id: 'campaigns', labelKey: 'dashboard.tabs.campaigns' },
   { id: 'contributions', labelKey: 'dashboard.tabs.contributions' },
+  { id: 'following', labelKey: 'dashboard.tabs.following' },
   { id: 'analytics', labelKey: 'dashboard.tabs.analytics' },
   { id: 'api-keys', labelKey: 'dashboard.tabs.apiKeys' },
 ];
@@ -292,13 +294,15 @@ export default function Dashboard() {
   const activeTab =
     tabParam === 'contributions'
       ? 'contributions'
-      : tabParam === 'referrals'
-        ? 'referrals'
-        : tabParam === 'analytics'
-          ? 'analytics'
-          : tabParam === 'api-keys'
-            ? 'api-keys'
-            : 'campaigns';
+      : tabParam === 'following'
+        ? 'following'
+        : tabParam === 'referrals'
+          ? 'referrals'
+          : tabParam === 'analytics'
+            ? 'analytics'
+            : tabParam === 'api-keys'
+              ? 'api-keys'
+              : 'campaigns';
 
   const [stats, setStats] = useState(null);
   const [campaigns, setCampaigns] = useState([]);
@@ -521,6 +525,8 @@ export default function Dashboard() {
   function setTab(tabId) {
     if (tabId === 'contributions') {
       setSearchParams({ tab: 'contributions' });
+    } else if (tabId === 'following') {
+      setSearchParams({ tab: 'following' });
     } else if (tabId === 'analytics') {
       setSearchParams({ tab: 'analytics' });
     } else if (tabId === 'referrals') {
@@ -891,6 +897,12 @@ export default function Dashboard() {
       {activeTab === 'contributions' && (
         <section role="tabpanel" aria-labelledby="tab-contributions">
           <ContributorDashboard />
+        </section>
+      )}
+
+      {activeTab === 'following' && (
+        <section role="tabpanel" aria-labelledby="tab-following">
+          <FollowedCampaigns />
         </section>
       )}
 

--- a/frontend/src/pages/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard.jsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { api } from '../services/api';
+
+export default function Leaderboard() {
+  const [entries, setEntries] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    api
+      .getLeaderboard(20)
+      .then(setEntries)
+      .catch((err) => setError(err.message || 'Could not load the leaderboard'));
+  }, []);
+
+  return (
+    <main className="container page-narrow" style={{ paddingTop: '3rem', paddingBottom: '4rem' }}>
+      <h1 style={{ fontSize: '1.75rem', fontWeight: 800, marginBottom: '0.35rem' }}>
+        Contributor leaderboard
+      </h1>
+      <p style={{ color: 'var(--color-text-secondary)', marginBottom: '1.5rem' }}>
+        The backers who have put the most behind CrowdPay campaigns.
+      </p>
+
+      {error && <p className="alert alert--error">{error}</p>}
+      {!entries && !error && <p style={{ color: 'var(--color-text-hint)' }}>Loading leaderboard…</p>}
+
+      {entries && entries.length === 0 && (
+        <p className="alert alert--info">No contributions have been recorded yet.</p>
+      )}
+
+      {entries && entries.length > 0 && (
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
+            <thead>
+              <tr style={{ textAlign: 'left', color: 'var(--color-text-hint)' }}>
+                <th style={{ padding: '0.5rem 0.6rem' }}>#</th>
+                <th style={{ padding: '0.5rem 0.6rem' }}>Contributor</th>
+                <th style={{ padding: '0.5rem 0.6rem', textAlign: 'right' }}>Contributed</th>
+                <th style={{ padding: '0.5rem 0.6rem', textAlign: 'right' }}>Campaigns</th>
+                <th style={{ padding: '0.5rem 0.6rem', textAlign: 'right' }}>Badges</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((entry) => (
+                <tr key={entry.user_id} style={{ borderTop: '1px solid var(--color-border-lighter)' }}>
+                  <td style={{ padding: '0.6rem', fontWeight: 700 }}>{entry.rank}</td>
+                  <td style={{ padding: '0.6rem' }}>{entry.name}</td>
+                  <td style={{ padding: '0.6rem', textAlign: 'right' }}>
+                    {entry.total_contributed.toLocaleString(undefined, {
+                      maximumFractionDigits: 2,
+                    })}
+                  </td>
+                  <td style={{ padding: '0.6rem', textAlign: 'right' }}>{entry.campaigns_backed}</td>
+                  <td style={{ padding: '0.6rem', textAlign: 'right' }}>{entry.badge_count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../context/AuthContext';
 import { stellarExpertAccountUrl } from '../config/stellar';
 import VerificationBadge from '../components/VerificationBadge';
 import KycPrompt from '../components/KycPrompt';
+import ContributorBadges from '../components/ContributorBadges';
 import { api } from '../services/api';
 
 const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || '').replace(/\/+$/, '');
@@ -188,6 +189,8 @@ export default function Profile() {
           </button>
         </form>
       </div>
+
+      <ContributorBadges />
 
       <div className="campaign-card" style={{ marginBottom: '2rem' }}>
         <div

--- a/frontend/src/pages/Widget.jsx
+++ b/frontend/src/pages/Widget.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
+import MilestoneProgressBar, { normalizeWidgetSize } from '../components/MilestoneProgressBar';
 
 const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || '').replace(/\/+$/, '');
 const BASE_URL = `${API_BASE_URL}/api`;
@@ -10,6 +11,8 @@ function isDocumentVisible() {
 
 export default function Widget() {
   const { id } = useParams();
+  const [searchParams] = useSearchParams();
+  const size = normalizeWidgetSize(searchParams.get('size'));
   const [data, setData] = useState(null);
   const [error, setError] = useState('');
 
@@ -108,6 +111,11 @@ export default function Widget() {
             </>
           )}
         </div>
+        <MilestoneProgressBar
+          milestones={data.milestones}
+          summary={data.milestone_summary}
+          size={size}
+        />
         <a
           href={campaignUrl}
           target="_blank"

--- a/frontend/src/pages/embed-widget.test.jsx
+++ b/frontend/src/pages/embed-widget.test.jsx
@@ -43,6 +43,20 @@ describe('embed-widget script', () => {
     expect(document.querySelector('iframe').src).toContain('theme=light');
   });
 
+  it('passes the requested widget size through to the iframe', () => {
+    createScript({ 'data-campaign': '7', 'data-size': 'large' });
+    initCrowdPayEmbed(script);
+    const iframe = document.querySelector('iframe');
+    expect(iframe.src).toContain('size=large');
+    expect(iframe.style.minHeight).toBe('300px');
+  });
+
+  it('falls back to the medium size for an unknown data-size', () => {
+    createScript({ 'data-campaign': '7', 'data-size': 'enormous' });
+    initCrowdPayEmbed(script);
+    expect(document.querySelector('iframe').src).toContain('size=medium');
+  });
+
   it('adds sandbox and payment allow', () => {
     createScript({ 'data-campaign': '7' });
     initCrowdPayEmbed(script);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -452,6 +452,17 @@ export const api = {
   addFavorite: (campaignId) => request('POST', `/campaigns/${campaignId}/favorite`, {}),
   removeFavorite: (campaignId) => request('DELETE', `/campaigns/${campaignId}/favorite`),
 
+  getCampaignFollow: (campaignId) => request('GET', `/campaigns/${campaignId}/follow`),
+  followCampaign: (campaignId, preferences) =>
+    request('POST', `/campaigns/${campaignId}/follow`, preferences || {}),
+  updateCampaignFollow: (campaignId, preferences) =>
+    request('PATCH', `/campaigns/${campaignId}/follow`, preferences),
+  unfollowCampaign: (campaignId) => request('DELETE', `/campaigns/${campaignId}/follow`),
+  getFollowedCampaigns: () => request('GET', '/users/me/following'),
+
+  getMyBadges: () => request('GET', '/users/me/badges'),
+  getLeaderboard: (limit) => request('GET', '/users/leaderboard', null, { query: { limit } }),
+
   getWithdrawalCapabilities: () => request('GET', '/withdrawals/capabilities'),
   listWithdrawals: (campaignId) => request('GET', `/withdrawals/campaign/${campaignId}`),
   requestWithdrawal: (body) => request('POST', '/withdrawals/request', body),

--- a/frontend/src/test/campaignDraft.test.js
+++ b/frontend/src/test/campaignDraft.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { saveDraft, loadDraft, clearDraft, hasDraftContent } from '../lib/campaignDraft';
+
+const STORAGE_KEY = 'crowdpay:campaign_draft';
+
+const EMPTY_FORM = {
+  title: '',
+  description: '',
+  target_amount: '',
+  asset_type: 'USDC',
+  deadline: '',
+  category: '',
+  show_backer_amounts: true,
+  milestones: [],
+  reward_tiers: [],
+};
+
+describe('campaignDraft', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('treats an untouched form as having nothing to restore', () => {
+    expect(hasDraftContent(EMPTY_FORM)).toBe(false);
+    expect(saveDraft(EMPTY_FORM, 1)).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('saves and restores a form with content', () => {
+    const form = { ...EMPTY_FORM, title: 'Solar grid', target_amount: '500' };
+
+    const saved = saveDraft(form, 2);
+
+    expect(saved.saved_at).toBeTruthy();
+    expect(loadDraft()).toEqual({ form, step: 2, saved_at: saved.saved_at });
+  });
+
+  it('counts a filled milestone list as content', () => {
+    const form = {
+      ...EMPTY_FORM,
+      milestones: [{ title: 'Prototype', description: '', release_percentage: '50' }],
+    };
+
+    expect(hasDraftContent(form)).toBe(true);
+    expect(saveDraft(form, 3)).not.toBeNull();
+  });
+
+  it('drops drafts older than a week', () => {
+    const staleDraft = {
+      form: { ...EMPTY_FORM, title: 'Old idea' },
+      step: 1,
+      saved_at: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(staleDraft));
+
+    expect(loadDraft()).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('ignores unparseable or malformed storage entries', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'not json');
+    expect(loadDraft()).toBeNull();
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ step: 1 }));
+    expect(loadDraft()).toBeNull();
+  });
+
+  it('clears a stored draft', () => {
+    saveDraft({ ...EMPTY_FORM, title: 'Solar grid' }, 1);
+
+    clearDraft();
+
+    expect(loadDraft()).toBeNull();
+  });
+});

--- a/frontend/src/test/components/ContributorBadges.test.jsx
+++ b/frontend/src/test/components/ContributorBadges.test.jsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../renderWithProviders';
+import ContributorBadges from '../../components/ContributorBadges';
+
+vi.mock('../../services/api', () => ({
+  api: { getMyBadges: vi.fn() },
+}));
+
+import { api } from '../../services/api';
+
+const BADGES = [
+  {
+    id: 'first_contribution',
+    label: 'First contribution',
+    description: 'Backed your first campaign.',
+    earned: true,
+    earned_at: '2026-07-01T00:00:00.000Z',
+  },
+  {
+    id: 'early_backer',
+    label: 'Early backer',
+    description: 'Among the first 10 backers of a campaign.',
+    earned: true,
+    earned_at: '2026-07-02T00:00:00.000Z',
+  },
+  {
+    id: 'milestone_witness',
+    label: 'Milestone witness',
+    description: 'Backed a campaign that has released a milestone.',
+    earned: false,
+    earned_at: null,
+  },
+];
+
+describe('ContributorBadges', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows how many badges have been earned and links to the leaderboard', async () => {
+    api.getMyBadges.mockResolvedValue(BADGES);
+
+    renderWithProviders(<ContributorBadges />);
+
+    expect(await screen.findByText('Badges (2/3)')).toBeInTheDocument();
+    expect(screen.getByText('Early backer')).toBeInTheDocument();
+    expect(screen.getByText('Milestone witness')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /View leaderboard/i })).toHaveAttribute(
+      'href',
+      '/leaderboard'
+    );
+  });
+
+  it('surfaces a load failure', async () => {
+    api.getMyBadges.mockRejectedValue(new Error('Server unavailable'));
+
+    renderWithProviders(<ContributorBadges />);
+
+    expect(await screen.findByText('Server unavailable')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/components/FollowCampaignButton.test.jsx
+++ b/frontend/src/test/components/FollowCampaignButton.test.jsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../renderWithProviders';
+import FollowCampaignButton from '../../components/FollowCampaignButton';
+
+vi.mock('../../services/api', () => ({
+  api: {
+    getCampaignFollow: vi.fn(),
+    followCampaign: vi.fn(),
+    unfollowCampaign: vi.fn(),
+    updateCampaignFollow: vi.fn(),
+  },
+}));
+
+import { api } from '../../services/api';
+
+const NOT_FOLLOWING = {
+  following: false,
+  notify_updates: true,
+  notify_milestones: true,
+  notify_funding: true,
+  follower_count: 4,
+};
+
+const FOLLOWING = { ...NOT_FOLLOWING, following: true, follower_count: 5 };
+
+describe('FollowCampaignButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('follows a campaign and shows the updated follower count', async () => {
+    api.getCampaignFollow.mockResolvedValue(NOT_FOLLOWING);
+    api.followCampaign.mockResolvedValue(FOLLOWING);
+
+    renderWithProviders(<FollowCampaignButton campaignId="campaign-1" />);
+
+    const button = await screen.findByRole('button', { name: /Follow/i });
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+
+    await userEvent.click(button);
+
+    await waitFor(() => expect(api.followCampaign).toHaveBeenCalledWith('campaign-1'));
+    expect(await screen.findByRole('button', { name: /Following \(5\)/i })).toBeInTheDocument();
+  });
+
+  it('unfollows a campaign', async () => {
+    api.getCampaignFollow.mockResolvedValue(FOLLOWING);
+    api.unfollowCampaign.mockResolvedValue(undefined);
+
+    renderWithProviders(<FollowCampaignButton campaignId="campaign-1" />);
+
+    await userEvent.click(await screen.findByRole('button', { name: /Following/i }));
+
+    await waitFor(() => expect(api.unfollowCampaign).toHaveBeenCalledWith('campaign-1'));
+    expect(await screen.findByRole('button', { name: /Follow \(4\)/i })).toBeInTheDocument();
+  });
+
+  it('saves a notification preference for the followed campaign', async () => {
+    api.getCampaignFollow.mockResolvedValue(FOLLOWING);
+    api.updateCampaignFollow.mockResolvedValue({ ...FOLLOWING, notify_funding: false });
+
+    renderWithProviders(<FollowCampaignButton campaignId="campaign-1" />);
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: /Notification preferences/i })
+    );
+    await userEvent.click(screen.getByLabelText('Funding milestones'));
+
+    await waitFor(() =>
+      expect(api.updateCampaignFollow).toHaveBeenCalledWith('campaign-1', {
+        notify_funding: false,
+      })
+    );
+    expect(screen.getByLabelText('Funding milestones')).not.toBeChecked();
+  });
+
+  it('restores the previous preference when saving fails', async () => {
+    api.getCampaignFollow.mockResolvedValue(FOLLOWING);
+    api.updateCampaignFollow.mockRejectedValue(new Error('Network error'));
+
+    renderWithProviders(<FollowCampaignButton campaignId="campaign-1" />);
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: /Notification preferences/i })
+    );
+    await userEvent.click(screen.getByLabelText('Campaign updates'));
+
+    expect(await screen.findByText('Network error')).toBeInTheDocument();
+    expect(screen.getByLabelText('Campaign updates')).toBeChecked();
+  });
+});

--- a/frontend/src/test/components/MilestoneProgressBar.test.jsx
+++ b/frontend/src/test/components/MilestoneProgressBar.test.jsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MilestoneProgressBar, { normalizeWidgetSize } from '../../components/MilestoneProgressBar';
+
+const MILESTONES = [
+  { id: 'm-1', title: 'Design', release_percentage: 25, status: 'released' },
+  { id: 'm-2', title: 'Build', release_percentage: 25, status: 'approved' },
+  { id: 'm-3', title: 'Install', release_percentage: 25, status: 'submitted' },
+  { id: 'm-4', title: 'Handover', release_percentage: 25, status: 'pending' },
+];
+
+const SUMMARY = {
+  total: 4,
+  released: 1,
+  approved: 1,
+  submitted: 1,
+  pending: 1,
+  released_percentage: 25,
+};
+
+describe('MilestoneProgressBar', () => {
+  it('falls back to the medium size for unknown values', () => {
+    expect(normalizeWidgetSize('large')).toBe('large');
+    expect(normalizeWidgetSize('huge')).toBe('medium');
+    expect(normalizeWidgetSize(null)).toBe('medium');
+  });
+
+  it('shows how many milestones have been released', () => {
+    render(<MilestoneProgressBar milestones={MILESTONES} summary={SUMMARY} />);
+
+    expect(screen.getByText('1 of 4 released')).toBeInTheDocument();
+    expect(
+      screen.getByRole('img', { name: '1 of 4 milestones released' })
+    ).toBeInTheDocument();
+  });
+
+  it('lists every milestone with its status at the large size', () => {
+    render(<MilestoneProgressBar milestones={MILESTONES} summary={SUMMARY} size="large" />);
+
+    expect(screen.getByText('Released')).toBeInTheDocument();
+    expect(screen.getByText('Approved')).toBeInTheDocument();
+    expect(screen.getByText('Submitted')).toBeInTheDocument();
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText('Handover')).toBeInTheDocument();
+  });
+
+  it('renders nothing at the small size or without milestones', () => {
+    const { container: small } = render(
+      <MilestoneProgressBar milestones={MILESTONES} summary={SUMMARY} size="small" />
+    );
+    expect(small).toBeEmptyDOMElement();
+
+    const { container: none } = render(<MilestoneProgressBar milestones={[]} summary={null} />);
+    expect(none).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/test/pages/CreateCampaignDraft.test.jsx
+++ b/frontend/src/test/pages/CreateCampaignDraft.test.jsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import CreateCampaign from '../../pages/CreateCampaign';
+import { renderWithProviders } from '../renderWithProviders';
+
+vi.mock('react-simplemde-editor', () => ({
+  default: ({ id, value, onChange }) => (
+    <textarea id={id} value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'user1', role: 'creator', kyc_status: 'verified' },
+    ready: true,
+    updateUser: vi.fn(),
+  }),
+}));
+
+const apiMocks = vi.hoisted(() => ({
+  getMe: vi.fn().mockResolvedValue({ id: 'user1', role: 'creator' }),
+  checkDuplicateCampaign: vi.fn().mockResolvedValue({ isDuplicate: false }),
+  createCampaign: vi.fn().mockResolvedValue({ id: 'new-campaign' }),
+  uploadCampaignCoverImage: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('../../services/api', () => ({ api: apiMocks }));
+
+const STORAGE_KEY = 'crowdpay:campaign_draft';
+
+function storedDraft() {
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  return raw ? JSON.parse(raw) : null;
+}
+
+describe('CreateCampaign draft auto-save', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, '');
+  });
+
+  it('auto-saves edits and shows a saved indicator', async () => {
+    renderWithProviders(<CreateCampaign />);
+
+    fireEvent.change(await screen.findByLabelText(/Campaign title/i), {
+      target: { value: 'Solar grid' },
+    });
+
+    expect(await screen.findByText(/Saving draft/i)).toBeInTheDocument();
+    await waitFor(() => expect(storedDraft()?.form.title).toBe('Solar grid'), { timeout: 3000 });
+    expect(await screen.findByText(/Draft saved/i)).toBeInTheDocument();
+  });
+
+  it('does not save an untouched form', async () => {
+    renderWithProviders(<CreateCampaign />);
+
+    await screen.findByLabelText(/Campaign title/i);
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    expect(storedDraft()).toBeNull();
+  });
+
+  it('offers to restore a stored draft and reinstates its values', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        form: {
+          title: 'Recovered campaign',
+          description: '',
+          target_amount: '900',
+          asset_type: 'XLM',
+          deadline: '',
+          category: '',
+          min_contribution: '',
+          max_contribution: '',
+          max_per_user: '',
+          show_backer_amounts: true,
+          milestones: [],
+          reward_tiers: [],
+        },
+        step: 1,
+        saved_at: new Date().toISOString(),
+      })
+    );
+
+    renderWithProviders(<CreateCampaign />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /Restore draft/i }));
+
+    expect(screen.getByLabelText(/Campaign title/i)).toHaveValue('Recovered campaign');
+    expect(screen.getByLabelText(/Fundraising goal/i)).toHaveValue(900);
+  });
+
+  it('discards a stored draft without touching the form', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        form: { title: 'Abandoned campaign', milestones: [], reward_tiers: [] },
+        step: 1,
+        saved_at: new Date().toISOString(),
+      })
+    );
+
+    renderWithProviders(<CreateCampaign />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /Discard draft/i }));
+
+    expect(storedDraft()).toBeNull();
+    expect(screen.getByLabelText(/Campaign title/i)).toHaveValue('');
+  });
+
+  it('clears the draft once the campaign is created', async () => {
+    renderWithProviders(<CreateCampaign />);
+
+    fireEvent.change(await screen.findByLabelText(/Campaign title/i), {
+      target: { value: 'Solar grid' },
+    });
+    fireEvent.change(screen.getByLabelText(/Fundraising goal/i), { target: { value: '500' } });
+    await waitFor(() => expect(storedDraft()).not.toBeNull(), { timeout: 3000 });
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue to details/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Continue to milestones/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Launch campaign/i }));
+
+    await waitFor(() => expect(apiMocks.createCampaign).toHaveBeenCalled());
+    await waitFor(() => expect(storedDraft()).toBeNull());
+  });
+});

--- a/frontend/src/test/pages/Leaderboard.test.jsx
+++ b/frontend/src/test/pages/Leaderboard.test.jsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../renderWithProviders';
+import Leaderboard from '../../pages/Leaderboard';
+
+vi.mock('../../services/api', () => ({
+  api: { getLeaderboard: vi.fn() },
+}));
+
+import { api } from '../../services/api';
+
+describe('Leaderboard page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ranks contributors by amount contributed', async () => {
+    api.getLeaderboard.mockResolvedValue([
+      { rank: 1, user_id: 'u1', name: 'Ada', total_contributed: 900, campaigns_backed: 4, badge_count: 3 },
+      { rank: 2, user_id: 'u2', name: 'Grace', total_contributed: 400, campaigns_backed: 2, badge_count: 1 },
+    ]);
+
+    renderWithProviders(<Leaderboard />);
+
+    expect(await screen.findByText('Ada')).toBeInTheDocument();
+    expect(screen.getByText('Grace')).toBeInTheDocument();
+    expect(screen.getAllByRole('row')).toHaveLength(3); // header + 2 contributors
+  });
+
+  it('explains an empty leaderboard', async () => {
+    api.getLeaderboard.mockResolvedValue([]);
+
+    renderWithProviders(<Leaderboard />);
+
+    expect(await screen.findByText(/No contributions have been recorded yet/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Implements four funded engagement-feature issues:

- **#592 — Campaign follow/watch**: contributors can follow a campaign to get notified about updates, milestone progress, and funding thresholds without contributing. Each follow has its own per-event notification toggles (`notify_updates`, `notify_milestones`, `notify_funding`). A `campaign_funding_milestones` table makes sure a 25/50/75/100% funding announcement only fires once. Follow button lives on the campaign page; a new "Following" dashboard tab lists followed campaigns.
- **#594 — Campaign draft auto-save**: `CreateCampaign` debounces the in-progress form into `localStorage`, shows a "Draft saved …" indicator, offers to restore a draft found on load (discarding anything older than a week), and clears the draft once the campaign is actually created.
- **#596 — Milestone progress for embeds**: the `/embed` and `/widget` campaign payloads now include each milestone's public status (`pending` / `submitted` / `approved` / `released`) plus a summary. The embed script accepts `data-size` (`small` / `medium` / `large`) to control how much milestone detail renders.
- **#597 — Contributor badges & leaderboard**: expands the existing badge system with `early_backer`, `high_value_backer`, and `milestone_witness` achievements, persists earned badges (`contributor_badges` table) so each is announced exactly once, and adds a public `GET /users/leaderboard` ranked by total contributed, with a `/leaderboard` page and a badges panel on `/profile`.

## Decisions worth flagging

- Funding-milestone and badge-earned notifications are evaluated inline in the ledger monitor's post-commit hooks (same place contribution receipts/webhooks already fire), wrapped so a failure there never breaks contribution indexing.
- Follow preferences default to "on" for a bare `POST /follow` with no body, matching how favoriting already works; `PATCH` only updates the keys explicitly sent.
- Badge criteria are computed from contribution history on each dashboard load and only persisted (and notified) the first time a badge is newly earned, so re-evaluating is idempotent.

## Test plan

- `cd backend && npm test` — all new/changed suites pass (`campaignFollowService`, `campaignFollowers` routes, `badgeService`, `campaigns.embed`, `userDashboard`, `campaigns`, `milestones`, `ledgerMonitor`). One pre-existing, unrelated failure (`listCreatorCampaigns queries by creator_id`) reproduces identically on `main` before this branch.
- `cd frontend && npm test` — 40 files / 123 tests pass, including new coverage for `FollowCampaignButton`, `FollowedCampaigns`, `campaignDraft`, the `CreateCampaign` draft flow, `MilestoneProgressBar`, `ContributorBadges`, and `Leaderboard`.
- `cd frontend && npm run build` — succeeds.
- `npm run lint` in both `backend/` and `frontend/` — 0 errors (warning counts unchanged/consistent with pre-existing style).
- Manually verified: follow/unfollow a campaign and toggle its notification checkboxes from the campaign page and the dashboard's Following tab; create a campaign, watch the draft auto-save and restore/discard flow; hit `/campaigns/:id/embed` and `/campaigns/:id/widget` and confirm `milestones`/`milestone_summary` in the response; load `/profile` and `/leaderboard` to see badges and rankings.

Closes #592, closes #594, closes #596, closes #597