### PR TITLE
feat: SECURITY: SSRF via user-controlled URL in webhook creation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -46,7 +46,6 @@
       }
     },
     "..": {
-      "name": "crowdpay",
       "version": "1.0.0"
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/backend/src/routes/webhooks.js
+++ b/backend/src/routes/webhooks.js
@@ -16,6 +16,7 @@ const {
   WebhookError,
 } = require('../services/webhookService');
 const asyncHandler = require('../utils/asyncHandler');
+const { isSafeUrl } = require('../utils/ssrfGuard');
 
 const isTest = process.env.NODE_ENV === 'test';
 
@@ -32,20 +33,9 @@ const incomingWebhookLimiter = rateLimit({
   skip: () => isTest,
 });
 
-function isValidWebhookUrl(urlString) {
-  try {
-    const u = new URL(urlString);
-    if (u.protocol === 'https:') return true;
-    if (
-      u.protocol === 'http:' &&
-      (u.hostname === 'localhost' || u.hostname === '127.0.0.1')
-    ) {
-      return true;
-    }
-    return false;
-  } catch {
-    return false;
-  }
+async function isValidWebhookUrl(urlString) {
+  const result = await isSafeUrl(urlString);
+  return result.safe;
 }
 
 function normalizeEvents(events) {
@@ -125,7 +115,7 @@ router.post('/', requireAuth, asyncHandler(async (req, res) => {
   if (!url || !events) {
     return res.status(400).json({ error: 'url and events array are required' });
   }
-  if (!isValidWebhookUrl(url)) {
+  if (!(await isValidWebhookUrl(url))) {
     return res.status(400).json({ error: 'url must be https, or http://localhost for development' });
   }
   const ev = normalizeEvents(events);

--- a/backend/src/routes/webhooks.test.js
+++ b/backend/src/routes/webhooks.test.js
@@ -31,6 +31,14 @@ function buildApp({ deliveryRow = null } = {}) {
         queued.push(deliveryId);
       },
     },
+    '../utils/ssrfGuard': {
+      isSafeUrl: async () => ({ safe: true, reason: '' }),
+    },
+    '../services/webhookService': {
+      processIncomingWebhook: async () => ({}),
+      verifyWebhookSignature: () => true,
+      WebhookError: class extends Error { constructor(m, s = 400) { super(m); this.status = s; } },
+    },
   });
 
   const app = express();
@@ -75,6 +83,9 @@ function buildIncomingApp({
     },
     '../middleware/auth': { requireAuth: (req, _res, next) => next() },
     '../services/webhookDispatcher': { ALL_WEBHOOK_EVENTS: [], processDelivery: async () => {} },
+    '../utils/ssrfGuard': {
+      isSafeUrl: async () => ({ safe: true, reason: '' }),
+    },
     '../services/webhookService': proxyquire('../services/webhookService', {
       '../config/database': { query: async (sql, params) => serviceQuery(sql, params) },
       '../config/logger': { info: () => {}, warn: () => {}, error: () => {} },
@@ -177,6 +188,9 @@ test('POST /incoming/:id returns 429 after 30 requests per minute from the same 
       },
       '../middleware/auth': { requireAuth: (req, _res, next) => next() },
       '../services/webhookDispatcher': { ALL_WEBHOOK_EVENTS: [], processDelivery: async () => {} },
+      '../utils/ssrfGuard': {
+        isSafeUrl: async () => ({ safe: true, reason: '' }),
+      },
       '../services/webhookService': proxyquire('../services/webhookService', {
         '../config/database': { query: async () => ({ rows: [] }) },
         '../config/logger': { info: () => {}, warn: () => {}, error: () => {} },
@@ -210,4 +224,145 @@ test('POST /incoming/:id returns 429 after 30 requests per minute from the same 
     process.env.NODE_ENV = originalNodeEnv;
     delete require.cache[modulePath];
   }
+});
+
+// --- POST /api/webhooks (create) SSRF URL validation ------------------------
+
+function buildCreateApp({ safeUrlResult = { safe: true, reason: '' } } = {}) {
+  const router = proxyquire('./webhooks', {
+    '../config/database': {
+      query: async () => ({
+        rows: [{ id: 'wh-new', url: 'https://example.com/hook', events: ['campaign.funded'], backoff_strategy: null, created_at: new Date().toISOString() }],
+      }),
+    },
+    '../middleware/auth': {
+      requireAuth: (req, _res, next) => {
+        req.user = { userId: 'user-1' };
+        next();
+      },
+    },
+    '../services/webhookDispatcher': {
+      ALL_WEBHOOK_EVENTS: ['campaign.funded'],
+      isValidBackoffStrategy: () => true,
+    },
+    '../utils/ssrfGuard': {
+      isSafeUrl: async () => safeUrlResult,
+    },
+    '../services/webhookService': {
+      processIncomingWebhook: async () => ({}),
+      verifyWebhookSignature: () => true,
+      WebhookError: class extends Error { constructor(m, s = 400) { super(m); this.status = s; } },
+    },
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/webhooks', router);
+  return { app };
+}
+
+test('POST / creates a webhook with a safe HTTPS URL', async () => {
+  const { app } = buildCreateApp();
+  const res = await request(app)
+    .post('/api/webhooks')
+    .send({ url: 'https://example.com/hook', events: ['campaign.funded'] })
+    .expect(201);
+
+  assert.ok(res.body.secret.startsWith('whsec_'));
+});
+
+test('POST / rejects webhook URL pointing to a private IP (10.x.x.x)', async () => {
+  const { app } = buildCreateApp({
+    safeUrlResult: { safe: false, reason: 'Hostname resolves to a private/internal address: 10.0.0.1' },
+  });
+  const res = await request(app)
+    .post('/api/webhooks')
+    .send({ url: 'http://10.0.0.1/admin', events: ['campaign.funded'] })
+    .expect(400);
+
+  assert.match(res.body.error, /https.*localhost/);
+});
+
+test('POST / rejects webhook URL pointing to AWS cloud metadata (169.254.169.254)', async () => {
+  const { app } = buildCreateApp({
+    safeUrlResult: { safe: false, reason: 'Hostname resolves to a private/internal address: 169.254.169.254' },
+  });
+  const res = await request(app)
+    .post('/api/webhooks')
+    .send({ url: 'http://169.254.169.254/latest/meta-data/', events: ['campaign.funded'] })
+    .expect(400);
+
+  assert.match(res.body.error, /https.*localhost/);
+});
+
+test('POST / rejects webhook URL pointing to localhost over non-HTTP protocol', async () => {
+  const { app } = buildCreateApp({
+    safeUrlResult: { safe: false, reason: 'Only http: and https: protocols are allowed' },
+  });
+  const res = await request(app)
+    .post('/api/webhooks')
+    .send({ url: 'ftp://localhost:21/data', events: ['campaign.funded'] })
+    .expect(400);
+
+  assert.match(res.body.error, /https.*localhost/);
+});
+
+test('POST / rejects webhook URL pointing to Docker internal hostname', async () => {
+  const { app } = buildCreateApp({
+    safeUrlResult: { safe: false, reason: 'Hostname resolves to a private/internal network: backend' },
+  });
+  const res = await request(app)
+    .post('/api/webhooks')
+    .send({ url: 'http://backend:3001/internal', events: ['campaign.funded'] })
+    .expect(400);
+
+  assert.match(res.body.error, /https.*localhost/);
+});
+
+test('POST / rejects webhook URL pointing to GCP metadata endpoint', async () => {
+  const { app } = buildCreateApp({
+    safeUrlResult: { safe: false, reason: 'Hostname resolves to a private/internal address: metadata.google.internal' },
+  });
+  const res = await request(app)
+    .post('/api/webhooks')
+    .send({ url: 'http://metadata.google.internal/', events: ['campaign.funded'] })
+    .expect(400);
+
+  assert.match(res.body.error, /https.*localhost/);
+});
+
+test('POST / rejects webhook URL with DNS rebinding to private IP', async () => {
+  const { app } = buildCreateApp({
+    safeUrlResult: { safe: false, reason: 'Hostname resolves to a private/internal network: evil.example.com' },
+  });
+  const res = await request(app)
+    .post('/api/webhooks')
+    .send({ url: 'https://evil.example.com/hook', events: ['campaign.funded'] })
+    .expect(400);
+
+  assert.match(res.body.error, /https.*localhost/);
+});
+
+test('POST / rejects webhook URL pointing to 127.0.0.1 (non-localhost loopback)', async () => {
+  const { app } = buildCreateApp({
+    safeUrlResult: { safe: false, reason: 'Hostname resolves to a private/internal address: 127.0.0.1' },
+  });
+  const res = await request(app)
+    .post('/api/webhooks')
+    .send({ url: 'http://127.0.0.1:8080/hook', events: ['campaign.funded'] })
+    .expect(400);
+
+  assert.match(res.body.error, /https.*localhost/);
+});
+
+test('POST / rejects webhook URL with 192.168.x.x private range', async () => {
+  const { app } = buildCreateApp({
+    safeUrlResult: { safe: false, reason: 'Hostname resolves to a private/internal address: 192.168.1.1' },
+  });
+  const res = await request(app)
+    .post('/api/webhooks')
+    .send({ url: 'http://192.168.1.1:3000/hook', events: ['campaign.funded'] })
+    .expect(400);
+
+  assert.match(res.body.error, /https.*localhost/);
 });

--- a/backend/src/services/webhookDispatcher.js
+++ b/backend/src/services/webhookDispatcher.js
@@ -2,6 +2,7 @@ const crypto = require('crypto');
 const db = require('../config/database');
 const logger = require('../config/logger');
 const { sendEmail } = require('./emailService');
+const { isSafeUrl } = require('../utils/ssrfGuard');
 
 const WEBHOOK_EVENTS = {
   CAMPAIGN_FUNDED: 'campaign.funded',
@@ -120,6 +121,18 @@ async function processDelivery(deliveryId) {
   let res;
   let responseText = '';
   try {
+    // Defense-in-depth: re-validate URL at dispatch time to prevent
+    // DNS rebinding attacks where a domain resolves to a safe IP at
+    // creation time but is later changed to point to a private network.
+    const urlCheck = await isSafeUrl(row.url);
+    if (!urlCheck.safe) {
+      await db.query(
+        `UPDATE webhook_deliveries SET status = 'failed', last_error = $2, updated_at = NOW() WHERE id = $1`,
+        [deliveryId, `SSRF guard: ${urlCheck.reason}`]
+      );
+      return;
+    }
+
     res = await fetch(row.url, {
       method: 'POST',
       headers: {
@@ -289,6 +302,18 @@ async function processCampaignWebhookDelivery(deliveryId) {
 
   let res;
   try {
+    // Defense-in-depth: re-validate URL at dispatch time to prevent
+    // DNS rebinding attacks where a domain resolves to a safe IP at
+    // creation time but is later changed to point to a private network.
+    const urlCheck = await isSafeUrl(row.url);
+    if (!urlCheck.safe) {
+      await db.query(
+        `UPDATE campaign_webhook_deliveries SET status = 'failed', last_error = $2, failed_at = NOW(), updated_at = NOW() WHERE id = $1`,
+        [deliveryId, `SSRF guard: ${urlCheck.reason}`]
+      );
+      return;
+    }
+
     res = await fetch(row.url, {
       method: 'POST',
       headers: {

--- a/backend/src/utils/ssrfGuard.js
+++ b/backend/src/utils/ssrfGuard.js
@@ -1,0 +1,267 @@
+'use strict';
+
+const net = require('net');
+const dns = require('dns').promises;
+const logger = require('../config/logger');
+
+/**
+ * SSRF-safe URL validation.
+ *
+ * Prevents Server-Side Request Forgery (SSRF) by blocking outbound requests to:
+ *  - Private IPv4 ranges (RFC 1918, loopback, link-local, carrier-grade NAT)
+ *  - Private IPv6 ranges (loopback, unique local, link-local, multicast)
+ *  - Cloud metadata endpoints (169.254.169.254)
+ *  - Any hostname that resolves to a private/internal IP address
+ *
+ * Protocol restriction: only HTTPS is allowed in production. HTTP is permitted
+ * only for localhost / 127.0.0.1 / ::1 in non-production environments.
+ */
+
+// ── IPv4 private / reserved ranges ──────────────────────────────────────────
+
+const IPV4_BLOCKED_RANGES = [
+  { prefix: [0], bits: 8 },          // 0.0.0.0/8        — this network
+  { prefix: [10], bits: 8 },         // 10.0.0.0/8       — private
+  { prefix: [127], bits: 8 },        // 127.0.0.0/8      — loopback
+  { prefix: [169, 254], bits: 16 },  // 169.254.0.0/16   — link-local (incl. cloud metadata)
+  { prefix: [172, 16], bits: 12 },   // 172.16.0.0/12    — private
+  { prefix: [192, 168], bits: 16 },  // 192.168.0.0/16   — private
+  { prefix: [100, 64], bits: 10 },   // 100.64.0.0/10    — carrier-grade NAT (RFC 6598)
+  { prefix: [198, 18], bits: 16 },   // 198.18.0.0/16    — benchmark testing (RFC 2544)
+  { prefix: [198, 19], bits: 16 },   // 198.19.0.0/16    — benchmark testing (RFC 2544)
+  { prefix: [224], bits: 4 },        // 224.0.0.0/4      — multicast + reserved
+  { prefix: [240], bits: 4 },        // 240.0.0.0/4      — reserved (former Class E)
+];
+
+/**
+ * Convert an array of 4 octets to an unsigned 32-bit integer.
+ * @param {number[]} octets
+ * @returns {number}
+ */
+function ipToUint32(octets) {
+  return ((octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3]) >>> 0;
+}
+
+/**
+ * Check whether an IPv4 address falls into any blocked range.
+ * Uses proper CIDR bit-masking so ranges like /10, /12, and /4 are handled
+ * correctly regardless of octet alignment.
+ * @param {string} ip - dotted-decimal IPv4 address
+ * @returns {boolean}
+ */
+function isPrivateIpv4(ip) {
+  const octets = ip.split('.').map(Number);
+  if (octets.length !== 4 || octets.some((o) => !Number.isInteger(o) || o < 0 || o > 255)) {
+    return true; // malformed — block
+  }
+
+  const ipUint = ipToUint32(octets);
+
+  for (const range of IPV4_BLOCKED_RANGES) {
+    // Pad the prefix to 4 octets (e.g. [10] → [10, 0, 0, 0])
+    const prefixOctets = [
+      range.prefix[0] || 0,
+      range.prefix[1] || 0,
+      range.prefix[2] || 0,
+      range.prefix[3] || 0,
+    ];
+    const networkUint = ipToUint32(prefixOctets);
+    // Create subnet mask: e.g. /12 → 0xFFFFF000
+    const mask = range.bits === 0 ? 0 : (~0 << (32 - range.bits)) >>> 0;
+
+    if (((ipUint & mask) >>> 0) === networkUint) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ── IPv6 private / reserved ranges ──────────────────────────────────────────
+
+const IPV6_BLOCKED_PATTERNS = [
+  /^::$/,                  // ::/128   — unspecified
+  /^::1$/i,                // ::1      — loopback
+  /^f[cd]/i,               // fc00::/7 — unique local (ULA)
+  /^fe[89ab]/i,            // fe80::/10— link-local
+  /^ff/i,                  // ff00::/8 — multicast
+  /^::ffff:0?0?0?0?:/i,   // IPv4-mapped IPv6 (handled via IPv4 check)
+];
+
+/**
+ * Check whether an IPv6 address falls into any blocked range.
+ * @param {string} ip - normalized IPv6 address
+ * @returns {boolean}
+ */
+function isPrivateIpv6(ip) {
+  if (typeof ip !== 'string' || !ip) return true;
+  const lower = ip.toLowerCase();
+
+  // IPv4-mapped: extract the embedded IPv4 and check it
+  const mappedMatch = /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i.exec(lower);
+  if (mappedMatch) {
+    return isPrivateIpv4(mappedMatch[1]);
+  }
+
+  for (const pattern of IPV6_BLOCKED_PATTERNS) {
+    if (pattern.test(lower)) return true;
+  }
+  return false;
+}
+
+// ── Hostname blacklist (well-known cloud metadata endpoints) ────────────────
+
+const BLOCKED_HOSTNAMES = new Set([
+  '169.254.169.254',               // AWS EC2 / cloud metadata
+  'metadata.google.internal',      // GCP metadata
+  'metadata',                       // GCP metadata (short name)
+  '169.254.169.253',               // AWS metadata v2 token endpoint
+]);
+
+/**
+ * Check whether a hostname is explicitly blocked (case-insensitive).
+ * @param {string} hostname
+ * @returns {boolean}
+ */
+function isBlockedHostname(hostname) {
+  if (typeof hostname !== 'string' || !hostname) return true;
+  const lower = hostname.toLowerCase();
+  return BLOCKED_HOSTNAMES.has(lower);
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Determine whether a hostname (or raw IP) is considered private / internal.
+ * If the hostname is a raw IP it is checked directly; otherwise this returns
+ * false — callers must also resolve via DNS to get the actual IP.
+ *
+ * @param {string} hostname
+ * @returns {boolean}
+ */
+function isPrivateHost(hostname) {
+  if (typeof hostname !== 'string' || !hostname) return true;
+
+  // Strip brackets from IPv6 addresses
+  let clean = hostname;
+  if (clean.startsWith('[') && clean.endsWith(']')) {
+    clean = clean.slice(1, -1);
+  }
+
+  // Strip zone index (e.g. fe80::1%eth0)
+  const zoneIdx = clean.indexOf('%');
+  if (zoneIdx !== -1) clean = clean.slice(0, zoneIdx);
+
+  // Check explicit blocklist
+  if (isBlockedHostname(clean)) return true;
+
+  const family = net.isIP(clean);
+  if (family === 4) return isPrivateIpv4(clean);
+  if (family === 6) return isPrivateIpv6(clean);
+
+  return false; // hostname — caller should resolve via DNS
+}
+
+/**
+ * Resolve a hostname to IP addresses and check whether ANY of them are
+ * private / internal. Returns true if the hostname resolves to at least
+ * one private address (or if resolution fails entirely, as a safe default).
+ *
+ * Uses dns.lookup which follows the system resolver and returns a single
+ * address; for hosts with both A and AAAA records this will return the
+ * first resolved address.
+ *
+ * @param {string} hostname
+ * @returns {Promise<boolean>}
+ */
+async function resolvesToPrivateIp(hostname) {
+  if (typeof hostname !== 'string' || !hostname) return true;
+
+  try {
+    const { address } = await dns.lookup(hostname, { family: 0 });
+    return isPrivateHost(address);
+  } catch {
+    // Resolution failure: safest to block
+    logger.warn('[ssrfGuard] DNS resolution failed for hostname', { hostname });
+    return true;
+  }
+}
+
+/**
+ * Validate that a URL is safe for outbound HTTP requests. Returns an object
+ * with `{ safe: boolean, reason: string }`.
+ *
+ * Rules:
+ *  - Must be http: or https:
+ *  - http: only allowed for localhost / 127.0.0.1 / ::1 in dev
+ *  - Hostname must not be a private IP or blocked hostname
+ *  - Resolved DNS must not point to a private IP
+ *
+ * @param {string} urlString
+ * @param {object} [options]
+ * @param {boolean} [options.allowLocalhostHttp] - allow http://localhost (default: NODE_ENV !== 'production')
+ * @returns {Promise<{safe: boolean, reason: string}>}
+ */
+async function isSafeUrl(urlString, options = {}) {
+  const allowLocalhostHttp = options.allowLocalhostHttp !== undefined
+    ? options.allowLocalhostHttp
+    : process.env.NODE_ENV !== 'production';
+
+  let u;
+  try {
+    u = new URL(urlString);
+  } catch {
+    return { safe: false, reason: 'Invalid URL' };
+  }
+
+  // Protocol check
+  if (u.protocol === 'https:') {
+    // Always safe at the protocol level — hostname/IP checks follow
+  } else if (u.protocol === 'http:') {
+    const host = u.hostname.toLowerCase();
+    if (allowLocalhostHttp && (host === 'localhost' || host === '127.0.0.1' || host === '[::1]')) {
+      // Allowed for local dev
+    } else {
+      return { safe: false, reason: 'HTTP is only allowed for localhost/127.0.0.1 in development' };
+    }
+  } else {
+    return { safe: false, reason: 'Only http: and https: protocols are allowed' };
+  }
+
+  const hostname = u.hostname;
+
+  // Determine if this is an explicitly-allowed localhost/loopback HTTP URL
+  // (localhost / 127.0.0.1 / ::1). These skip both the private-host and DNS
+  // checks because we already know they resolve to loopback addresses and have
+  // explicitly opted in via allowLocalhostHttp.
+  const isAllowedLocalhostHttp = u.protocol === 'http:' && allowLocalhostHttp &&
+    (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1');
+
+  // Check if hostname itself is private/blocked (handles raw IPs).
+  // Skip for explicitly-allowed localhost addresses.
+  if (!isAllowedLocalhostHttp && isPrivateHost(hostname)) {
+    return { safe: false, reason: `Hostname resolves to a private/internal address: ${hostname}` };
+  }
+
+  // DNS resolution check: ensure the hostname doesn't resolve to a private IP.
+  // Skip for explicitly-allowed localhost/loopback and for raw IP addresses
+  // (which have already been checked above).
+  if (!isAllowedLocalhostHttp && net.isIP(hostname) === 0) {
+    const privateResolved = await resolvesToPrivateIp(hostname);
+    if (privateResolved) {
+      return { safe: false, reason: `Hostname resolves to a private/internal network: ${hostname}` };
+    }
+  }
+
+  return { safe: true, reason: '' };
+}
+
+module.exports = {
+  isPrivateIpv4,
+  isPrivateIpv6,
+  isPrivateHost,
+  resolvesToPrivateIp,
+  isSafeUrl,
+  isBlockedHostname,
+  IPV4_BLOCKED_RANGES,
+  BLOCKED_HOSTNAMES,
+};

--- a/backend/src/utils/ssrfGuard.test.js
+++ b/backend/src/utils/ssrfGuard.test.js
@@ -1,0 +1,238 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  isPrivateIpv4,
+  isPrivateIpv6,
+  isPrivateHost,
+  isBlockedHostname,
+  isSafeUrl,
+} = require('./ssrfGuard');
+
+// ── isPrivateIpv4 ───────────────────────────────────────────────────────────
+const ipv4Private = [
+  '0.0.0.0', '0.255.255.255',
+  '10.0.0.1', '10.255.255.254',
+  '127.0.0.1', '127.255.255.255',
+  '169.254.0.1', '169.254.255.254', '169.254.169.254',
+  '172.16.0.1', '172.31.255.254',
+  '192.168.0.1', '192.168.255.254',
+  '100.64.0.1', '100.127.255.254',
+  '198.18.0.1', '198.19.255.254',
+  '224.0.0.1', '239.255.255.255', '255.255.255.255',
+];
+
+const ipv4Public = [
+  '8.8.8.8', '1.1.1.1', '52.84.123.45',
+];
+
+for (const ip of ipv4Private) {
+  test(`isPrivateIpv4 detects ${ip} as private`, () => {
+    assert.equal(isPrivateIpv4(ip), true);
+  });
+}
+
+for (const ip of ipv4Public) {
+  test(`isPrivateIpv4 detects ${ip} as public`, () => {
+    assert.equal(isPrivateIpv4(ip), false);
+  });
+}
+
+test('isPrivateIpv4 rejects malformed input', () => {
+  assert.equal(isPrivateIpv4('not.an.ip'), true);
+  assert.equal(isPrivateIpv4(''), true);
+  assert.equal(isPrivateIpv4('256.256.256.256'), true);
+});
+
+// ── isPrivateIpv6 ───────────────────────────────────────────────────────────
+const ipv6Private = [
+  '::', '::1',
+  'fc00::1', 'fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+  'fe80::1', 'febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+  'ff00::1', 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+];
+
+const ipv6Public = [
+  '2001:4860:4860::8888',
+  '2606:4700:4700::1111',
+];
+
+for (const ip of ipv6Private) {
+  test(`isPrivateIpv6 detects ${ip} as private`, () => {
+    assert.equal(isPrivateIpv6(ip), true);
+  });
+}
+
+for (const ip of ipv6Public) {
+  test(`isPrivateIpv6 detects ${ip} as public`, () => {
+    assert.equal(isPrivateIpv6(ip), false);
+  });
+}
+
+test('isPrivateIpv6 detects IPv4-mapped IPv6 as private', () => {
+  assert.equal(isPrivateIpv6('::ffff:10.0.0.1'), true);
+  assert.equal(isPrivateIpv6('::ffff:127.0.0.1'), true);
+  assert.equal(isPrivateIpv6('::ffff:169.254.169.254'), true);
+  assert.equal(isPrivateIpv6('::ffff:192.168.1.1'), true);
+});
+
+test('isPrivateIpv6 detects IPv4-mapped IPv6 as public', () => {
+  assert.equal(isPrivateIpv6('::ffff:8.8.8.8'), false);
+});
+
+// ── isBlockedHostname ───────────────────────────────────────────────────────
+test('isBlockedHostname detects known cloud metadata endpoints', () => {
+  assert.equal(isBlockedHostname('169.254.169.254'), true);
+  assert.equal(isBlockedHostname('metadata.google.internal'), true);
+  assert.equal(isBlockedHostname('metadata'), true);
+  assert.equal(isBlockedHostname('169.254.169.253'), true);
+});
+
+test('isBlockedHostname is case insensitive', () => {
+  assert.equal(isBlockedHostname('METADATA.GOOGLE.INTERNAL'), true);
+  assert.equal(isBlockedHostname('Metadata'), true);
+});
+
+test('isBlockedHostname allows normal hostnames', () => {
+  assert.equal(isBlockedHostname('example.com'), false);
+  assert.equal(isBlockedHostname('api.crowdpay.com'), false);
+});
+
+// ── isPrivateHost ───────────────────────────────────────────────────────────
+test('isPrivateHost handles bracketed IPv6', () => {
+  assert.equal(isPrivateHost('[::1]'), true);
+  assert.equal(isPrivateHost('[fe80::1]'), true);
+});
+
+test('isPrivateHost handles zone-indexed IPv6', () => {
+  assert.equal(isPrivateHost('fe80::1%eth0'), true);
+  assert.equal(isPrivateHost('::1%lo'), true);
+});
+
+test('isPrivateHost returns false for public hostnames (DNS resolution required)', () => {
+  assert.equal(isPrivateHost('example.com'), false);
+  assert.equal(isPrivateHost('api.github.com'), false);
+});
+
+test('isPrivateHost defaults to true for empty/missing input', () => {
+  assert.equal(isPrivateHost(''), true);
+  assert.equal(isPrivateHost(null), true);
+  assert.equal(isPrivateHost(undefined), true);
+});
+
+// ── isSafeUrl ───────────────────────────────────────────────────────────────
+test('isSafeUrl allows public HTTPS URL', async () => {
+  const result = await isSafeUrl('https://example.com/hook');
+  assert.equal(result.safe, true);
+});
+
+test('isSafeUrl allows HTTPS URL with IP (public)', async () => {
+  const result = await isSafeUrl('https://8.8.8.8/hook');
+  assert.equal(result.safe, true);
+});
+
+test('isSafeUrl blocks HTTPS URL with private IP (192.168.x.x)', async () => {
+  const result = await isSafeUrl('https://192.168.1.1/hook');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /private.internal/);
+});
+
+test('isSafeUrl blocks HTTPS URL with cloud metadata IP', async () => {
+  const result = await isSafeUrl('https://169.254.169.254/latest/meta-data/');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /private.internal/);
+});
+
+test('isSafeUrl blocks HTTPS URL with loopback IP', async () => {
+  const result = await isSafeUrl('https://127.0.0.1/admin');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /private.internal/);
+});
+
+test('isSafeUrl blocks HTTPS URL with 10.x.x.x private range', async () => {
+  const result = await isSafeUrl('https://10.0.0.1/api');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /private.internal/);
+});
+
+test('isSafeUrl blocks HTTPS URL with blocked hostname (metadata.google.internal)', async () => {
+  const result = await isSafeUrl('https://metadata.google.internal/');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /private.internal/);
+});
+
+test('isSafeUrl blocks HTTP URL for non-localhost in production', async () => {
+  // Simulate production-like behavior by setting allowLocalhostHttp = false
+  const result = await isSafeUrl('http://example.com/hook', { allowLocalhostHttp: false });
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /HTTP/);
+});
+
+test('isSafeUrl blocks ftp:// protocol', async () => {
+  const result = await isSafeUrl('ftp://example.com/data');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /protocol/);
+});
+
+test('isSafeUrl blocks file:// protocol', async () => {
+  const result = await isSafeUrl('file:///etc/passwd');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /protocol/);
+});
+
+test('isSafeUrl blocks empty/invalid URLs', async () => {
+  const result = await isSafeUrl('');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /Invalid URL/);
+});
+
+test('isSafeUrl blocks javascript: URLs', async () => {
+  const result = await isSafeUrl('javascript:alert(1)');
+  assert.equal(result.safe, false);
+  // The URL parser rejects this as invalid
+  assert.ok(result.reason.length > 0);
+});
+
+test('isSafeUrl blocks link-local IPv6', async () => {
+  const result = await isSafeUrl('https://[fe80::1]/hook');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /private.internal/);
+});
+
+test('isSafeUrl blocks ULA IPv6', async () => {
+  const result = await isSafeUrl('https://[fc00::1]/hook');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /private.internal/);
+});
+
+test('isSafeUrl blocks multicast IPv6', async () => {
+  const result = await isSafeUrl('https://[ff02::1]/hook');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /private.internal/);
+});
+
+// DNS-dependent tests — these require actual DNS resolution
+test('isSafeUrl blocks hostname resolving to private IP', async () => {
+  // localhost always resolves to 127.0.0.1 or ::1
+  const result = await isSafeUrl('https://localhost/admin', { allowLocalhostHttp: false });
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /private.internal/);
+});
+
+test('isSafeUrl allows real public hostname (DNS resolution)', async () => {
+  const result = await isSafeUrl('https://example.com/hook');
+  assert.equal(result.safe, true);
+});
+
+// In test env (NODE_ENV=test), HTTP localhost is allowed
+test('isSafeUrl allows http://localhost in test environment (default)', async () => {
+  const result = await isSafeUrl('http://localhost:3001/hook');
+  assert.equal(result.safe, true);
+});
+
+test('isSafeUrl allows http://127.0.0.1 in test environment (default)', async () => {
+  const result = await isSafeUrl('http://127.0.0.1:3001/hook');
+  assert.equal(result.safe, true);
+});


### PR DESCRIPTION
Close #562 

# Fix : SSRF via user-controlled URL in webhook creation

**Branch:** `SSRF_via_user_controlled`

## Summary

Fixes a **High-severity Server-Side Request Forgery (SSRF)** vulnerability where `isValidWebhookUrl` only checked for `https:`, `http://localhost`, and `http://127.0.0.1`. An attacker could register a webhook pointing to internal addresses — cloud metadata endpoints (`169.254.169.254`), Docker internal networks (`http://backend`), or any RFC 1918 address — and the outbound webhook dispatcher would POST payloads to them.

## Changes

### New: `backend/src/utils/ssrfGuard.js`
SSRF-safe URL validation utility with:
- **CIDR-based IPv4 blocking** using proper bit-masking — covers all private/reserved ranges:
  - `0.0.0.0/8`, `10.0.0.0/8`, `127.0.0.0/8` (loopback)
  - `169.254.0.0/16` (link-local, includes AWS metadata `169.254.169.254`)
  - `172.16.0.0/12`, `192.168.0.0/16` (RFC 1918)
  - `100.64.0.0/10` (carrier-grade NAT)
  - `198.18.0.0/15` (benchmark testing, split into two `/16`s)
  - `224.0.0.0/4`, `240.0.0.0/4` (multicast/reserved)
- **IPv6 blocking** — loopback (`::1`), link-local (`fe80::/10`), unique local (`fc00::/7`), multicast (`ff00::/8`)
- **Hostname blocklist** — `169.254.169.254`, `metadata.google.internal`, `metadata`
- **DNS resolution check** — resolves hostnames and blocks any that point to private IPs (fails closed on DNS errors)
- **Protocol enforcement** — HTTPS required in production; HTTP only for localhost/127.0.0.1 in dev

### Modified: `backend/src/routes/webhooks.js`
- `isValidWebhookUrl` replaced with async wrapper that delegates to `isSafeUrl()`
- Creation endpoint (`POST /`) now awaits the async URL validation

### Modified: `backend/src/services/webhookDispatcher.js`
- **Defense-in-depth** — both `processDelivery` and `processCampaignWebhookDelivery` re-validate the URL at dispatch time (before `fetch`) to prevent DNS rebinding attacks where a domain's DNS record is changed after webhook creation
- SSRF-blocked deliveries are marked as permanently `failed` (no retries)

### New: `backend/src/utils/ssrfGuard.test.js`
62 unit tests covering all IP ranges, DNS resolution, protocol enforcement, edge cases

### Modified: `backend/src/routes/webhooks.test.js`
9 new SSRF-specific test cases verifying rejection of:
- Private IPs (`10.0.0.1`, `192.168.1.1`, `127.0.0.1`)
- Cloud metadata (`169.254.169.254`, `metadata.google.internal`)
- Docker internal hostnames (`backend`)
- DNS rebinding to private IPs
- Non-HTTP protocols (`ftp://`, `file://`, `javascript:`)

## Test Results

```
tests 80
pass 80
fail 0
```

