### PR TITLE
fix(embed): replace polling with ResizeObserver for height updates (#…

### DIFF
--- a/frontend/eslint.config.cjs
+++ b/frontend/eslint.config.cjs
@@ -56,6 +56,7 @@ module.exports = [
         EventSource: 'readonly',
         MessageEvent: 'readonly',
         CustomEvent: 'readonly',
+        ResizeObserver: 'readonly',
         confirm: 'readonly',
       },
     },

--- a/frontend/src/embed-widget/index.js
+++ b/frontend/src/embed-widget/index.js
@@ -16,7 +16,7 @@ export function initCrowdPayEmbed(script) {
   }
 
   const iframe = document.createElement('iframe');
-  const params = new URLSearchParams({ theme, size });
+  const params = new URLSearchParams({ theme, size, origin: window.location.origin });
   iframe.src = `${window.location.origin}/embed/campaigns/${campaignId}?${params.toString()}`;
   iframe.style.minHeight = `${MIN_HEIGHTS[size]}px`;
   iframe.style.width = '100%';

--- a/frontend/src/pages/CampaignEmbed.jsx
+++ b/frontend/src/pages/CampaignEmbed.jsx
@@ -4,16 +4,26 @@ import MilestoneProgressBar, { normalizeWidgetSize } from '../components/Milesto
 const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || '').replace(/\/+$/, '');
 const BASE_URL = import.meta.env.VITE_API_URL || `${API_BASE_URL}/api`;
 
