### PR TITLE
Fix #393: Add EventSource reconnection logic

### DIFF
--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -616,43 +616,66 @@ export default function Campaign() {
   useEffect(() => {
     if (!window.EventSource) return;
 
-    const es = new EventSource(`/api/campaigns/${id}/stream`);
+    let es = null;
+    let retryDelay = 1000;
+    let retryTimeout = null;
+    let isUnmounted = false;
 
-    es.onopen = () => setIsLive(true);
+    function connect() {
+      if (isUnmounted) return;
 
-    es.onmessage = (e) => {
-      let msg;
-      try {
-        msg = JSON.parse(e.data);
-      } catch {
-        return;
-      }
+      es = new EventSource(`/api/campaigns/${id}/stream`);
 
-      if (msg.type === 'contribution') {
-        setCampaign((prev) => (prev ? { ...prev, raised_amount: msg.raised_amount } : prev));
-        setContributions((prev) => {
-          const current = prev || [];
-          const exists = current.some((c) => c.tx_hash === msg.contribution.tx_hash);
-          if (exists) return current;
+      es.onopen = () => {
+        setIsLive(true);
+        retryDelay = 1000;
+      };
 
-          setTotalContributions((t) => t + 1);
+      es.onmessage = (e) => {
+        let msg;
+        try {
+          msg = JSON.parse(e.data);
+        } catch {
+          return;
+        }
 
-          const updated = [msg.contribution, ...current];
-          if (!showAll && updated.length > 10) {
-            return updated.slice(0, 10);
-          }
-          return updated;
-        });
-      }
-    };
+        if (msg.type === 'contribution') {
+          setCampaign((prev) => (prev ? { ...prev, raised_amount: msg.raised_amount } : prev));
+          setContributions((prev) => {
+            const current = prev || [];
+            const exists = current.some((c) => c.tx_hash === msg.contribution.tx_hash);
+            if (exists) return current;
 
-    es.onerror = () => {
-      setIsLive(false);
-      es.close();
-    };
+            setTotalContributions((t) => t + 1);
+
+            const updated = [msg.contribution, ...current];
+            if (!showAll && updated.length > 10) {
+              return updated.slice(0, 10);
+            }
+            return updated;
+          });
+        }
+      };
+
+      es.onerror = () => {
+        setIsLive(false);
+        es.close();
+
+        if (!isUnmounted) {
+          retryTimeout = setTimeout(() => {
+            connect();
+            retryDelay = Math.min(retryDelay * 2, 30000);
+          }, retryDelay);
+        }
+      };
+    }
+
+    connect();
 
     return () => {
-      es.close();
+      isUnmounted = true;
+      if (es) es.close();
+      if (retryTimeout) clearTimeout(retryTimeout);
       setIsLive(false);
     };
   }, [id, showAll]);


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Description</h2><p>Fixes #393 by adding resilient reconnection logic to the campaign live funding stream. Previously, the <code inline="">EventSource</code> connection was established once and never recovered if the network dropped or the server restarted, leaving the funding progress stale while the UI continued to indicate that the live stream was active. This PR introduces exponential-backoff reconnection, immediately updates the live status on disconnect, and ensures the connection is properly cleaned up when the component unmounts.</p><h2>Changes</h2><h3><code inline="">frontend/src/pages/Campaign.jsx</code></h3><ul><li><p>Refactored the EventSource lifecycle into a reusable <code inline="">connect()</code> function.</p></li><li><p>Added automatic reconnection when the SSE connection is interrupted.</p></li><li><p>Implemented exponential backoff for reconnect attempts:</p><ul><li><p>Initial retry delay: <strong>1 second</strong></p></li><li><p>Delay doubles after each failed attempt</p></li><li><p>Maximum retry delay capped at <strong>30 seconds</strong></p></li></ul></li><li><p>Reset the retry delay after a successful reconnection.</p></li><li><p>Updated the <code inline="">isLive</code> indicator:</p><ul><li><p>Set to <code inline="">true</code> when the connection opens successfully.</p></li><li><p>Set to <code inline="">false</code> immediately when the connection is lost.</p></li></ul></li><li><p>Ensured the active <code inline="">EventSource</code> instance and any pending reconnect timers are cleaned up when the component unmounts to prevent memory leaks and duplicate connections.</p></li></ul><h2>How It Works</h2><pre><code class="language-text">Component mounts
    │
    ├─ connect()
    │     ├─ Create EventSource
    │     ├─ onopen
    │     │      ├─ setIsLive(true)
    │     │      └─ retryDelay = 1s
    │     │
    │     ├─ onmessage
    │     │      └─ Update campaign funding state
    │     │
    │     └─ onerror
    │            ├─ setIsLive(false)
    │            ├─ Close EventSource
    │            └─ Schedule reconnect
    │                    delay = min(delay × 2, 30s)
    │
    └─ Component unmount
           ├─ Cancel pending reconnect
           └─ Close EventSource
</code></pre><h2>Acceptance Criteria</h2>
Criteria | Status
-- | --
Live updates reconnect automatically after network loss | ✅ Automatic exponential-backoff reconnection implemented
isLive indicator turns off immediately on disconnect | ✅ Updated in the onerror handler before reconnecting
Retry backoff caps at 30 seconds | ✅ Maximum retry delay limited to 30 seconds
Connection cleaned up on component unmount | ✅ EventSource and reconnect timer are both cleaned up

<h2>Testing</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" disabled=""> Unit test reconnect scheduling after connection failure.</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> Unit test retry delay resets after a successful reconnect.</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> Integration: disconnect network and verify automatic reconnection.</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> Integration: verify <code inline="">isLive</code> changes to <code inline="">false</code> immediately after disconnect.</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> Integration: verify retry delay increases exponentially and never exceeds 30 seconds.</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> Integration: verify funding updates resume after reconnection.</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> Integration: verify no duplicate EventSource connections are created after repeated reconnects.</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> Integration: verify EventSource and reconnect timer are cleaned up when navigating away from the page.</p></li></ul></body></html><!--EndFragment-->
</body>
</html>