### PR TITLE
Fix/issue 488 560 574 576 error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,21 @@ on:
     branches: [main]
 
 jobs:
+  secret-hygiene:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Fail if any .env file is tracked by git
+        run: node .husky/check-env.js --tracked
+
   backend-checks:
     runs-on: ubuntu-latest
     services:

--- a/.husky/check-env.js
+++ b/.husky/check-env.js
@@ -1,15 +1,49 @@
 const { execSync } = require('child_process');
 
+// .env, .env.local, backend/.env.production — but never the committed templates.
+const ENV_FILE_PATTERN = /(^|\/)\.env(\.|$)/;
+const TEMPLATE_PATTERN = /\.(example|template|sample)$/;
+
+function isSecretEnvFile(file) {
+  return ENV_FILE_PATTERN.test(file) && !TEMPLATE_PATTERN.test(file);
+}
+
+function listFiles(command) {
+  return execSync(command, { encoding: 'utf8' })
+    .split(/\r?\n/)
+    .map((f) => f.trim())
+    .filter(Boolean);
+}
+
+// --tracked is for CI: a pre-commit hook can be skipped with --no-verify or by a
+// contributor who never ran `npm install`, so the same rule is enforced on the
+// files already in the index.
+const trackedMode = process.argv.includes('--tracked');
+
 try {
-  const output = execSync('git diff --cached --name-only', { encoding: 'utf8' });
-  const files = output.split(/\r?\n/).map(f => f.trim()).filter(Boolean);
-  const envFiles = files.filter(f => /(^|\/)\.env(\.|$)/.test(f));
+  const files = listFiles(
+    trackedMode ? 'git ls-files' : 'git diff --cached --name-only'
+  );
+  const envFiles = files.filter(isSecretEnvFile);
 
   if (envFiles.length > 0) {
-    console.error('\n  ✖  COMMIT BLOCKED — detected staged .env file(s):\n');
-    envFiles.forEach(f => console.error('      ' + f));
-    console.error('\n  .env files must never be committed. Check your .gitignore.\n  If you need a template, name it .env.example or .env.template.\n');
+    if (trackedMode) {
+      console.error('\n  ✖  CHECK FAILED — .env file(s) are tracked by git:\n');
+    } else {
+      console.error('\n  ✖  COMMIT BLOCKED — detected staged .env file(s):\n');
+    }
+    envFiles.forEach((f) => console.error('      ' + f));
+    console.error(
+      '\n  .env files must never be committed — they hold live credentials.' +
+        '\n  Remove them from git with `git rm --cached <file>`, rotate any secret' +
+        '\n  they exposed, and keep real values in your platform secret manager.' +
+        '\n  If you need a template, name it .env.example or .env.template.\n'
+    );
     process.exit(1);
+  }
+
+  if (trackedMode) {
+    console.log('[check-env] No .env files are tracked by git.');
   }
 } catch (err) {
   if (err.status && err.status !== 0) {

--- a/backend/db/migrate.js
+++ b/backend/db/migrate.js
@@ -51,7 +51,9 @@ async function migrate() {
 
     console.log(`[migrate] Done. ${count} migration(s) applied.`);
   } catch (err) {
-    await client.query('ROLLBACK').catch(() => {});
+    await client.query('ROLLBACK').catch((rollbackErr) => {
+      console.error('[migrate] ROLLBACK failed:', rollbackErr.message);
+    });
     console.error('[migrate] Failed:', err.message);
     process.exit(1);
   } finally {

--- a/backend/src/routes/withdrawals.js
+++ b/backend/src/routes/withdrawals.js
@@ -558,7 +558,12 @@ const platformApproveHandler = async (req, res) => {
           title: 'Withdrawal approved',
           body: `Your withdrawal of ${updatedWithdrawalRow.amount} was approved and submitted on-chain.`,
           link: `/campaigns/${updatedWithdrawalRow.campaign_id}`,
-        }).catch(() => {});
+        }).catch((err) =>
+          logger.warn('Withdrawal approved notification failed', {
+            withdrawal_id: req.params.id,
+            error: err.message,
+          })
+        );
 
         notifyContributorFundRelease({
           campaignId: updatedWithdrawalRow.campaign_id,
@@ -752,7 +757,12 @@ router.post('/:id/reject', requireAuth, requirePlatformApprover, async (req, res
         title: 'Withdrawal rejected',
         body: `Your withdrawal request was rejected. Reason: ${reason}`,
         link: `/campaigns/${requestRow.campaign_id}`,
-      }).catch(() => {});
+      }).catch((err) =>
+        logger.warn('Withdrawal rejected notification failed', {
+          withdrawal_id: req.params.id,
+          error: err.message,
+        })
+      );
       emitWithdrawalUpdated(cRows[0].creator_id, updated[0]);
     }
 