+function getParentOrigin() {
+  const explicit = new URLSearchParams(window.location.search).get('origin');
+  if (explicit) return explicit;
+  try {
+    return new URL(document.referrer).origin;
+  } catch {
+    return '';
+  }
+}
+
 export default function CampaignEmbed() {
   const [campaign, setCampaign] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [isLive, setIsLive] = useState(false);
 
-  // Extract campaign ID from URL path: /embed/campaigns/:id
   const pathParts = window.location.pathname.split('/');
   const campaignId = pathParts[pathParts.length - 1];
   const size = normalizeWidgetSize(new URLSearchParams(window.location.search).get('size'));
+  const parentOrigin = getParentOrigin();
 
   useEffect(() => {
     if (!campaignId) {
@@ -22,7 +32,6 @@ export default function CampaignEmbed() {
       return;
     }
 
-    // Fetch initial campaign data
     fetch(`${BASE_URL}/campaigns/${campaignId}/embed`)
       .then((res) => {
         if (!res.ok) throw new Error('Campaign not found');
@@ -38,7 +47,6 @@ export default function CampaignEmbed() {
       });
   }, [campaignId]);
 
-  // Connect to SSE for live updates
   useEffect(() => {
     if (!campaignId || !campaign) return;
     if (!window.EventSource) return;
@@ -71,20 +79,28 @@ export default function CampaignEmbed() {
     };
   }, [campaignId, campaign]);
 
-  // Auto-resize iframe via postMessage
   useEffect(() => {
+    const targetOrigin = parentOrigin || '*';
+    let lastHeight = 0;
+
     const notifyHeight = () => {
       const height = document.documentElement.scrollHeight;
-      window.parent.postMessage({ type: 'resize', height }, '*');
+      if (height !== lastHeight) {
+        lastHeight = height;
+        window.parent.postMessage({ type: 'resize', height }, targetOrigin);
+      }
     };
 
     notifyHeight();
-    const interval = setInterval(notifyHeight, 500);
 
-    return () => clearInterval(interval);
-  }, [campaign, loading, error]);
+    const observer = new ResizeObserver(notifyHeight);
+    observer.observe(document.documentElement);
 
-  // Listen for open message from parent
+    return () => {
+      observer.disconnect();
+    };
+  }, [campaign, loading, error, parentOrigin]);
+
   useEffect(() => {
     const handler = (event) => {
       if (event.data && event.data.type === 'open') {
@@ -174,8 +190,7 @@ export default function CampaignEmbed() {
         rel="noopener noreferrer"
         style={styles.ctaButton}
         onClick={() => {
-          // Notify parent that user clicked (for analytics tracking)
-          window.parent.postMessage({ type: 'cta_click', campaignId: campaign.id }, '*');
+          window.parent.postMessage({ type: 'cta_click', campaignId: campaign.id }, parentOrigin || '*');
         }}
       >
         Back this campaign

--- a/frontend/src/pages/CampaignEmbed.test.jsx
+++ b/frontend/src/pages/CampaignEmbed.test.jsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import CampaignEmbed from './CampaignEmbed';
+
+const CAMPAIGN_DATA = {
+  id: '123',
+  title: 'Test Campaign',
+  description: 'A test campaign',
+  raised_amount: '5000',
+  target_amount: '10000',
+  asset_type: 'USDC',
+  progress_percentage: 50,
+  backer_count: 25,
+  days_remaining: 10,
+  contribution_url: 'https://example.com/contribute',
+  milestones: [],
+  milestone_summary: null,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('CampaignEmbed', () => {
+  let resizeObserverMock;
+  let postMessageSpy;
+
+  beforeEach(() => {
+    let resizeCb = null;
+    resizeObserverMock = {
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+      trigger: () => {
+        if (resizeCb) resizeCb();
+      },
+    };
+    globalThis.ResizeObserver = class {
+      constructor(cb) {
+        resizeCb = () => cb();
+      }
+      observe(el) { resizeObserverMock.observe(el); }
+      unobserve() { resizeObserverMock.unobserve(); }
+      disconnect() { resizeObserverMock.disconnect(); }
+    };
+
+    postMessageSpy = vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {});
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      value: 500,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  function renderEmbed(url) {
+    window.history.pushState({}, '', url || '/embed/campaigns/123?origin=http://localhost');
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(CAMPAIGN_DATA),
+    });
+    return render(<CampaignEmbed />);
+  }
+
+  it('sends initial height notification using the configured origin', async () => {
+    renderEmbed();
+    await waitFor(() => {
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        { type: 'resize', height: 500 },
+        'http://localhost'
+      );
+    });
+  });
+
+  it('observes document.documentElement with ResizeObserver', () => {
+    renderEmbed();
+    expect(resizeObserverMock.observe).toHaveBeenCalledWith(document.documentElement);
+  });
+
+  it('does not send duplicate height notifications when size is unchanged', async () => {
+    renderEmbed();
+    await waitFor(() => {
+      expect(postMessageSpy).toHaveBeenCalledTimes(2);
+    });
+    act(() => { resizeObserverMock.trigger(); });
+    expect(postMessageSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('sends a new notification when height actually changes', async () => {
+    renderEmbed();
+    await waitFor(() => {
+      expect(postMessageSpy).toHaveBeenCalledTimes(2);
+    });
+    Object.defineProperty(document.documentElement, 'scrollHeight', {
+      value: 999,
+      configurable: true,
+      writable: true,
+    });
+    act(() => { resizeObserverMock.trigger(); });
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { type: 'resize', height: 999 },
+      'http://localhost'
+    );
+  });
+
+  it('disconnects ResizeObserver on unmount', () => {
+    const { unmount } = renderEmbed();
+    unmount();
+    expect(resizeObserverMock.disconnect).toHaveBeenCalled();
+  });
+
+  it('falls back to document.referrer origin when origin param is absent', async () => {
+    Object.defineProperty(document, 'referrer', {
+      value: 'https://example.com/some-page',
+      configurable: true,
+    });
+    renderEmbed('/embed/campaigns/123');
+    await waitFor(() => {
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        { type: 'resize', height: expect.any(Number) },
+        'https://example.com'
+      );
+    });
+  });
+
+  it('uses wildcard when no origin is available', async () => {
+    Object.defineProperty(document, 'referrer', {
+      value: '',
+      configurable: true,
+    });
+    renderEmbed('/embed/campaigns/123');
+    await waitFor(() => {
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        { type: 'resize', height: expect.any(Number) },
+        '*'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #566

Replace setInterval(500ms) polling with ResizeObserver to eliminate unnecessary CPU usage, DOM measurements, and postMessage traffic.
- Add getParentOrigin() helper: reads explicit origin query param with document.referrer fallback, avoids wildcard postMessage origin
- Observe document.documentElement via ResizeObserver, notify parent only when actual scrollHeight changes
- Secure CTA click postMessage target origin
- Disconnect observer and remove all polling on unmount
- Add ResizeObserver to eslint globals
- Pass parent origin via query param from embed-widget script