### PR TITLE
feat: return 422 for invalid withdrawal destination_key (closes #391)

### DIFF
--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -399,12 +399,12 @@ function validateRequest(req, res, next) {
     message: e.msg,
   }));
 
-  const isContributionsPath = Boolean(
-    (req.originalUrl && req.originalUrl.includes('/contributions')) ||
-    (req.baseUrl && req.baseUrl.includes('/contributions')) ||
-    (req.path && req.path.includes('/contributions'))
+  const usesUnprocessableEntity = Boolean(
+    (req.originalUrl && (req.originalUrl.includes('/contributions') || req.originalUrl.includes('/withdrawals'))) ||
+    (req.baseUrl && (req.baseUrl.includes('/contributions') || req.baseUrl.includes('/withdrawals'))) ||
+    (req.path && (req.path.includes('/contributions') || req.path.includes('/withdrawals')))
   );
-  const statusCode = isContributionsPath ? 422 : 400;
+  const statusCode = usesUnprocessableEntity ? 422 : 400;
 
   return res.status(statusCode).json({
     error: {

--- a/backend/src/routes/withdrawals.test.js
+++ b/backend/src/routes/withdrawals.test.js
@@ -140,6 +140,26 @@ test('POST /api/withdrawals/request creates pending request and logs event', asy
   assert.ok(calls.some((c) => c.includes('INSERT INTO stellar_transactions')));
 });
 
+test('POST /api/withdrawals/request rejects an invalid Stellar public key with 422', async () => {
+  const { app, cleanup } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns WHERE id')) {
+        return { rows: [campaignRow()] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/request')
+    .set('Authorization', 'Bearer token')
+    .send({ campaign_id: '11111111-1111-1111-1111-111111111111', destination_key: 'not-a-valid-key', amount: '10.0000000' });
+
+  cleanup();
+  assert.equal(response.status, 422);
+  assert.match(response.body.error.message, /destination_key must be a valid Stellar public key/);
+});
+
 test('POST /api/withdrawals/request returns 400 for failed campaigns', async () => {
   const { app, cleanup } = buildApp({
     role: 'admin',


### PR DESCRIPTION
## What I built

`withdrawals.js` already validated `destination_key` with `Keypair.fromPublicKey` via the shared `withdrawalValidation` middleware, but the shared `validateRequest` handler only mapped validation failures to `422` for paths containing `/contributions` — everything else, including `/withdrawals`, fell through to `400`. That meant an invalid Stellar key was rejected, just with the wrong status code, failing the issue's acceptance criteria.

Fixed `validateRequest` in `backend/src/middleware/validation.js` to also return `422` for `/withdrawals` paths, and added a regression test asserting an invalid `destination_key` on `POST /api/withdrawals/request` returns `422` with a clear error message.

## Decisions worth noting

No new validation logic was added — the `Keypair.fromPublicKey` check already existed and matches the pattern used in `contributions.js`. This PR only corrects the status code mapping so the existing validation actually satisfies the issue's acceptance criteria.

## How to test manually

1. `POST /api/withdrawals/request` with a valid `campaign_id`/`amount` and `destination_key: "not-a-valid-key"` → expect `422` with `error.message` containing "destination_key must be a valid Stellar public key"
2. Same request with a valid G-address `destination_key` → expect the normal `201` pending-request flow, unaffected

## Checklist

- [x] Acceptance criteria satisfied (422 on invalid key, clear message, valid keys unaffected)
- [ ] `npm test` — could not run in this environment (no `node_modules` installed); please run `cd backend && npm test` in review
- [x] No files added beyond what the issue required
- [x] PR is against `main`, branch is rebased and clean

Closes #391