--- a/backend/src/services/kycProvider.js
+++ b/backend/src/services/kycProvider.js
@@ -1,5 +1,6 @@
 const crypto = require('crypto');
 const ff = require('./featureFlags');
+const logger = require('../config/logger');
 
 function isKycRequiredForCampaigns() {
   return ff.isEnabled('kyc-required-for-campaigns');
@@ -47,7 +48,13 @@ async function createPersonaInquiry({ user }) {
     }),
   });
 
-  const body = await response.json().catch(() => ({}));
+  const body = await response.json().catch((err) => {
+    logger.warn('Could not parse Persona inquiry response body', {
+      status: response.status,
+      error: err.message,
+    });
+    return {};
+  });
   if (!response.ok) {
     const message = body?.errors?.[0]?.detail || body?.errors?.[0]?.title || 'Could not create KYC session';
     throw new Error(message);

--- a/backend/src/services/ledgerMonitor.js
+++ b/backend/src/services/ledgerMonitor.js
@@ -630,7 +630,11 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
               });
             }
           })
-          .catch(() => {});
+          .catch((err) =>
+            logger.warn("Ledger stream health check failed", {
+              error: err.message,
+            }),
+          );
       },
       5 * 60 * 1000,
     );

--- a/frontend/src/components/ContributeModal.jsx
+++ b/frontend/src/components/ContributeModal.jsx
@@ -36,6 +36,32 @@ function friendlyContributeError(err) {
   return err.message || 'Payment could not be submitted. Try again.';
 }
 
