### PR TITLE
fix(#568): use adaptive per-instance intervals in useRelativeTime

### DIFF
--- a/frontend/src/hooks/useRelativeTime.js
+++ b/frontend/src/hooks/useRelativeTime.js
@@ -17,12 +17,37 @@ function getRelative(date) {
   return dateObj.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
+/**
+ * Returns the refresh interval (ms) appropriate for a given timestamp age.
+ * Timestamps older than 24 h are static — no interval needed.
+ * Timestamps older than 1 h refresh every 5 minutes.
+ * Timestamps older than 1 min refresh every 60 seconds.
+ * Recent timestamps refresh every 30 seconds.
+ */
+function getIntervalMs(date) {
+  if (!date) return null;
+  const abs = Math.abs(Date.now() - new Date(date).getTime()) / 1000; // age in seconds
+  if (abs >= 86400) return null;   // older than 24 h — static, no timer needed
+  if (abs >= 3600)  return 300_000; // older than 1 h  — refresh every 5 min
+  if (abs >= 60)    return 60_000;  // older than 1 min — refresh every 60 s
+  return 30_000;                    // recent           — refresh every 30 s
+}
+
 export function useRelativeTime(date) {
   const [label, setLabel] = useState(() => getRelative(date));
+
   useEffect(() => {
     setLabel(getRelative(date));
-    const id = setInterval(() => setLabel(getRelative(date)), 30_000);
+
+    const intervalMs = getIntervalMs(date);
+    if (intervalMs === null) return; // timestamp is old enough to be static
+
+    const id = setInterval(() => {
+      setLabel(getRelative(date));
+    }, intervalMs);
+
     return () => clearInterval(id);
   }, [date]);
+
   return label;
 }


### PR DESCRIPTION
closes #568 
- Add getIntervalMs() helper that returns refresh frequency based on timestamp age: 30s for recent, 60s for >1min, 5min for >1h, null (no timer) for timestamps older than 24h
- Each hook instance now schedules its own timer only when needed, eliminating unnecessary re-renders for stale timestamps