### PR TITLE
fix(contributions): atomically decrement reward tier claimed_count on…

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,77 @@
+## Description
+
+Fixes #397 — Reward tier `claimed_count` is now atomically decremented when a tier-backed contribution is made, preventing overselling of limited-edition reward tiers.
+
+**The Problem**
+The `claimed_count` (and hence computed `remaining`) on `reward_tiers` was only incremented asynchronously in the ledger monitor when Horizon detected the on-chain payment. The contribution route itself never decremented the count, so:
+- Sold-out tiers continued showing availability in the UI
+- Multiple backers could claim the last slot of a limited tier
+- Creators could end up owing more physical rewards than they could fulfil
+
+**The Fix**
+A new `reserveTierSlot()` function in `rewardTierService.js` atomically increments `claimed_count` **inside the contribution route's database transaction** — before the Stellar transaction is even submitted. If the tier is already at capacity, the contribution is rejected with **HTTP 409 Sold out** and the entire transaction is rolled back.
+
+## Changes
+
+### `backend/src/services/rewardTierService.js`
+- **`reserveTierSlot(client, { tierId, campaignId })`** — Atomically increments `claimed_count` via `UPDATE ... WHERE (tier_limit IS NULL OR claimed_count < tier_limit) RETURNING`. Returns the tier row on success, or `null` if sold out.
+- **`assignTierToContribution(client, { ..., tierId })`** — Extended to accept an optional `tierId`. When provided, only creates the `contribution_rewards` join row (idempotent via `ON CONFLICT DO NOTHING`) without double-incrementing `claimed_count`, since the route already reserved the slot.
+
+### `backend/src/routes/contributions.js`
+- Custodial `POST /` route now extracts optional `tier_id` from `req.body`
+- Validates the tier belongs to the campaign (pre-flight `SELECT`)
+- Calls `reserveTierSlot()` inside the existing transaction, **before** submitting to Stellar
+- Returns **HTTP 409** with `{ error: "This reward tier is sold out", tier_id }` if the tier is at capacity
+- Passes `tierId` through to `submitCustodialContribution` so it flows into metadata
+
+### `backend/src/services/contributionService.js`
+- Accepts new `tierId` parameter and includes it in `stellar_transactions.metadata` as `tier_id`
+
+### `backend/src/services/ledgerMonitor.js`
+- Reads `tier_id` from `stellar_transactions.metadata` and passes it to `assignTierToContribution`, ensuring pre-reserved tiers are honoured without double-counting `claimed_count`
+
+### `backend/src/middleware/validation.js`
+- Added optional `tier_id` validation (UUID format) to `contributionValidation`
+
+## How It Works End-to-End
+
+```
+User contributes (with tier_id)
+  │
+  ├─ 1. Route validates tier exists & belongs to campaign (pre-flight)
+  │
+  ├─ 2. BEGIN transaction
+  │     ├─ Advisory lock (campaign + user)
+  │     ├─ Check per-user cap
+  │     ├─ reserveTierSlot() → UPDATE reward_tiers SET claimed_count++ 
+  │     │                        WHERE id = tier_id AND claimed_count < tier_limit
+  │     │                        RETURNING id
+  │     │     └─ If 0 rows → ROLLBACK, respond 409 Sold out 🚫
+  │     ├─ Submit Stellar transaction
+  │     ├─ Insert stellar_transactions record (metadata.tier_id set)
+  │     └─ COMMIT ✅
+  │
+  └─ 3. (async) Ledger monitor indexes on-chain payment
+        ├─ Insert contributions row
+        ├─ assignTierToContribution(tierId) → creates contribution_rewards
+        │   (idempotent via ON CONFLICT DO NOTHING, no double-increment)
+        └─ Update campaign raised_amount
+```
+
+## Acceptance Criteria
+
+| Criteria | Status |
+|----------|--------|
+| Tier `claimed_count` decrements atomically with each contribution | ✅ `UPDATE ... SET claimed_count = claimed_count + 1` inside route transaction |
+| Contribution rejected with 409 when tier is sold out | ✅ `reserveTierSlot()` returns null → `res.status(409)` |
+| Concurrent contributions for the last slot handled correctly (only one succeeds) | ✅ Atomic `UPDATE ... WHERE claimed_count < tier_limit` with PostgreSQL row-level locking inside transaction |
+| Tier sold-out state reflected in UI immediately | ✅ `claimed_count` is updated atomically in the route, so the next `listTiersWithAvailability()` query reflects the correct `remaining` |
+
+## Testing
+
+- [ ] Unit test `reserveTierSlot()` — success path
+- [ ] Unit test `reserveTierSlot()` — sold-out path returns null
+- [ ] Unit test `assignTierToContribution()` with explicit `tierId` — no double-increment
+- [ ] Integration: contribute with valid `tier_id`, verify `claimed_count` incremented
+- [ ] Integration: contribute with sold-out `tier_id`, verify 409 response
+- [ ] Integration: concurrent contributions for last slot, verify exactly one 202 and one 409

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -39,14 +39,13 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@noble/hashes": "^1.3.1",
-        "eslint": "^9.39.4",
+        "eslint": "^9.39.5",
         "nodemon": "^3.1.0",
         "proxyquire": "^2.1.3",
         "supertest": "^7.2.2"
       }
     },
     "..": {
-      "name": "crowdpay",
       "version": "1.0.0"
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -1146,9 +1145,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1158,7 +1157,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -1232,9 +1231,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2576,9 +2575,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3720,9 +3719,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3731,8 +3730,8 @@
         "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@noble/hashes": "^1.3.1",
-    "eslint": "^9.39.4",
+    "eslint": "^9.39.5",
     "nodemon": "^3.1.0",
     "proxyquire": "^2.1.3",
     "supertest": "^7.2.2"

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -273,6 +273,14 @@ const contributionValidation = [
     })
     .isLength({ max: 50 })
     .withMessage('Display name must be at most 50 characters'),
