### PR TITLE
feat: lazy-load non-fallback i18n locale bundles (closes #579)

### DIFF
--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -2,15 +2,35 @@ import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 import en from './locales/en.json';
-import fr from './locales/fr.json';
+
+// 'en' is bundled eagerly since it's the fallback language and near-guaranteed
+// to be needed. Other locales are code-split and fetched only when selected.
+const lazyLocaleLoaders = {
+  fr: () => import('./locales/fr.json'),
+};
+
+const lazyLocaleBackend = {
+  type: 'backend',
+  init() {},
+  read(language, _namespace, callback) {
+    const loadLocale = lazyLocaleLoaders[language];
+    if (!loadLocale) {
+      callback(new Error(`Unsupported language: ${language}`), false);
+      return;
+    }
+    loadLocale()
+      .then((module) => callback(null, module.default))
+      .catch((err) => callback(err, false));
+  },
+};
 
 i18n
+  .use(lazyLocaleBackend)
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     resources: {
       en: { translation: en },
-      fr: { translation: fr },
     },
     fallbackLng: 'en',
     supportedLngs: ['en', 'fr'],
@@ -25,6 +45,9 @@ i18n
     },
     returnEmptyString: false,
     returnNull: false,
+    react: {
+      useSuspense: false,
+    },
   });
 
 export default i18n;

--- a/frontend/src/i18n.test.js
+++ b/frontend/src/i18n.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.unmock('react-i18next');
+
+async function loadI18n() {
+  const i18n = (await import('./i18n')).default;
+  if (!i18n.isInitialized) {
+    await new Promise((resolve) => i18n.on('initialized', resolve));
+  }
+  return i18n;
+}
+
+describe('i18n lazy locale loading', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    window.localStorage.clear();
+  });
+
+  it('does not load the fr bundle when the resolved language is en', async () => {
+    window.localStorage.setItem('i18nextLng', 'en');
+    const i18n = await loadI18n();
+
+    expect(i18n.resolvedLanguage).toBe('en');
+    expect(i18n.hasResourceBundle('fr', 'translation')).toBe(false);
+    expect(i18n.t('common.cancel')).toBe('Cancel');
+  });
+
+  it('lazily loads the fr bundle when switching languages', async () => {
+    window.localStorage.setItem('i18nextLng', 'en');
+    const i18n = await loadI18n();
+
+    expect(i18n.hasResourceBundle('fr', 'translation')).toBe(false);
+
+    await i18n.changeLanguage('fr');
+
+    expect(i18n.hasResourceBundle('fr', 'translation')).toBe(true);
+    expect(i18n.t('common.cancel')).toBe('Annuler');
+  });
+
+  it('falls back gracefully for an unsupported language', async () => {
+    window.localStorage.setItem('i18nextLng', 'en');
+    const i18n = await loadI18n();
+
+    await i18n.changeLanguage('de');
+
+    expect(i18n.t('common.cancel')).toBe('Cancel');
+  });
+});


### PR DESCRIPTION
## What I built

`src/i18n.js` statically imported both `en.json` and `fr.json`, so every user's initial bundle included both locale files regardless of which language they actually needed.

`en` stays as an eagerly bundled resource since it's the `fallbackLng` and effectively always needed. `fr` is now loaded via a small custom i18next backend plugin that dynamically `import()`s the locale file only when that language is actually requested (either as the detected/saved language, or via a runtime `changeLanguage` call). Vite code-splits the dynamic `import()` into its own chunk automatically, so `fr.json` is no longer part of the initial bundle for users who don't need it.

## Decisions worth noting

- Used i18next's built-in backend plugin interface (`{ type: 'backend', read(lng, ns, cb) }`) instead of pulling in `i18next-http-backend`/`i18next-resources-to-backend` — no new dependency needed since the interface is a few lines.
- Set `react: { useSuspense: false }` so components rendered outside the route-level `<Suspense>` boundary (`Navbar`, `AnnouncementBanner`, etc.) don't break while a locale is loading. With this setting, `useTranslation` keeps rendering the previously-loaded language's text until the new bundle resolves and `i18n` fires `languageChanged`, so switching languages doesn't flash untranslated keys.
- Added `frontend/src/i18n.test.js` covering: initial load doesn't fetch the `fr` bundle when resolved language is `en`, switching to `fr` lazily loads and applies it, and switching to an unsupported language falls back to `en` without breaking.

## How to test manually

1. Run the app with browser/localStorage language left as English → open devtools Network tab → confirm no request/chunk for `fr.json` fires until you switch languages
2. Switch the app language to French → confirm the `fr` locale chunk loads and the UI updates to French text
3. `cd frontend && npm test -- i18n.test.js`

## Checklist

- [x] Dynamic `import()` used based on detected/saved language
- [ ] `npm test` — could not run in this environment (no `node_modules` installed); please run `cd frontend && npm test` in review
- [x] No files added beyond what the issue required (plus one test file)
- [x] PR is against `main`, branch is rebased and clean

Closes #579