### PR TITLE
fix(widget): clear polling interval when tab hides (#561)

### DIFF
--- a/frontend/src/pages/Widget.jsx
+++ b/frontend/src/pages/Widget.jsx
@@ -55,7 +55,7 @@ export default function Widget() {
     };
 
     const stop = () => {
-      if (intervalId !== null) return;
+      if (intervalId === null) return;
       window.clearInterval(intervalId);
       intervalId = null;
       controller?.abort();

--- a/frontend/src/pages/Widget.test.jsx
+++ b/frontend/src/pages/Widget.test.jsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import Widget from './Widget';
+
+function setVisibility(state) {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+function renderWidget() {
+  return render(
+    <MemoryRouter initialEntries={['/embed/campaigns/test-id']}>
+      <Routes>
+        <Route path="/embed/campaigns/:id" element={<Widget />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('Widget polling interval lifecycle', () => {
+  let setIntervalSpy;
+  let clearIntervalSpy;
+
+  beforeEach(() => {
+    setVisibility('visible');
+    // Keep load()'s fetch pending so the effect performs no state updates.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})));
+    setIntervalSpy = vi.spyOn(window, 'setInterval');
+    clearIntervalSpy = vi.spyOn(window, 'clearInterval');
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    setVisibility('visible');
+  });
+
+  it('clears the polling interval when the tab becomes hidden', () => {
+    renderWidget();
+
+    // On mount (visible) start() schedules the 30s poll exactly once.
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    const intervalId = setIntervalSpy.mock.results[0].value;
+
+    // Hiding the tab must actually clear the interval. The bug inverted the
+    // guard so stop() returned early and never reached clearInterval.
+    setVisibility('hidden');
+    expect(clearIntervalSpy).toHaveBeenCalledWith(intervalId);
+  });
+
+  it('does not accumulate intervals across hide/show cycles', () => {
+    renderWidget();
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+    setVisibility('hidden');
+    setVisibility('visible');
+    setVisibility('hidden');
+    setVisibility('visible');
+
+    // Each hide clears the live interval before the next show starts a new one,
+    // so exactly one interval is ever outstanding (started = cleared + 1).
+    expect(clearIntervalSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(setIntervalSpy.mock.calls.length).toBe(
+      clearIntervalSpy.mock.calls.length + 1,
+    );
+  });
+});


### PR DESCRIPTION
Closes #561

## The bug
`stop()` in `frontend/src/pages/Widget.jsx` had an inverted guard:

```js
const stop = () => {
  if (intervalId !== null) return;   // returns early exactly when an interval IS live
  window.clearInterval(intervalId);
  ...
};
```

So `stop()` returned before ever calling `clearInterval`. Two consequences:
- The 30s polling interval leaked whenever the tab was hidden (CPU/battery waste, uncleared timer).
- Because `intervalId` was never reset to `null`, `start()`'s own (correct) `if (intervalId !== null) return` guard then blocked polling from resuming when the tab became visible again.

## The fix
Flip the guard to `if (intervalId === null) return;` (return early only when there is nothing to clear). One line; `start()`'s guard was already correct and is untouched.

## Tests
Adds `frontend/src/pages/Widget.test.jsx`:
- `clears the polling interval when the tab becomes hidden` - asserts `clearInterval` is called with the live interval id on `visibilitychange` to hidden.
- `does not accumulate intervals across hide/show cycles` - asserts every start is matched by a clear so only one interval is ever outstanding.

Both tests fail against the buggy guard and pass with the fix. Full frontend suite: 125 passed (41 files).

Verification: `cd frontend && npx vitest run`.