+  body('tier_id')
+    .optional({ nullable: true })
+    .custom((value) => {
+      if (value === null || value === undefined || value === '') return true;
+      if (!isUuid(value)) throw new Error('tier_id must be a valid UUID');
+      return true;
+    })
+    .withMessage('tier_id must be a valid UUID'),
 ];
 
 const withdrawalValidation = [

--- a/backend/src/routes/contributions.js
+++ b/backend/src/routes/contributions.js
@@ -38,6 +38,7 @@ const { emitWebhookEventForUser, emitWebhookEventForCampaign, WEBHOOK_EVENTS } =
 const { assertUserKycVerified } = require('../services/kycService');
 const asyncHandler = require('../utils/asyncHandler');
 const { getReferralCodeFromRequest } = require('../services/referralService');
+const { reserveTierSlot } = require('../services/rewardTierService');
 
 const SUPPORTED_ASSETS = getSupportedAssetCodes();
 const PREPARED_CONTRIBUTION_EXPIRES_IN = '10m';
@@ -505,7 +506,7 @@ router.post('/', contributionPostLimiter, requireAuth, contributionValidation, v
     throw err;
   }
 
-  const { campaign_id, amount, send_asset, display_name } = req.body;
+  const { campaign_id, amount, send_asset, display_name, tier_id } = req.body;
 
   const campaign = await loadActiveCampaign(campaign_id);
   if (!campaign) return res.status(404).json({ error: 'Campaign not found' });
@@ -526,6 +527,17 @@ router.post('/', contributionPostLimiter, requireAuth, contributionValidation, v
     return res.status(400).json({
       error: `Maximum contribution is ${campaign.max_contribution} ${campaign.asset_type}`,
     });
+  }
+
+  // If a specific reward tier was chosen, validate it exists and belongs to this campaign
+  if (tier_id) {
+    const { rows: tierRows } = await db.query(
+      'SELECT id, title, tier_limit, claimed_count FROM reward_tiers WHERE id = $1 AND campaign_id = $2',
+      [tier_id, campaign_id]
+    );
+    if (!tierRows.length) {
+      return res.status(404).json({ error: 'Reward tier not found for this campaign' });
+    }
   }
 
   const client = await db.connect();
@@ -553,6 +565,20 @@ router.post('/', contributionPostLimiter, requireAuth, contributionValidation, v
       }
     }
 