+const FREIGHTER_TIMEOUT_MS = 60000;
+const SIGNING_CANCELLED = 'SIGNING_CANCELLED';
+
+// Freighter never rejects when its popup is dismissed or hangs, so every call
+// that opens the extension is raced against a timeout and a manual cancel.
+function withFreighterTimeout(promise, { signal, timeoutMessage }) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+      fn(value);
+    };
+    const onAbort = () => finish(reject, new Error(SIGNING_CANCELLED));
+    const timer = setTimeout(() => finish(reject, new Error(timeoutMessage)), FREIGHTER_TIMEOUT_MS);
+
+    signal.addEventListener('abort', onAbort);
+    promise.then(
+      (value) => finish(resolve, value),
+      (err) => finish(reject, err)
+    );
+  });
+}
+
 function friendlyFreighterError(err, fallback) {
   if (!err) return fallback;
   if (typeof err === 'string') return err;
@@ -107,6 +133,8 @@ export default function ContributeModal({
   const anchorPopupRef = useRef(null);
   const submitLockRef = useRef(false);
   const activeSubmissionKeyRef = useRef(null);
+  const signingAbortRef = useRef(null);
+  const [signingInFlight, setSigningInFlight] = useState(false);
 
   const modalRef = useRef(null);
 
@@ -139,7 +167,12 @@ export default function ContributeModal({
     String(import.meta.env.VITE_KYC_REQUIRED_FOR_CAMPAIGNS ?? 'true').toLowerCase() !== 'false';
   const needsKyc = kycRequired && user?.kyc_status !== 'verified';
 
+  const handleCancelSigning = () => {
+    signingAbortRef.current?.abort();
+  };
+
   const handleClose = () => {
+    signingAbortRef.current?.abort();
     if (anchorPopupRef.current && !anchorPopupRef.current.closed) {
       anchorPopupRef.current.close();
     }
@@ -218,6 +251,8 @@ export default function ContributeModal({
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose]);
+
+  useEffect(() => () => signingAbortRef.current?.abort(), []);
 
   useEffect(() => {
     let active = true;
@@ -356,8 +391,24 @@ export default function ContributeModal({
   }
 
   async function submitWithFreighter() {
+    const abortController = new AbortController();
+    signingAbortRef.current = abortController;
+    setSigningInFlight(true);
+    try {
+      return await runFreighterFlow(abortController.signal);
+    } finally {
+      setSigningInFlight(false);
+      signingAbortRef.current = null;
+    }
+  }
+
+  async function runFreighterFlow(signal) {
     setLoadingLabel('Connecting to Freighter…');
-    const access = await requestAccess();
+    const access = await withFreighterTimeout(requestAccess(), {
+      signal,
+      timeoutMessage:
+        'Freighter did not respond within 60 seconds. Open the extension and try again.',
+    });
     if (access?.error) {
       throw new Error(friendlyFreighterError(access.error, 'Could not connect to Freighter.'));
     }
@@ -380,7 +431,10 @@ export default function ContributeModal({
     );
 
     setLoadingLabel('Checking Freighter network…');
-    const network = await getNetwork();
+    const network = await withFreighterTimeout(getNetwork(), {
+      signal,
+      timeoutMessage: 'Freighter did not report its network within 60 seconds. Try again.',
+    });
     if (network?.error) {
       throw new Error(friendlyFreighterError(network.error, 'Could not read Freighter network.'));
     }
@@ -392,10 +446,17 @@ export default function ContributeModal({
     }
 
     setLoadingLabel('Waiting for signature…');
-    const signed = await signTransaction(prepared.unsigned_xdr, {
-      networkPassphrase: prepared.network_passphrase,
-      address: signerAddress,
-    });
+    const signed = await withFreighterTimeout(
+      signTransaction(prepared.unsigned_xdr, {
+        networkPassphrase: prepared.network_passphrase,
+        address: signerAddress,
+      }),
+      {
+        signal,
+        timeoutMessage:
+          'Freighter did not return a signature within 60 seconds. Approve the request in the extension, or cancel and try again.',
+      }
+    );
     if (signed?.error) {
       throw new Error(
         friendlyFreighterError(signed.error, 'Freighter could not sign this transaction.')
@@ -539,11 +600,15 @@ export default function ContributeModal({
       if (paymentMethod === 'anchor' && anchorPopupRef.current && !anchorPopupRef.current.closed) {
         anchorPopupRef.current.close();
       }
-      setError(
-        paymentMethod === 'freighter'
-          ? friendlyFreighterError(err, 'Freighter payment could not be submitted. Try again.')
-          : friendlyContributeError(err)
-      );
+      if (err?.message === SIGNING_CANCELLED) {
+        setError('Signing cancelled. Nothing was sent — you can start the payment again.');
+      } else {
+        setError(
+          paymentMethod === 'freighter'
+            ? friendlyFreighterError(err, 'Freighter payment could not be submitted. Try again.')
+            : friendlyContributeError(err)
+        );
+      }
     } finally {
       submitLockRef.current = false;
       activeSubmissionKeyRef.current = null;
@@ -923,9 +988,15 @@ export default function ContributeModal({
               )}
 
               <div style={styles.actions}>
-                <button type="button" className="btn-secondary" onClick={handleClose}>
-                  Cancel
-                </button>
+                {signingInFlight ? (
+                  <button type="button" className="btn-secondary" onClick={handleCancelSigning}>
+                    Cancel signing
+                  </button>
+                ) : (
+                  <button type="button" className="btn-secondary" onClick={handleClose}>
+                    Cancel
+                  </button>
+                )}
                 <button
                   type="submit"
                   className="btn-primary"

--- a/frontend/src/components/ContributeModal.test.jsx
+++ b/frontend/src/components/ContributeModal.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ContributeModal from './ContributeModal';
@@ -33,6 +33,8 @@ vi.mock('../context/AuthContext', () => ({
 
 const mockContribute = vi.fn();
 const mockQuote = vi.fn();
+const mockPrepareContribution = vi.fn();
+const mockSubmitSignedContribution = vi.fn();
 const mockOnClose = vi.fn();
 const mockOnSuccess = vi.fn();
 
@@ -46,6 +48,8 @@ vi.mock('../services/api', () => ({
     getAnchorInfo: vi.fn().mockResolvedValue({ anchors: [] }),
     quoteContribution: (...args) => mockQuote(...args),
     contribute: (...args) => mockContribute(...args),
+    prepareContribution: (...args) => mockPrepareContribution(...args),
+    submitSignedContribution: (...args) => mockSubmitSignedContribution(...args),
   },
 }));
 
@@ -62,6 +66,8 @@ describe('ContributeModal', () => {
     randomUUID.mockClear();
     mockContribute.mockReset();
     mockQuote.mockReset();
+    mockPrepareContribution.mockReset();
+    mockSubmitSignedContribution.mockReset();
     mockOnClose.mockReset();
     mockOnSuccess.mockReset();
     mockQuote.mockResolvedValue({
@@ -211,6 +217,80 @@ describe('ContributeModal', () => {
     renderModal();
     await user.click(screen.getByRole('button', { name: /cancel/i }));
     expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  describe('Freighter signing timeout and cancellation', () => {
+    const NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    async function startSigning() {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      const freighterApi = await import('@stellar/freighter-api');
+      freighterApi.isConnected.mockResolvedValue({ isConnected: true });
+      freighterApi.requestAccess.mockResolvedValue({ address: 'GSIGNER' });
+      freighterApi.getNetwork.mockResolvedValue({
+        network: 'TESTNET',
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+      // Freighter never settles when its popup is dismissed or hangs.
+      freighterApi.signTransaction.mockReturnValue(new Promise(() => {}));
+      mockPrepareContribution.mockResolvedValue({
+        unsigned_xdr: 'UNSIGNED_XDR',
+        prepare_token: 'prepare-token',
+        network_passphrase: NETWORK_PASSPHRASE,
+        network_name: 'testnet',
+      });
+
+      renderModal();
+      await user.click(screen.getByRole('radio', { name: /my own wallet/i }));
+      await user.clear(screen.getByLabelText(/amount campaign receives/i));
+      await user.type(screen.getByLabelText(/amount campaign receives/i), '15');
+      await user.click(screen.getByRole('button', { name: /review in freighter/i }));
+
+      await waitFor(() => expect(freighterApi.signTransaction).toHaveBeenCalled());
+      return { user };
+    }
+
+    it('shows a Cancel signing button while waiting for the signature', async () => {
+      await startSigning();
+
+      expect(
+        await screen.findByRole('button', { name: /cancel signing/i })
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /^cancel$/i })).not.toBeInTheDocument();
+    });
+
+    it('times out after 60 seconds instead of hanging in the signing state', async () => {
+      await startSigning();
+
+      await vi.advanceTimersByTimeAsync(59000);
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(await screen.findByRole('alert')).toHaveTextContent(
+        /did not return a signature within 60 seconds/i
+      );
+      expect(mockSubmitSignedContribution).not.toHaveBeenCalled();
+      // Submission is unlocked so the contributor can retry.
+      expect(screen.getByRole('button', { name: /review in freighter/i })).toBeEnabled();
+    });
+
+    it('aborts the signing attempt when Cancel signing is clicked', async () => {
+      const { user } = await startSigning();
+
+      await user.click(await screen.findByRole('button', { name: /cancel signing/i }));
+
+      expect(await screen.findByRole('alert')).toHaveTextContent(/signing cancelled/i);
+      expect(mockSubmitSignedContribution).not.toHaveBeenCalled();
+      expect(screen.getByRole('button', { name: /review in freighter/i })).toBeEnabled();
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
   });
 
   describe('Freighter fallback panel', () => {

--- a/frontend/src/components/DepositModal.jsx
+++ b/frontend/src/components/DepositModal.jsx
@@ -1,6 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import { api } from '../services/api';
 
+const POLL_INTERVAL_MS = 4000;
+// Consecutive-failure backoff. A 5th failure gives up instead of polling forever.
+const POLL_BACKOFF_MS = [5000, 10000, 20000, 40000];
+const MAX_POLL_FAILURES = POLL_BACKOFF_MS.length + 1;
+
 export default function DepositModal({ onClose, onSuccess }) {
   const [amount, setAmount] = useState('');
   const [anchorInfo, setAnchorInfo] = useState({ anchors: [] });
@@ -9,6 +14,7 @@ export default function DepositModal({ onClose, onSuccess }) {
   const [loading, setLoading] = useState(false);
   const [loadingLabel, setLoadingLabel] = useState('Submitting…');
   const [error, setError] = useState('');
+  const [pollRetryNotice, setPollRetryNotice] = useState('');
   const [kycRequired, setKycRequired] = useState(false);
   const [phase, setPhase] = useState('form');
   const [balance, setBalance] = useState(null);
@@ -43,11 +49,19 @@ export default function DepositModal({ onClose, onSuccess }) {
   useEffect(() => {
     if (phase !== 'anchor' || !session?.id) return;
     let stopped = false;
+    let timerId;
+    let failures = 0;
+
+    const schedule = (delayMs) => {
+      timerId = window.setTimeout(poll, delayMs);
+    };
 
     const poll = async () => {
       try {
         const next = await api.getAnchorDepositStatus(session.id);
         if (stopped) return;
+        failures = 0;
+        setPollRetryNotice('');
         setSession(next);
         if (next.status === 'completed') {
           setPhase('success');
@@ -67,22 +81,35 @@ export default function DepositModal({ onClose, onSuccess }) {
           setError(customError);
           setPhase('form');
           if (popupRef.current && !popupRef.current.closed) popupRef.current.close();
-        } else {
-          setKycRequired(
-            next.last_anchor_status === 'pending_user_info_update' ||
-              next.last_anchor_status === 'pending_customer_info_update'
-          );
+          return;
         }
+        setKycRequired(
+          next.last_anchor_status === 'pending_user_info_update' ||
+            next.last_anchor_status === 'pending_customer_info_update'
+        );
+        schedule(POLL_INTERVAL_MS);
       } catch (err) {
-        if (!stopped) setError(err.message || 'Could not refresh deposit status.');
+        if (stopped) return;
+        failures += 1;
+        if (failures >= MAX_POLL_FAILURES) {
+          setPollRetryNotice('');
+          setError(
+            `We stopped checking your deposit status after ${MAX_POLL_FAILURES} failed attempts (${err.message || 'network error'}). Your deposit is unaffected — reopen the deposit window or check your balance again shortly.`
+          );
+          return;
+        }
+        const delayMs = POLL_BACKOFF_MS[failures - 1];
+        setPollRetryNotice(
+          `Could not refresh the deposit status (${err.message || 'network error'}). Retrying in ${delayMs / 1000}s — attempt ${failures + 1} of ${MAX_POLL_FAILURES}.`
+        );
+        schedule(delayMs);
       }
     };
 
     poll();
-    const id = window.setInterval(poll, 4000);
     return () => {
       stopped = true;
-      window.clearInterval(id);
+      window.clearTimeout(timerId);
     };
   }, [session?.id, onSuccess, phase]);
 
@@ -127,6 +154,7 @@ export default function DepositModal({ onClose, onSuccess }) {
     setLoading(true);
     setLoadingLabel('Preparing deposit…');
     setError('');
+    setPollRetryNotice('');
     try {
       const popup = window.open('', 'crowdpay-wallet-deposit', 'popup,width=520,height=780');
       popupRef.current = popup;
@@ -272,6 +300,16 @@ export default function DepositModal({ onClose, onSuccess }) {
               <p className="alert alert--warning" style={{ marginBottom: '1rem' }} role="status">
                 <strong>Action Required:</strong> The partner needs additional KYC information.
                 Please complete the form in the deposit window.
+              </p>
+            )}
+            {pollRetryNotice && (
+              <p className="alert alert--warning" style={{ marginBottom: '1rem' }} role="status">
+                {pollRetryNotice}
+              </p>
+            )}
+            {error && (
+              <p className="alert alert--error" style={{ marginBottom: '1rem' }} role="alert">
+                {error}
               </p>
             )}
             {session?.anchor_transaction_id && (

--- a/frontend/src/components/DepositModal.test.jsx
+++ b/frontend/src/components/DepositModal.test.jsx
@@ -172,6 +172,77 @@ describe('DepositModal', () => {
     expect(screen.getByText('Add Funds')).toBeInTheDocument();
   });
 
+  async function enterAnchorPhaseWithFakeTimers() {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    mockStartWalletDeposit.mockResolvedValue({
+      id: 'session-1',
+      interactive_url: 'https://anchor.example/interactive',
+      status: 'pending',
+    });
+
+    const utils = setup();
+
+    const amountInput = await screen.findByLabelText(/Amount/i);
+    await user.type(amountInput, '25');
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    await screen.findByText('Complete your deposit');
+    await waitFor(() => expect(mockGetAnchorDepositStatus).toHaveBeenCalledTimes(1));
+
+    return utils;
+  }
+
+  it('backs off exponentially between failed status polls', async () => {
+    mockGetAnchorDepositStatus.mockRejectedValue(new Error('Network down'));
+
+    await enterAnchorPhaseWithFakeTimers();
+
+    for (const [index, delay] of [5000, 10000, 20000, 40000].entries()) {
+      expect(
+        await screen.findByText(
+          new RegExp(`Retrying in ${delay / 1000}s — attempt ${index + 2} of 5`)
+        )
+      ).toBeInTheDocument();
+      await vi.advanceTimersByTimeAsync(delay);
+      await waitFor(() => expect(mockGetAnchorDepositStatus).toHaveBeenCalledTimes(index + 2));
+    }
+  });
+
+  it('stops polling after the retry limit and surfaces an error', async () => {
+    mockGetAnchorDepositStatus.mockRejectedValue(new Error('Network down'));
+
+    await enterAnchorPhaseWithFakeTimers();
+
+    await vi.advanceTimersByTimeAsync(5000 + 10000 + 20000 + 40000);
+
+    await waitFor(() => expect(mockGetAnchorDepositStatus).toHaveBeenCalledTimes(5));
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /stopped checking your deposit status after 5 failed attempts/i
+    );
+
+    // No further requests once the limit is hit.
+    await vi.advanceTimersByTimeAsync(120000);
+    expect(mockGetAnchorDepositStatus).toHaveBeenCalledTimes(5);
+  });
+
+  it('resets the backoff after a successful poll', async () => {
+    mockGetAnchorDepositStatus
+      .mockRejectedValueOnce(new Error('Network down'))
+      .mockResolvedValue({ id: 'session-1', status: 'pending' });
+
+    await enterAnchorPhaseWithFakeTimers();
+
+    expect(await screen.findByText(/Retrying in 5s/)).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await waitFor(() => expect(mockGetAnchorDepositStatus).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByText(/Retrying in/)).not.toBeInTheDocument());
+
+    // Back to the steady-state interval, not the escalated delay.
+    await vi.advanceTimersByTimeAsync(4000);
+    await waitFor(() => expect(mockGetAnchorDepositStatus).toHaveBeenCalledTimes(3));
+  });
+
   it('calls onClose when the Cancel button is clicked', async () => {
     const user = userEvent.setup();
     const { onClose } = setup();


### PR DESCRIPTION
# PR title

```
fix: error logging, .env CI guard, and modal resilience (closes #488, #560, #574, #576)
```

# PR body

## Description

Four related reliability/security fixes, one commit each.

Closes #488
Closes #560
Closes #574
Closes #576

---

### #488 — Silent `.catch(() => {})` replaced with real logging

All five call sites named in the issue now log instead of discarding the rejection:

| File | What now gets logged |
|---|---|
| `backend/db/migrate.js:54` | `[migrate] ROLLBACK failed: <message>` |
| `backend/src/services/kycProvider.js:50` | `logger.warn('Could not parse Persona inquiry response body', { status, error })` — still falls back to `{}` so the existing error-message extraction below it is unchanged |
| `backend/src/services/ledgerMonitor.js:611` | `logger.warn('Ledger stream health check failed', { error })` |
| `backend/src/routes/withdrawals.js:518` | `logger.warn('Withdrawal approved notification failed', { withdrawal_id, error })` |
| `backend/src/routes/withdrawals.js:700` | `logger.warn('Withdrawal rejected notification failed', { withdrawal_id, error })` |

**Decision worth flagging:** the issue suggested using the project's logger module everywhere. I used `console.error` in `db/migrate.js` instead. That file is a standalone CLI script — it has no logger import, prints everything as `[migrate] …` via `console`, and runs before/outside the Express app. Pulling winston into it would change migration output formatting in CI for no benefit. The other four all use the shared `logger` as suggested. Happy to switch it if you'd rather be literal about it.

Notification failures are `warn` rather than `error` because they are non-fatal side effects — the withdrawal itself already succeeded and is logged separately.

### #560 — `.env` credentials

`.env` is already untracked and absent from history (`git log --all -- .env` is empty), and #635 added the pre-commit hook, so the credential removal itself was already done. What was left is that the guard could still be bypassed:

- **Added a `secret-hygiene` CI job** that runs `node .husky/check-env.js --tracked` and fails the build if any `.env` file is tracked. A pre-commit hook does nothing against `git commit --no-verify`, or for a contributor who never ran `npm install` at the repo root — CI closes that gap.
- **Fixed a false positive in the hook**: its pattern `/(^|\/)\.env(\.|$)/` matched `.env.example` and `.env.template`, so it blocked commits containing the very template files its own error message recommends. Templates are now excluded (`.example`, `.template`, `.sample`).
- **Expanded the failure message** to cover rotating the exposed secret and moving real values into platform secret management, not just `.gitignore`.

Secret rotation itself (Neon connection string, `JWT_SECRET`) is an ops action and can't be done in a PR — worth confirming it happened when #560 is closed, since anyone who cloned before the removal still holds the old values.

### #574 — Freighter signing has a timeout and a cancel button

`@stellar/freighter-api` never settles its promise when the user dismisses the popup or the extension hangs, so `ContributeModal` sat in the signing state forever with no retry and no cancel.

- New `withFreighterTimeout()` helper races each extension call against a **60s timeout** and an `AbortController`.
- Applied to all three calls that open the extension: `requestAccess`, `getNetwork`, `signTransaction` — each with its own message, since any of them can hang.
- While a signing request is in flight, the modal's **Cancel** button becomes **"Cancel signing"** and aborts the attempt.
- Closing the modal, or unmounting it, also aborts.
- Cancelling shows `Signing cancelled. Nothing was sent — you can start the payment again.` and releases the submit lock so the contributor can retry immediately. A timeout releases it the same way.

### #576 — Deposit polling backs off and gives up

`DepositModal`'s SEP-24 poll ran on a fixed 4s `setInterval` no matter how many requests failed.

- Replaced with a self-scheduling `setTimeout`.
- Consecutive failures back off **5s → 10s → 20s → 40s**.
- Any successful poll resets the backoff to the 4s steady-state interval.
- A **5th** consecutive failure stops polling and shows an error explaining the deposit itself is unaffected.
- Each retry shows a user-visible notice with the delay and attempt number (`Retrying in 10s — attempt 3 of 5`).
- The `status === 'failed'` branch now `return`s instead of falling through, so no further poll is scheduled once the modal drops back to the form.

The 4s steady-state interval is kept from the original code — the issue's `5s` figure is used as the first *backoff* step, so normal polling isn't slowed down for everyone.

---

## Manual testing

**#488 — silent catches**
```bash
cd backend
# ROLLBACK logging: point at a DB, add a deliberately broken .sql to db/migrations/, then
npm run migrate     # expect "[migrate] Failed: …"; a broken ROLLBACK now also prints "[migrate] ROLLBACK failed: …"
```
For the withdrawals paths, stub `createNotification` to reject and approve/reject a withdrawal — the route still returns 200 and the log now carries `Withdrawal approved notification failed` with the `withdrawal_id`.

**#560 — env guard**
```bash
# tracked-mode check (this is what CI runs)
node .husky/check-env.js --tracked
# => [check-env] No .env files are tracked by git.

# hook still blocks a real .env
echo "SECRET=1" > .env && git add -f .env && node .husky/check-env.js   # exit 1, COMMIT BLOCKED
git reset && rm .env

# templates are no longer false-positives
git add .env.example && node .husky/check-env.js                        # exit 0
```

**#574 — Freighter timeout / cancel**
1. Open a campaign → **Support this campaign** → select **My own wallet (advanced)** → enter an amount → **Review in Freighter**.
2. When Freighter asks you to sign, **dismiss the popup without approving**.
3. The button row now shows **Cancel signing** — click it: the modal returns to the form with "Signing cancelled…" and the submit button is enabled again.
4. Repeat, and this time just leave the popup untouched for 60s: you get "Freighter did not return a signature within 60 seconds…" and can retry.

**#576 — deposit backoff**
1. Dashboard → **Add Funds** → pick an anchor → amount → **Continue** to reach "Complete your deposit".
2. Block `GET /api/anchor/deposits/:id` in DevTools (Network → block request URL) or go offline.
3. Watch the request timing in the Network tab: retries land ~5s, ~10s, ~20s, ~40s apart, each with a visible "Retrying in Xs — attempt N of 5" notice.
4. After the 5th failure, polling stops and an error appears. Unblock the request → no further polls fire (by design; reopen the deposit window or reload).
5. Unblock partway through instead, and the interval snaps back to 4s.

## Tests

```bash
cd frontend && npm test    # 132 passed, 6 failed
cd backend  && npm run lint
```

Added 7 tests:

- `DepositModal.test.jsx` — exponential backoff schedule, stop-after-limit + error, backoff reset after a successful poll (3)
- `ContributeModal.test.jsx` — "Cancel signing" button appears during signing, 60s timeout instead of hanging, cancel aborts the attempt (3, plus one shared fake-timer harness)

**Pre-existing failures on `main`, not touched by this PR** (verified by stashing this branch and re-running):

- `frontend` — 6 failures in `CreateCampaign.test.jsx` / `CreateCampaignDraft.test.jsx`: `api.getMyCampaignDraft is not a function`
- `backend` — `src/routes/withdrawals.test.js` "returns 410 when XDR time bounds are expired" returns 400

Also worth a separate issue: `backend`'s `npm test` script in `package.json` is truncated mid-value —

```
"test": "NODE_ENV=test … PLATFORM_SECRET_KEY=SC[...",
```

so it sets env vars and never invokes a test runner. It exits 0 having run nothing, which means the CI "Run test suite" step is currently a no-op. I left it alone as out of scope, and ran the backend tests for the files I touched directly with `node --test` instead.
