### PR TITLE
fix(wallet): require WALLET_ENCRYPTION_KEY and remove ephemeral walle…

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,24 @@ cd frontend && npm run dev   # http://localhost:5173
 | `STELLAR_HORIZON_URL` | Horizon endpoint URL |
 | `PLATFORM_SECRET_KEY` | Stellar secret key for the platform co-signer wallet |
 | `USDC_ISSUER` | USDC issuer (`GBBD47...` on testnet) |
-| `WALLET_SECRET_LOCAL_KEK` | Base64-encoded key-encryption key for stored secrets |
+| `WALLET_ENCRYPTION_KEY` | Base64 or hex-encoded 32-byte encryption key used by backend wallet recovery |
+| `WALLET_SECRET_LOCAL_KEK` | Base64-encoded 32-byte key-encryption key for stored secrets |
 | `FRONTEND_URL` | Allowed CORS origin (dev: `http://localhost:5173`) |
 | `SMTP_HOST` / `EMAIL_SERVICE_API_KEY` | Email delivery (optional in dev) |
 | `PERSONA_API_KEY` / `PERSONA_TEMPLATE_ID` | KYC provider (optional in dev) |
 | `AWS_ACCESS_KEY_ID` + S3 vars | Image uploads (optional in dev) |
+
+Generate a 32-byte key:
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+```
+
+### Wallet secret key rotation
+
+- `WALLET_SECRET_LOCAL_KEK` and `WALLET_ENCRYPTION_KEY` must remain stable across process restarts. If either key is changed while encrypted wallet secrets still exist, those secrets become unrecoverable.
+- For local secret storage, generate the keys once and keep them in a secure secret store or deployment environment.
+- To rotate keys safely, decrypt existing secrets with the current key and re-encrypt them with the new key before switching the environment to use the new value.
+- In production, using `WALLET_SECRET_PROVIDER=aws-kms` is the recommended approach because AWS KMS can manage key lifecycle without direct key material rotation in the app.
 
 Generate a platform keypair:
 ```bash

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -46,6 +46,14 @@ USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
 # Generate a new keypair: https://laboratory.stellar.org/#account-creator
 PLATFORM_SECRET_KEY=replace-with-platform-stellar-secret
 
+# Key used by backend wallet encryption and recovery
+# Generate a stable 32-byte secret: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+WALLET_ENCRYPTION_KEY=replace-with-a-32-byte-base64-key
+
+# Local key-encryption key for stored wallet secrets (32 bytes base64)
+# Generate a stable 32-byte secret: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+WALLET_SECRET_LOCAL_KEK=replace-with-a-32-byte-base64-key
+
 # The user ID (UUID from the users table) allowed to approve withdrawals
 # Leave unset in development — all authenticated users can approve (dev mode only!)
 # PLATFORM_APPROVER_USER_ID=

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -1,4 +1,5 @@
 const { validateWalletSecretConfig } = require('../services/walletSecrets');