+    // Atomically reserve a reward tier slot (if a tier was selected)
+    let reservedTier = null;
+    if (tier_id) {
+      reservedTier = await reserveTierSlot(client, { tierId: tier_id, campaignId: campaign_id });
+      if (!reservedTier) {
+        await client.query('ROLLBACK');
+        transactionStarted = false;
+        return res.status(409).json({
+          error: 'This reward tier is sold out',
+          tier_id,
+        });
+      }
+    }
+
     const result = await submitCustodialContribution({
       campaign,
       campaignId: campaign_id,
@@ -565,6 +591,7 @@ router.post('/', contributionPostLimiter, requireAuth, contributionValidation, v
       referralCode: getReferralCodeFromRequest(campaign_id, req),
       ipAddress: req.ip,
       client,
+      tierId: reservedTier ? reservedTier.id : null,
     });
     await client.query('COMMIT');
     transactionStarted = false;

--- a/backend/src/services/contributionService.js
+++ b/backend/src/services/contributionService.js
@@ -88,6 +88,7 @@ async function submitCustodialContribution({
   referralCode,
   ipAddress,
   client,
+  tierId,
 }) {
   const intent =
     intentOverride ||
@@ -145,6 +146,7 @@ async function submitCustodialContribution({
   const metadata = {
     ...intent.flowMetadata,
     ip_address: ipAddress || null,
+    tier_id: tierId || null,
     ...(referralCode ? { referral_code: referralCode } : {}),
     ...(anchorMetadata
       ? {

--- a/backend/src/services/ledgerMonitor.js
+++ b/backend/src/services/ledgerMonitor.js
@@ -238,6 +238,7 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
     const displayName = submittedRows[0]?.metadata?.display_name || null;
     const referralCode = submittedRows[0]?.metadata?.referral_code || null;
     const ipAddress = submittedRows[0]?.metadata?.ip_address || null;
+    const reservedTierId = submittedRows[0]?.metadata?.tier_id || null;
 
     const { rows: inserted } = await client.query(
       `INSERT INTO contributions
@@ -282,10 +283,13 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
 
     // Match this contribution to the highest reward tier it qualifies for that
     // still has capacity (idempotent + atomic with the insert above).
+    // If the contribution was made with an explicit tier_id that was reserved
+    // atomically in the route, use that tier directly without bumping claimed_count.
     const assignedTier = await assignTierToContribution(client, {
       campaignId,
       amount: destinationAmount,
       contributionId: inserted[0].id,
+      tierId: reservedTierId || undefined,
     });
 
     await markContributionIndexed(client, txHash, inserted[0].id);

--- a/backend/src/services/rewardTierService.js
+++ b/backend/src/services/rewardTierService.js
@@ -110,8 +110,38 @@ async function listTiersWithAvailability(campaignId) {
 }
 
 /**
+ * Reserve a slot in a specific reward tier by incrementing its claimed_count.
+ *
+ * Called from the contribution route INSIDE its transaction so the tier slot
+ * is atomically reserved alongside the Stellar transaction submission. If the
+ * tier is already sold out (claimed_count >= tier_limit with a finite limit)
+ * the UPDATE returns zero rows and the caller should reject the contribution
+ * with HTTP 409.
+ *
+ * @param {object} client   Database client inside an open transaction
+ * @param {{tierId: string, campaignId: string}} params
+ * @returns {{id: string, title: string}|null} the reserved tier, or null if sold out
+ */
+async function reserveTierSlot(client, { tierId, campaignId }) {
+  const { rows } = await client.query(
+    `UPDATE reward_tiers
+        SET claimed_count = claimed_count + 1
+      WHERE id = $1
+        AND campaign_id = $2
+        AND (tier_limit IS NULL OR claimed_count < tier_limit)
+      RETURNING id, title`,
+    [tierId, campaignId],
+  );
+  return rows[0] || null;
+}
+
+/**
  * Match a contribution to the highest reward tier it qualifies for that still
  * has capacity, record it, and increment that tier's claimed_count.
+ *
+ * When an explicit tierId is provided (pre-reserved via reserveTierSlot) the
+ * function only creates the contribution_rewards join row without bumping
+ * claimed_count (the slot was already reserved in the route transaction).
  *
  * Runs on a provided client inside the contribution-indexing transaction so the
  * assignment is atomic with the contribution insert. The whole operation is a
@@ -122,9 +152,31 @@ async function listTiersWithAvailability(campaignId) {
  *   - Full tiers are filtered out, so a contributor that can't get the top tier
  *     automatically falls back to the next qualifying one.
  *
+ * @param {object}   client  Database client inside an open transaction
+ * @param {{campaignId: string, amount: number, contributionId: string, tierId?: string}} params
  * @returns {{id: string, title: string}|null} the assigned tier, or null if none matched
  */
-async function assignTierToContribution(client, { campaignId, amount, contributionId }) {
+async function assignTierToContribution(client, { campaignId, amount, contributionId, tierId }) {
+  if (tierId) {
+    // Explicit tier — slot was already reserved by the contribution route.
+    // Only create the contribution_rewards join row; do NOT bump claimed_count
+    // again because reserveTierSlot already did that atomically.
+    const { rows } = await client.query(
+      `WITH ins AS (
+         INSERT INTO contribution_rewards (contribution_id, reward_tier_id)
+         VALUES ($1, $2)
+         ON CONFLICT (contribution_id) DO NOTHING
+         RETURNING reward_tier_id
+       )
+       SELECT r.id, r.title
+         FROM reward_tiers r
+         JOIN ins ON ins.reward_tier_id = r.id`,
+      [contributionId, tierId],
+    );
+    return rows[0] || null;
+  }
+
+  // Auto-match to the highest qualifying tier (legacy behaviour)
   const { rows } = await client.query(
     `WITH chosen AS (
        SELECT id
@@ -158,4 +210,5 @@ module.exports = {
   insertTiers,
   listTiersWithAvailability,
   assignTierToContribution,
+  reserveTierSlot,
 };


### PR DESCRIPTION
## Description

Closes #397
 Reward tier `claimed_count` is now atomically decremented when a tier-backed contribution is made, preventing overselling of limited-edition reward tiers.

**The Problem**
The `claimed_count` (and hence computed `remaining`) on `reward_tiers` was only incremented asynchronously in the ledger monitor when Horizon detected the on-chain payment. The contribution route itself never decremented the count, so:
- Sold-out tiers continued showing availability in the UI
- Multiple backers could claim the last slot of a limited tier
- Creators could end up owing more physical rewards than they could fulfil

**The Fix**
A new `reserveTierSlot()` function in `rewardTierService.js` atomically increments `claimed_count` **inside the contribution route's database transaction** — before the Stellar transaction is even submitted. If the tier is already at capacity, the contribution is rejected with **HTTP 409 Sold out** and the entire transaction is rolled back.

## Changes

### `backend/src/services/rewardTierService.js`
- **`reserveTierSlot(client, { tierId, campaignId })`** — Atomically increments `claimed_count` via `UPDATE ... WHERE (tier_limit IS NULL OR claimed_count < tier_limit) RETURNING`. Returns the tier row on success, or `null` if sold out.
- **`assignTierToContribution(client, { ..., tierId })`** — Extended to accept an optional `tierId`. When provided, only creates the `contribution_rewards` join row (idempotent via `ON CONFLICT DO NOTHING`) without double-incrementing `claimed_count`, since the route already reserved the slot.

### `backend/src/routes/contributions.js`
- Custodial `POST /` route now extracts optional `tier_id` from `req.body`
- Validates the tier belongs to the campaign (pre-flight `SELECT`)
- Calls `reserveTierSlot()` inside the existing transaction, **before** submitting to Stellar
- Returns **HTTP 409** with `{ error: "This reward tier is sold out", tier_id }` if the tier is at capacity
- Passes `tierId` through to `submitCustodialContribution` so it flows into metadata

### `backend/src/services/contributionService.js`
- Accepts new `tierId` parameter and includes it in `stellar_transactions.metadata` as `tier_id`

### `backend/src/services/ledgerMonitor.js`
- Reads `tier_id` from `stellar_transactions.metadata` and passes it to `assignTierToContribution`, ensuring pre-reserved tiers are honoured without double-counting `claimed_count`

### `backend/src/middleware/validation.js`
- Added optional `tier_id` validation (UUID format) to `contributionValidation`

## How It Works End-to-End

```
User contributes (with tier_id)
  │
  ├─ 1. Route validates tier exists & belongs to campaign (pre-flight)
  │
  ├─ 2. BEGIN transaction
  │     ├─ Advisory lock (campaign + user)
  │     ├─ Check per-user cap
  │     ├─ reserveTierSlot() → UPDATE reward_tiers SET claimed_count++ 
  │     │                        WHERE id = tier_id AND claimed_count < tier_limit
  │     │                        RETURNING id
  │     │     └─ If 0 rows → ROLLBACK, respond 409 Sold out 🚫
  │     ├─ Submit Stellar transaction
  │     ├─ Insert stellar_transactions record (metadata.tier_id set)
  │     └─ COMMIT ✅
  │
  └─ 3. (async) Ledger monitor indexes on-chain payment
        ├─ Insert contributions row
        ├─ assignTierToContribution(tierId) → creates contribution_rewards
        │   (idempotent via ON CONFLICT DO NOTHING, no double-increment)
        └─ Update campaign raised_amount
```

## Acceptance Criteria

| Criteria | Status |
|----------|--------|
| Tier `claimed_count` decrements atomically with each contribution | ✅ `UPDATE ... SET claimed_count = claimed_count + 1` inside route transaction |
| Contribution rejected with 409 when tier is sold out | ✅ `reserveTierSlot()` returns null → `res.status(409)` |
| Concurrent contributions for the last slot handled correctly (only one succeeds) | ✅ Atomic `UPDATE ... WHERE claimed_count < tier_limit` with PostgreSQL row-level locking inside transaction |
| Tier sold-out state reflected in UI immediately | ✅ `claimed_count` is updated atomically in the route, so the next `listTiersWithAvailability()` query reflects the correct `remaining` |

## Testing

- [ ] Unit test `reserveTierSlot()` — success path
- [ ] Unit test `reserveTierSlot()` — sold-out path returns null
- [ ] Unit test `assignTierToContribution()` with explicit `tierId` — no double-increment
- [ ] Integration: contribute with valid `tier_id`, verify `claimed_count` incremented
- [ ] Integration: contribute with sold-out `tier_id`, verify 409 response
- [ ] Integration: concurrent contributions for last slot, verify exactly one 202 and one 409
