### PR TITLE
Add contributor milestone voting

### DIFF
--- a/backend/db/migrations/20260728_milestone_votes.sql
+++ b/backend/db/migrations/20260728_milestone_votes.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS milestone_votes (
+  milestone_id UUID NOT NULL REFERENCES milestones(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  vote TEXT NOT NULL CHECK (vote IN ('approve', 'reject')),
+  note TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (milestone_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS milestone_votes_milestone_vote_idx
+  ON milestone_votes (milestone_id, vote);

--- a/backend/src/routes/milestones.js
+++ b/backend/src/routes/milestones.js
@@ -131,6 +131,70 @@ async function assertCanSubmitMilestone(milestone, userId, userRole) {
   }
 }
 
+async function getMilestoneVoteContext(milestoneId, userId) {
+  const { rows } = await db.query(
+    `SELECT m.id, m.campaign_id, m.title, m.status,
+            c.creator_id, c.title AS campaign_title,
+            u.wallet_public_key
+     FROM milestones m
+     JOIN campaigns c ON c.id = m.campaign_id
+     JOIN users u ON u.id = $2
+     WHERE m.id = $1`,
+    [milestoneId, userId]
+  );
+  if (!rows.length) return null;
+
+  const milestone = rows[0];
+  const { rows: contributorRows } = await db.query(
+    `SELECT 1
+     FROM contributions
+     WHERE campaign_id = $1 AND sender_public_key = $2
+     LIMIT 1`,
+    [milestone.campaign_id, milestone.wallet_public_key]
+  );
+
+  return {
+    milestone,
+    isContributor: contributorRows.length > 0,
+    isCreator: milestone.creator_id === userId,
+  };
+}
+
+async function getMilestoneVoteTally(milestoneId, userId) {
+  const { rows } = await db.query(
+    `SELECT
+       COUNT(*) FILTER (WHERE vote = 'approve')::int AS approve_count,
+       COUNT(*) FILTER (WHERE vote = 'reject')::int AS reject_count,
+       COUNT(*)::int AS total_votes
+     FROM milestone_votes
+     WHERE milestone_id = $1`,
+    [milestoneId]
+  );
+  const tally = rows[0] || {};
+  const approveCount = Number(tally.approve_count || 0);
+  const rejectCount = Number(tally.reject_count || 0);
+  const totalVotes = Number(tally.total_votes || 0);
+  let userVote = null;
+
+  if (userId) {
+    const { rows: userRows } = await db.query(
+      `SELECT vote, note, created_at, updated_at
+       FROM milestone_votes
+       WHERE milestone_id = $1 AND user_id = $2`,
+      [milestoneId, userId]
+    );
+    userVote = userRows[0] || null;
+  }
+
+  return {
+    approve_count: approveCount,
+    reject_count: rejectCount,
+    total_votes: totalVotes,
+    approval_ratio: totalVotes ? approveCount / totalVotes : null,
+    user_vote: userVote,
+  };
+}
+
 async function logWithdrawalEvent(client, { withdrawalRequestId, actorUserId, action, note, metadata }) {
   await client.query(
     `INSERT INTO withdrawal_approval_events
@@ -456,6 +520,64 @@ router.get('/:id/events', requireAuth, asyncHandler(async (req, res) => {
   res.json(rows);
 }));
 
+router.get('/:id/votes', requireAuth, asyncHandler(async (req, res) => {
+  const context = await getMilestoneVoteContext(req.params.id, req.user.userId);
+  if (!context) return res.status(404).json({ error: 'Milestone not found' });
+
+  const canPlatform = canPerformPlatformSignature(req.user.userId);
+  if (!context.isContributor && !context.isCreator && !canPlatform && req.user.role !== 'admin') {
+    return res.status(403).json({ error: 'Not authorized to view milestone votes' });
+  }
+
+  const tally = await getMilestoneVoteTally(req.params.id, req.user.userId);
+  res.json({
+    milestone_id: req.params.id,
+    ...tally,
+  });
+}));
+
+router.post('/:id/votes', requireAuth, asyncHandler(async (req, res) => {
+  const vote = String(req.body?.vote || '').trim().toLowerCase();
+  const note = String(req.body?.note || '').trim() || null;
+  if (!['approve', 'reject'].includes(vote)) {
+    return res.status(400).json({ error: 'vote must be approve or reject' });
+  }
+
+  const context = await getMilestoneVoteContext(req.params.id, req.user.userId);
+  if (!context) return res.status(404).json({ error: 'Milestone not found' });
+  if (!context.isContributor) {
+    return res.status(403).json({ error: 'Only contributors can vote on milestone approval' });
+  }
+  if (context.isCreator) {
+    return res.status(403).json({ error: 'Campaign creators cannot vote on their own milestone approval' });
+  }
+  if (context.milestone.status !== 'pending_review') {
+    return res.status(409).json({ error: 'Milestone voting is only open while evidence is awaiting review' });
+  }
+
+  await db.query(
+    `INSERT INTO milestone_votes (milestone_id, user_id, vote, note)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (milestone_id, user_id)
+     DO UPDATE SET vote = EXCLUDED.vote, note = EXCLUDED.note, updated_at = NOW()`,
+    [req.params.id, req.user.userId, vote, note]
+  );
+
+  await logMilestoneEvent(null, {
+    milestoneId: req.params.id,
+    actorUserId: req.user.userId,
+    action: 'contributor_voted',
+    note,
+    metadata: { vote },
+  });
+
+  const tally = await getMilestoneVoteTally(req.params.id, req.user.userId);
+  res.json({
+    milestone_id: req.params.id,
+    ...tally,
+  });
+}));
+
 router.post('/:id/reject', requireAuth, async (req, res) => {
   if (!canPerformPlatformSignature(req.user.userId)) {
     return res.status(403).json({ error: 'Only the designated platform approver can reject milestones' });
@@ -558,6 +680,17 @@ const approveMilestoneReleaseHandler = async (req, res) => {
   }
   if (milestone.status === 'released') {
     return res.status(409).json({ error: 'Milestone already released' });
+  }
+
+  const contributorTally = await getMilestoneVoteTally(milestone.id);
+  if (
+    contributorTally.total_votes > 0 &&
+    contributorTally.approve_count <= contributorTally.reject_count
+  ) {
+    return res.status(409).json({
+      error: 'Contributor vote threshold has not been met for this milestone release',
+      contributor_votes: contributorTally,
+    });
   }
 
   const releaseAmount = toReleaseAmount(milestone.raised_amount, milestone.release_percentage);

--- a/frontend/src/components/MilestoneVotePanel.jsx
+++ b/frontend/src/components/MilestoneVotePanel.jsx
@@ -1,0 +1,189 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { api } from '../services/api';
+
+const buttonBase = {
+  border: 0,
+  borderRadius: '8px',
+  color: '#fff',
+  cursor: 'pointer',
+  fontWeight: 700,
+  padding: '0.55rem 0.85rem',
+};
+
+export default function MilestoneVotePanel({ milestones }) {
+  const votableMilestones = useMemo(
+    () => (milestones || []).filter((milestone) => milestone.status === 'pending_review'),
+    [milestones]
+  );
+  const [votesByMilestone, setVotesByMilestone] = useState({});
+  const [notesByMilestone, setNotesByMilestone] = useState({});
+  const [busyByMilestone, setBusyByMilestone] = useState({});
+  const [errorByMilestone, setErrorByMilestone] = useState({});
+
+  useEffect(() => {
+    let active = true;
+    if (!votableMilestones.length) {
+      setVotesByMilestone({});
+      return () => {
+        active = false;
+      };
+    }
+
+    Promise.all(
+      votableMilestones.map((milestone) =>
+        api
+          .getMilestoneVotes(milestone.id)
+          .then((result) => [milestone.id, result])
+          .catch((err) => [milestone.id, { error: err.message || 'Could not load votes' }])
+      )
+    ).then((results) => {
+      if (!active) return;
+      const nextVotes = {};
+      const nextErrors = {};
+      results.forEach(([milestoneId, result]) => {
+        if (result.error) nextErrors[milestoneId] = result.error;
+        else nextVotes[milestoneId] = result;
+      });
+      setVotesByMilestone(nextVotes);
+      setErrorByMilestone(nextErrors);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [votableMilestones]);
+
+  if (!votableMilestones.length) return null;
+
+  async function submitVote(milestoneId, vote) {
+    setBusyByMilestone((current) => ({ ...current, [milestoneId]: true }));
+    setErrorByMilestone((current) => ({ ...current, [milestoneId]: '' }));
+    try {
+      const result = await api.voteMilestone(milestoneId, {
+        vote,
+        note: notesByMilestone[milestoneId] || '',
+      });
+      setVotesByMilestone((current) => ({ ...current, [milestoneId]: result }));
+    } catch (err) {
+      setErrorByMilestone((current) => ({
+        ...current,
+        [milestoneId]: err.message || 'Could not submit vote',
+      }));
+    } finally {
+      setBusyByMilestone((current) => ({ ...current, [milestoneId]: false }));
+    }
+  }
+
+  return (
+    <section style={{ marginTop: '1rem', marginBottom: '1.5rem' }} aria-label="Milestone voting">
+      <h2
+        style={{
+          color: 'var(--color-text-primary)',
+          fontSize: '1.05rem',
+          fontWeight: 800,
+          marginBottom: '0.75rem',
+        }}
+      >
+        Contributor milestone votes
+      </h2>
+      <div style={{ display: 'grid', gap: '0.75rem' }}>
+        {votableMilestones.map((milestone) => {
+          const tally = votesByMilestone[milestone.id];
+          const busy = !!busyByMilestone[milestone.id];
+          const error = errorByMilestone[milestone.id];
+          const currentVote = tally?.user_vote?.vote;
+
+          return (
+            <article key={milestone.id} className="campaign-card">
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  gap: '0.75rem',
+                  flexWrap: 'wrap',
+                }}
+              >
+                <div>
+                  <strong>{milestone.title}</strong>
+                  <div style={{ color: 'var(--color-text-secondary)', fontSize: '0.86rem' }}>
+                    {tally
+                      ? `${tally.approve_count} approve / ${tally.reject_count} reject`
+                      : 'Vote tally loading'}
+                  </div>
+                </div>
+                {currentVote && (
+                  <span
+                    style={{
+                      alignSelf: 'flex-start',
+                      background:
+                        currentVote === 'approve'
+                          ? 'var(--color-success-bg)'
+                          : 'var(--color-error-bg)',
+                      borderRadius: '999px',
+                      color:
+                        currentVote === 'approve'
+                          ? 'var(--color-success-text)'
+                          : 'var(--color-error-text)',
+                      fontSize: '0.78rem',
+                      fontWeight: 700,
+                      padding: '0.25rem 0.6rem',
+                    }}
+                  >
+                    Your vote: {currentVote}
+                  </span>
+                )}
+              </div>
+
+              <textarea
+                value={notesByMilestone[milestone.id] || ''}
+                onChange={(event) =>
+                  setNotesByMilestone((current) => ({
+                    ...current,
+                    [milestone.id]: event.target.value,
+                  }))
+                }
+                placeholder="Add an optional note"
+                rows={2}
+                style={{
+                  background: 'var(--color-surface)',
+                  border: '1px solid var(--color-border)',
+                  borderRadius: '8px',
+                  color: 'var(--color-text-primary)',
+                  marginTop: '0.75rem',
+                  padding: '0.65rem',
+                  resize: 'vertical',
+                  width: '100%',
+                }}
+              />
+
+              {error && (
+                <div className="alert alert--error" style={{ marginTop: '0.65rem', fontSize: '0.82rem' }}>
+                  {error}
+                </div>
+              )}
+
+              <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.75rem', flexWrap: 'wrap' }}>
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => submitVote(milestone.id, 'approve')}
+                  style={{ ...buttonBase, background: 'var(--color-success, #15803d)' }}
+                >
+                  Approve
+                </button>
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => submitVote(milestone.id, 'reject')}
+                  style={{ ...buttonBase, background: 'var(--color-error, #b91c1c)' }}
+                >
+                  Reject
+                </button>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -10,6 +10,7 @@ import RelativeTime from '../components/RelativeTime';
 import DisputeModal from '../components/DisputeModal';
 import TransactionHistory from '../components/TransactionHistory';
 import MilestoneTracker from '../components/MilestoneTracker';
+import MilestoneVotePanel from '../components/MilestoneVotePanel';
 import WithdrawalsSection from '../components/WithdrawalsSection';
 import CampaignDetailSkeleton from '../components/skeletons/CampaignDetailSkeleton';
 import ContributionListSkeleton from '../components/skeletons/ContributionListSkeleton';
@@ -1810,6 +1811,7 @@ export default function Campaign() {
       />
 
       <MilestoneTracker milestones={milestones} assetType={campaign.asset_type} />
+      <MilestoneVotePanel milestones={milestones} />
       {canManageTeam && (
         <div style={{ marginBottom: '2rem' }} data-no-print>
           <div

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -422,6 +422,8 @@ export const api = {
     return uploadFormData(`/milestones/${encodeURIComponent(id)}/upload-evidence`, formData);
   },
   getMilestoneEvents: (id) => request('GET', `/milestones/${id}/events`),
+  getMilestoneVotes: (id) => request('GET', `/milestones/${id}/votes`),
+  voteMilestone: (id, body) => request('POST', `/milestones/${id}/votes`, body || {}),
   approveMilestone: (id, body) => request('POST', `/milestones/${id}/release`, body || {}),
   rejectMilestone: (id, body) => request('POST', `/milestones/${id}/reject`, body || {}),
   contribute: (body) => request('POST', '/contributions', body),


### PR DESCRIPTION
Summary
- Added contributor milestone approval voting so backers can approve or reject milestones while evidence is awaiting platform review.
- Added backend tally endpoints, vote persistence, and release threshold enforcement before platform release.
- Added a campaign page voting panel for pending-review milestones.

Issue
- Closes #586

Changes
- Added a milestone_votes table keyed by milestone and contributor.
- Added GET/POST milestone vote endpoints with contributor access checks.
- Added vote tally threshold logic to block release when contributor votes do not support approval.
- Added frontend API helpers and a contributor milestone voting panel on campaign pages.

Validation
- Ran node --check backend/src/routes/milestones.js.
- Ran git diff --check.
- Did not run full lint/test/build because dependencies are not installed in this fresh clone and the request was to PR after required changes without CI cleanup.

Notes
- Platform release remains available when no contributor votes exist.
- When votes exist, approval votes must outnumber rejection votes before release can proceed.