+const { validateWalletEncryptionKey } = require('../services/walletService');
 const { validateGeoipConfig } = require('../services/geoipService');
 
 const REQUIRED = [
@@ -8,6 +9,7 @@ const REQUIRED = [
   'PLATFORM_SECRET_KEY',
   'STELLAR_NETWORK',
   'STELLAR_HORIZON_URL',
+  'WALLET_ENCRYPTION_KEY',
 ];
 const STORAGE_VARS = ['STORAGE_BUCKET', 'STORAGE_ENDPOINT'];
 
@@ -80,6 +82,13 @@ function validateEnv() {
 
   try {
     validateWalletSecretConfig();
+  } catch (err) {
+    process.stderr.write(`\n[crowdpay] Cannot start: ${err.message}\n\n`);
+    process.exit(1);
+  }
+
+  try {
+    validateWalletEncryptionKey();
   } catch (err) {
     process.stderr.write(`\n[crowdpay] Cannot start: ${err.message}\n\n`);
     process.exit(1);

--- a/backend/src/services/walletService.js
+++ b/backend/src/services/walletService.js
@@ -1,11 +1,43 @@
 const crypto = require('crypto');
 
 const ALGORITHM = 'aes-256-gcm';
-const KEY = Buffer.from(process.env.WALLET_ENCRYPTION_KEY || crypto.randomBytes(32).toString('hex').slice(0, 64), 'hex');
+let KEY_CACHE;
+
+function decodeKeyMaterial(value) {
+  const input = String(value || '').trim();
+  if (!input) {
+    throw new Error('WALLET_ENCRYPTION_KEY must be set for wallet encryption');
+  }
+
+  if (/^[0-9a-fA-F]{64}$/.test(input)) {
+    return Buffer.from(input, 'hex');
+  }
+
+  if (/^[A-Za-z0-9+/]+={0,2}$/.test(input)) {
+    return Buffer.from(input, 'base64');
+  }
+
+  throw new Error('WALLET_ENCRYPTION_KEY must be base64 or hex encoded');
+}
+
+function getKey() {
+  if (KEY_CACHE) return KEY_CACHE;
+  const key = decodeKeyMaterial(process.env.WALLET_ENCRYPTION_KEY);
+  if (key.length !== 32) {
+    throw new Error('WALLET_ENCRYPTION_KEY must decode to exactly 32 bytes');
+  }
+  KEY_CACHE = key;
+  return key;
+}
+
+function validateWalletEncryptionKey() {
+  getKey();
+}
 
 function encryptSecret(secret) {
+  const key = getKey();
   const iv = crypto.randomBytes(16);
-  const cipher = crypto.createCipheriv(ALGORITHM, KEY, iv);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
   const encrypted = Buffer.concat([cipher.update(secret, 'utf8'), cipher.final()]);
   const authTag = cipher.getAuthTag();
   return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`;
@@ -13,9 +45,9 @@ function encryptSecret(secret) {
 
 function decryptSecret(encryptedData) {
   const [ivHex, authTagHex, encryptedHex] = encryptedData.split(':');
-  const decipher = crypto.createDecipheriv(ALGORITHM, KEY, Buffer.from(ivHex, 'hex'));
+  const decipher = crypto.createDecipheriv(ALGORITHM, getKey(), Buffer.from(ivHex, 'hex'));
   decipher.setAuthTag(Buffer.from(authTagHex, 'hex'));
   return decipher.update(Buffer.from(encryptedHex, 'hex'), null, 'utf8') + decipher.final('utf8');
 }
 
-module.exports = { encryptSecret, decryptSecret };
+module.exports = { encryptSecret, decryptSecret, validateWalletEncryptionKey };

--- a/backend/src/services/walletService.test.js
+++ b/backend/src/services/walletService.test.js
@@ -66,3 +66,25 @@ test('decryptSecret throws on malformed input missing the expected iv:authTag:ci
     delete process.env.WALLET_ENCRYPTION_KEY;
   });
 });
+
+test('validateWalletEncryptionKey throws when WALLET_ENCRYPTION_KEY is missing or invalid', (t) => {
+  delete process.env.WALLET_ENCRYPTION_KEY;
+  delete require.cache[require.resolve(MODULE_PATH)];
+  const walletService = require(MODULE_PATH);
+
+  assert.throws(() => walletService.validateWalletEncryptionKey(), {
+    message: 'WALLET_ENCRYPTION_KEY must be set for wallet encryption',
+  });
+
+  process.env.WALLET_ENCRYPTION_KEY = 'not-a-valid-key';
+  delete require.cache[require.resolve(MODULE_PATH)];
+  const walletServiceInvalid = require(MODULE_PATH);
+
+  assert.throws(() => walletServiceInvalid.validateWalletEncryptionKey(), {
+    message: 'WALLET_ENCRYPTION_KEY must be base64 or hex encoded',
+  });
+
+  t.after(() => {
+    delete process.env.WALLET_ENCRYPTION_KEY;
+  });
+});


### PR DESCRIPTION
…t encryption fallback

## Description

Fixes #397 — Reward tier `claimed_count` is now atomically decremented when a tier-backed contribution is made, preventing overselling of limited-edition reward tiers.

**The Problem**
The `claimed_count` (and hence computed `remaining`) on `reward_tiers` was only incremented asynchronously in the ledger monitor when Horizon detected the on-chain payment. The contribution route itself never decremented the count, so:
- Sold-out tiers continued showing availability in the UI
- Multiple backers could claim the last slot of a limited tier
- Creators could end up owing more physical rewards than they could fulfil

**The Fix**
A new `reserveTierSlot()` function in `rewardTierService.js` atomically increments `claimed_count` **inside the contribution route's database transaction** — before the Stellar transaction is even submitted. If the tier is already at capacity, the contribution is rejected with **HTTP 409 Sold out** and the entire transaction is rolled back.

## Changes

### `backend/src/services/rewardTierService.js`
- **`reserveTierSlot(client, { tierId, campaignId })`** — Atomically increments `claimed_count` via `UPDATE ... WHERE (tier_limit IS NULL OR claimed_count < tier_limit) RETURNING`. Returns the tier row on success, or `null` if sold out.
- **`assignTierToContribution(client, { ..., tierId })`** — Extended to accept an optional `tierId`. When provided, only creates the `contribution_rewards` join row (idempotent via `ON CONFLICT DO NOTHING`) without double-incrementing `claimed_count`, since the route already reserved the slot.

### `backend/src/routes/contributions.js`
- Custodial `POST /` route now extracts optional `tier_id` from `req.body`
- Validates the tier belongs to the campaign (pre-flight `SELECT`)
- Calls `reserveTierSlot()` inside the existing transaction, **before** submitting to Stellar
- Returns **HTTP 409** with `{ error: "This reward tier is sold out", tier_id }` if the tier is at capacity
- Passes `tierId` through to `submitCustodialContribution` so it flows into metadata

### `backend/src/services/contributionService.js`
- Accepts new `tierId` parameter and includes it in `stellar_transactions.metadata` as `tier_id`

### `backend/src/services/ledgerMonitor.js`
- Reads `tier_id` from `stellar_transactions.metadata` and passes it to `assignTierToContribution`, ensuring pre-reserved tiers are honoured without double-counting `claimed_count`

### `backend/src/middleware/validation.js`
- Added optional `tier_id` validation (UUID format) to `contributionValidation`

## How It Works End-to-End

```
User contributes (with tier_id)
  │
  ├─ 1. Route validates tier exists & belongs to campaign (pre-flight)
  │
  ├─ 2. BEGIN transaction
  │     ├─ Advisory lock (campaign + user)
  │     ├─ Check per-user cap
  │     ├─ reserveTierSlot() → UPDATE reward_tiers SET claimed_count++ 
  │     │                        WHERE id = tier_id AND claimed_count < tier_limit
  │     │                        RETURNING id
  │     │     └─ If 0 rows → ROLLBACK, respond 409 Sold out 🚫
  │     ├─ Submit Stellar transaction
  │     ├─ Insert stellar_transactions record (metadata.tier_id set)
  │     └─ COMMIT ✅
  │
  └─ 3. (async) Ledger monitor indexes on-chain payment
        ├─ Insert contributions row
        ├─ assignTierToContribution(tierId) → creates contribution_rewards
        │   (idempotent via ON CONFLICT DO NOTHING, no double-increment)
        └─ Update campaign raised_amount
```

## Acceptance Criteria

| Criteria | Status |
|----------|--------|
| Tier `claimed_count` decrements atomically with each contribution | ✅ `UPDATE ... SET claimed_count = claimed_count + 1` inside route transaction |
| Contribution rejected with 409 when tier is sold out | ✅ `reserveTierSlot()` returns null → `res.status(409)` |
| Concurrent contributions for the last slot handled correctly (only one succeeds) | ✅ Atomic `UPDATE ... WHERE claimed_count < tier_limit` with PostgreSQL row-level locking inside transaction |
| Tier sold-out state reflected in UI immediately | ✅ `claimed_count` is updated atomically in the route, so the next `listTiersWithAvailability()` query reflects the correct `remaining` |

## Testing

- [ ] Unit test `reserveTierSlot()` — success path
- [ ] Unit test `reserveTierSlot()` — sold-out path returns null
- [ ] Unit test `assignTierToContribution()` with explicit `tierId` — no double-increment
- [ ] Integration: contribute with valid `tier_id`, verify `claimed_count` incremented
- [ ] Integration: contribute with sold-out `tier_id`, verify 409 response
- [ ] Integration: concurrent contributions for last slot, verify exactly one 202 and one 409
