### PR TITLE
Add downloadable tax receipts

### DIFF
--- a/backend/src/routes/contributions.js
+++ b/backend/src/routes/contributions.js
@@ -33,6 +33,7 @@ const {
   getContributorDashboard,
   getContributorDashboardCsv,
 } = require('../services/userDashboardService');
+const { buildTaxReceiptPdf } = require('../services/taxReceiptPdf');
 const { triggerRefund } = require('../services/sorobanService');
 const { emitWebhookEventForUser, emitWebhookEventForCampaign, WEBHOOK_EVENTS } = require('../services/webhookDispatcher');
 const { assertUserKycVerified } = require('../services/kycService');
@@ -144,6 +145,39 @@ function validateSubmittedContributionXdr({ signedXdr, unsignedXdr, senderPublic
   }
 }
 
+async function getTaxReceiptRows(userId, contributionId = null) {
+  const params = [userId];
+  let contributionFilter = '';
+  if (contributionId) {
+    params.push(contributionId);
+    contributionFilter = 'AND ctr.id = $2';
+  }
+
+  const { rows } = await db.query(
+    `SELECT
+       ctr.id, ctr.amount, ctr.asset, ctr.tx_hash, ctr.created_at,
+       ctr.sender_public_key,
+       c.id AS campaign_id, c.title AS campaign_title, c.status AS campaign_status,
+       creator.name AS campaign_creator_name,
+       u.name AS contributor_name, u.email AS contributor_email
+     FROM users u
+     JOIN contributions ctr ON ctr.sender_public_key = u.wallet_public_key
+     JOIN campaigns c ON c.id = ctr.campaign_id
+     LEFT JOIN users creator ON creator.id = c.creator_id
+     WHERE u.id = $1 ${contributionFilter}
+     ORDER BY ctr.created_at DESC`,
+    params
+  );
+  return rows;
+}
+
+function taxReceiptFilename(receipts, fallback = 'crowdpay-tax-receipts.pdf') {
+  if (receipts.length === 1) {
+    return `crowdpay-tax-receipt-${receipts[0].id}.pdf`;
+  }
+  return fallback;
+}
+
 router.get('/mine', requireAuth, asyncHandler(async (req, res) => {
   const rows = await listUserContributions(req.user.userId);
   if (rows === null) return res.status(404).json({ error: 'User not found' });
@@ -162,6 +196,42 @@ router.get('/dashboard/export.csv', requireAuth, asyncHandler(async (req, res) =
   res.setHeader('Content-Type', 'text/csv');
   res.setHeader('Content-Disposition', 'attachment; filename="contributions.csv"');
   res.send(csv);
+}));
+
+router.get('/tax-receipts', requireAuth, asyncHandler(async (req, res) => {
+  const rows = await getTaxReceiptRows(req.user.userId);
+  res.json({
+    receipts: rows.map((row) => ({
+      id: row.id,
+      amount: row.amount,
+      asset: row.asset,
+      tx_hash: row.tx_hash,
+      created_at: row.created_at,
+      campaign_id: row.campaign_id,
+      campaign_title: row.campaign_title,
+      campaign_status: row.campaign_status,
+    })),
+  });
+}));
+
+router.get('/tax-receipts/download', requireAuth, asyncHandler(async (req, res) => {
+  const rows = await getTaxReceiptRows(req.user.userId);
+  if (!rows.length) return res.status(404).json({ error: 'No contribution receipts found' });
+
+  const pdf = buildTaxReceiptPdf(rows);
+  res.setHeader('Content-Type', 'application/pdf');
+  res.setHeader('Content-Disposition', `attachment; filename="${taxReceiptFilename(rows)}"`);
+  res.send(pdf);
+}));
+
+router.get('/tax-receipts/:id/download', requireAuth, asyncHandler(async (req, res) => {
+  const rows = await getTaxReceiptRows(req.user.userId, req.params.id);
+  if (!rows.length) return res.status(404).json({ error: 'Tax receipt not found' });
+
+  const pdf = buildTaxReceiptPdf(rows);
+  res.setHeader('Content-Type', 'application/pdf');
+  res.setHeader('Content-Disposition', `attachment; filename="${taxReceiptFilename(rows)}"`);
+  res.send(pdf);
 }));
 
 router.get('/campaign/:campaignId', asyncHandler(async (req, res) => {

--- a/backend/src/services/taxReceiptPdf.js
+++ b/backend/src/services/taxReceiptPdf.js
@@ -1,0 +1,108 @@
+function asciiText(value) {
+  return String(value ?? '')
+    .replace(/[^\x20-\x7E]/g, '?')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function escapePdfText(value) {
+  return asciiText(value).replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+}
+
+function money(value, asset) {
+  const amount = Number(value || 0).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 7,
+  });
+  return `${amount} ${asset || ''}`.trim();
+}
+
+function receiptLines(receipt, index, total) {
+  const contributedAt = receipt.created_at
+    ? new Date(receipt.created_at).toISOString()
+    : 'Unknown date';
+
+  return [
+    'Crowdpay Contribution Tax Receipt',
+    `Receipt: ${receipt.id}`,
+    total > 1 ? `Receipt ${index + 1} of ${total}` : '',
+    '',
+    `Contributor: ${receipt.contributor_name || 'Contributor'}`,
+    `Contributor email: ${receipt.contributor_email || 'Not provided'}`,
+    `Contributor wallet: ${receipt.sender_public_key}`,
+    '',
+    `Campaign: ${receipt.campaign_title}`,
+    `Campaign ID: ${receipt.campaign_id}`,
+    `Campaign creator: ${receipt.campaign_creator_name || 'Not provided'}`,
+    `Campaign status: ${receipt.campaign_status}`,
+    '',
+    `Contribution amount: ${money(receipt.amount, receipt.asset)}`,
+    `Contribution date: ${contributedAt}`,
+    `Transaction hash: ${receipt.tx_hash}`,
+    '',
+    'Note: This receipt is generated from Crowdpay contribution records.',
+    'Consult a tax professional to confirm deductibility in your jurisdiction.',
+  ].filter((line) => line !== '');
+}
+
+function buildPageContent(lines) {
+  const commands = ['BT', '/F1 18 Tf', '72 750 Td', `(${escapePdfText(lines[0])}) Tj`, '/F1 10 Tf'];
+  for (const line of lines.slice(1)) {
+    commands.push('0 -18 Td');
+    commands.push(`(${escapePdfText(line)}) Tj`);
+  }
+  commands.push('ET');
+  return commands.join('\n');
+}
+
+function buildTaxReceiptPdf(receipts) {
+  const rows = Array.isArray(receipts) ? receipts : [receipts];
+  const objects = [
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '',
+  ];
+
+  const pageObjectNumbers = [];
+  const contentObjectNumbers = [];
+
+  rows.forEach((receipt, index) => {
+    const pageObjectNumber = objects.length + 1;
+    const contentObjectNumber = pageObjectNumber + 1;
+    pageObjectNumbers.push(pageObjectNumber);
+    contentObjectNumbers.push(contentObjectNumber);
+    objects.push('');
+
+    const content = buildPageContent(receiptLines(receipt, index, rows.length));
+    objects.push(`<< /Length ${Buffer.byteLength(content)} >>\nstream\n${content}\nendstream`);
+  });
+
+  objects[1] = `<< /Type /Pages /Kids [${pageObjectNumbers.map((num) => `${num} 0 R`).join(' ')}] /Count ${pageObjectNumbers.length} >>`;
+
+  pageObjectNumbers.forEach((pageObjectNumber, index) => {
+    objects[pageObjectNumber - 1] =
+      `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 ${objects.length + 1} 0 R >> >> /Contents ${contentObjectNumbers[index]} 0 R >>`;
+  });
+
+  objects.push('<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>');
+
+  const chunks = ['%PDF-1.4\n'];
+  const offsets = [0];
+  objects.forEach((object, index) => {
+    offsets.push(Buffer.byteLength(chunks.join('')));
+    chunks.push(`${index + 1} 0 obj\n${object}\nendobj\n`);
+  });
+
+  const xrefOffset = Buffer.byteLength(chunks.join(''));
+  chunks.push(`xref\n0 ${objects.length + 1}\n`);
+  chunks.push('0000000000 65535 f \n');
+  offsets.slice(1).forEach((offset) => {
+    chunks.push(`${String(offset).padStart(10, '0')} 00000 n \n`);
+  });
+  chunks.push(`trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`);
+
+  return Buffer.from(chunks.join(''), 'ascii');
+}
+
+module.exports = {
+  buildTaxReceiptPdf,
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,7 @@ const Developer = lazy(() => import('./pages/Developer'));
 const Dashboard = lazy(() => import('./pages/Dashboard'));
 const Profile = lazy(() => import('./pages/Profile'));
 const NotificationSettings = lazy(() => import('./pages/NotificationSettings'));
+const TaxReceipts = lazy(() => import('./pages/TaxReceipts'));
 const HowItWorks = lazy(() => import('./pages/HowItWorks'));
 const Pricing = lazy(() => import('./pages/Pricing'));
 const About = lazy(() => import('./pages/About'));
@@ -115,6 +116,14 @@ export default function App() {
                   element={
                     <PrivateRoute>
                       <NotificationSettings />
+                    </PrivateRoute>
+                  }
+                />
+                <Route
+                  path="/tax-receipts"
+                  element={
+                    <PrivateRoute>
+                      <TaxReceipts />
                     </PrivateRoute>
                   }
                 />

--- a/frontend/src/components/ContributorDashboard.jsx
+++ b/frontend/src/components/ContributorDashboard.jsx
@@ -366,9 +366,14 @@ export default function ContributorDashboard() {
         }}
       >
         <div style={{ fontSize: '0.85rem', color: 'var(--color-text-hint)' }}>Your portfolio</div>
-        <button type="button" onClick={exportCsv} disabled={exporting} style={{ fontSize: '0.8rem' }}>
-          {exporting ? 'Exporting…' : 'Export CSV'}
-        </button>
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'center' }}>
+          <Link to="/tax-receipts" style={{ fontSize: '0.8rem', color: 'var(--color-accent)', fontWeight: 700 }}>
+            Tax receipts
+          </Link>
+          <button type="button" onClick={exportCsv} disabled={exporting} style={{ fontSize: '0.8rem' }}>
+            {exporting ? 'Exporting…' : 'Export CSV'}
+          </button>
+        </div>
       </div>
 
       <div

--- a/frontend/src/pages/TaxReceipts.jsx
+++ b/frontend/src/pages/TaxReceipts.jsx
@@ -1,0 +1,164 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { api } from '../services/api';
+import { stellarExpertTxUrl } from '../config/stellar';
+
+function downloadBlob({ blob, filename }) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+export default function TaxReceipts() {
+  const [receipts, setReceipts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [downloading, setDownloading] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let active = true;
+    api
+      .getTaxReceipts()
+      .then((data) => {
+        if (active) setReceipts(data.receipts || []);
+      })
+      .catch((err) => {
+        if (active) setError(err.message || 'Could not load tax receipts');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  async function downloadAll() {
+    setDownloading('all');
+    setError('');
+    try {
+      downloadBlob(await api.downloadTaxReceiptsPdf());
+    } catch (err) {
+      setError(err.message || 'Could not download receipts');
+    } finally {
+      setDownloading('');
+    }
+  }
+
+  async function downloadOne(id) {
+    setDownloading(id);
+    setError('');
+    try {
+      downloadBlob(await api.downloadTaxReceiptPdf(id));
+    } catch (err) {
+      setError(err.message || 'Could not download receipt');
+    } finally {
+      setDownloading('');
+    }
+  }
+
+  return (
+    <main className="container" style={{ paddingTop: '2rem', paddingBottom: '3rem' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: '0.75rem',
+          flexWrap: 'wrap',
+          marginBottom: '1rem',
+        }}
+      >
+        <div>
+          <h1 style={{ fontSize: '1.6rem', fontWeight: 800, margin: 0 }}>Tax receipts</h1>
+          <p style={{ color: 'var(--color-text-secondary)', margin: '0.35rem 0 0' }}>
+            Download contribution receipts for your records.
+          </p>
+        </div>
+        {receipts.length > 0 && (
+          <button
+            type="button"
+            className="btn-primary"
+            disabled={downloading === 'all'}
+            onClick={downloadAll}
+          >
+            {downloading === 'all' ? 'Preparing...' : 'Download all PDFs'}
+          </button>
+        )}
+      </div>
+
+      {error && <p className="alert alert--error">{error}</p>}
+
+      {loading ? (
+        <p style={{ color: 'var(--color-text-hint)' }}>Loading receipts...</p>
+      ) : receipts.length === 0 ? (
+        <p className="alert alert--info">
+          No contribution receipts are available yet.{' '}
+          <Link to="/discover" style={{ color: 'var(--color-accent)', fontWeight: 600 }}>
+            Browse campaigns
+          </Link>
+          .
+        </p>
+      ) : (
+        <div style={{ display: 'grid', gap: '0.75rem' }}>
+          {receipts.map((receipt) => (
+            <article key={receipt.id} className="campaign-card" style={{ minHeight: 'auto' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  gap: '0.75rem',
+                  flexWrap: 'wrap',
+                }}
+              >
+                <div>
+                  <Link
+                    to={`/campaigns/${receipt.campaign_id}`}
+                    style={{ color: 'var(--color-accent)', fontWeight: 700 }}
+                  >
+                    {receipt.campaign_title}
+                  </Link>
+                  <div style={{ marginTop: '0.35rem', color: 'var(--color-text-primary)' }}>
+                    {Number(receipt.amount).toLocaleString()} {receipt.asset}
+                  </div>
+                  <div style={{ fontSize: '0.84rem', color: 'var(--color-text-secondary)' }}>
+                    {new Date(receipt.created_at).toLocaleString()} | {receipt.campaign_status}
+                  </div>
+                  {receipt.tx_hash && (
+                    <a
+                      href={stellarExpertTxUrl(receipt.tx_hash)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{
+                        color: 'var(--color-accent)',
+                        display: 'inline-block',
+                        fontSize: '0.84rem',
+                        marginTop: '0.35rem',
+                      }}
+                    >
+                      View transaction
+                    </a>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  disabled={downloading === receipt.id}
+                  onClick={() => downloadOne(receipt.id)}
+                  style={{ alignSelf: 'flex-start' }}
+                >
+                  {downloading === receipt.id ? 'Preparing...' : 'Download PDF'}
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -447,6 +447,14 @@ export const api = {
   getContributorDashboard: () => request('GET', '/contributions/dashboard'),
   exportContributionsCsv: () =>
     downloadFile('/contributions/dashboard/export.csv', 'contributions.csv'),
+  getTaxReceipts: () => request('GET', '/contributions/tax-receipts'),
+  downloadTaxReceiptsPdf: () =>
+    downloadFile('/contributions/tax-receipts/download', 'crowdpay-tax-receipts.pdf'),
+  downloadTaxReceiptPdf: (id) =>
+    downloadFile(
+      `/contributions/tax-receipts/${encodeURIComponent(id)}/download`,
+      `crowdpay-tax-receipt-${id}.pdf`
+    ),
 
   getFavorites: () => request('GET', '/users/me/favorites'),
   addFavorite: (campaignId) => request('POST', `/campaigns/${campaignId}/favorite`, {}),


### PR DESCRIPTION
Summary
- Added downloadable PDF tax receipts for contributor contribution history.
- Added individual receipt downloads and a batch PDF download for all contribution receipts.
- Added a protected frontend tax receipts page linked from the contributor dashboard.

Issue
- Closes #589

Changes
- Added authenticated receipt listing and PDF download endpoints under /api/contributions/tax-receipts.
- Added dependency-free PDF generation for contribution receipt records.
- Added frontend API helpers for receipt listing and downloads.
- Added /tax-receipts page and linked it from the contributor dashboard.

Validation
- Ran node --check backend/src/routes/contributions.js.
- Ran node --check backend/src/services/taxReceiptPdf.js.
- Ran git diff --check.
- Did not run full lint/test/build because dependencies are not installed in this fresh clone and the request was to PR after required changes without CI cleanup.

Notes
- Receipts include contribution amount, date, campaign details, contributor details, and transaction hash.
- Batch download generates one PDF with one receipt page per contribution.