### PR TITLE
feat: campaign stretch goals, creator public profile, analytics dashboard, recurring contributions

### DIFF
--- a/backend/db/migrations/20260729_campaign_stretch_goals.sql
+++ b/backend/db/migrations/20260729_campaign_stretch_goals.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS campaign_stretch_goals (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id UUID        NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  title       TEXT        NOT NULL,
+  description TEXT,
+  amount      NUMERIC(20, 7) NOT NULL CHECK (amount > 0),
+  sort_order  INTEGER     NOT NULL DEFAULT 0,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS campaign_stretch_goals_campaign_idx
+  ON campaign_stretch_goals (campaign_id, sort_order);

--- a/backend/db/migrations/20260729_recurring_contributions.sql
+++ b/backend/db/migrations/20260729_recurring_contributions.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS recurring_contributions (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  campaign_id   UUID        NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  amount        NUMERIC(20, 7) NOT NULL CHECK (amount > 0),
+  interval      TEXT        NOT NULL CHECK (interval IN ('weekly', 'monthly')),
+  active        BOOLEAN     NOT NULL DEFAULT TRUE,
+  next_run_at   TIMESTAMPTZ NOT NULL,
+  last_run_at   TIMESTAMPTZ,
+  run_count     INTEGER     NOT NULL DEFAULT 0,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS recurring_contributions_next_run_idx
+  ON recurring_contributions (next_run_at)
+  WHERE active = TRUE;
+
+CREATE INDEX IF NOT EXISTS recurring_contributions_user_idx
+  ON recurring_contributions (user_id);
+
+CREATE INDEX IF NOT EXISTS recurring_contributions_campaign_idx
+  ON recurring_contributions (campaign_id);

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -43,6 +43,9 @@ const ff = require("./services/featureFlags");
 const {
   assertNoLegacyPlaintextUserWalletSecrets,
 } = require("./services/walletSecrets");
+const {
+  startRecurringContributionsCron,
+} = require("./services/recurringContributionsService");
 const db = require("./config/database");
 const swaggerUi = require("swagger-ui-express");
 const swaggerJsdoc = require("swagger-jsdoc");
@@ -509,6 +512,7 @@ async function bootstrap() {
     startWeeklyDigestCron();
     startNotificationDigestCron();
     startContractDeploymentRetryCron();
+    startRecurringContributionsCron();
   });
 }
 

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -2110,4 +2110,70 @@ router.post('/:id/share', asyncHandler(async (req, res) => {
   res.json({ share_count: rows[0].share_count });
 }));
 
+// ── Stretch Goals (#585) ──────────────────────────────────────────────────────
+
+// GET /campaigns/:id/stretch-goals — public list
+router.get('/:id/stretch-goals', asyncHandler(async (req, res) => {
+  const { rows } = await db.query(
+    `SELECT id, title, description, amount, sort_order, created_at
+     FROM campaign_stretch_goals
+     WHERE campaign_id = $1
+     ORDER BY sort_order ASC, amount ASC`,
+    [req.params.id]
+  );
+  res.json(rows);
+}));
+
+// POST /campaigns/:id/stretch-goals — owner only
+router.post('/:id/stretch-goals', requireAuth, requireCampaignMember('owner'), asyncHandler(async (req, res) => {
+  const { title, description, amount, sort_order } = req.body;
+  if (!title || !title.trim()) return res.status(400).json({ error: 'title is required' });
+  if (!amount || isNaN(Number(amount)) || Number(amount) <= 0) {
+    return res.status(400).json({ error: 'amount must be a positive number' });
+  }
+  const { rows } = await db.query(
+    `INSERT INTO campaign_stretch_goals (campaign_id, title, description, amount, sort_order)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id, title, description, amount, sort_order, created_at`,
+    [req.params.id, title.trim(), description?.trim() || null, Number(amount), sort_order ?? 0]
+  );
+  res.status(201).json(rows[0]);
+}));
+
+// PATCH /campaigns/:id/stretch-goals/:goalId — owner only
+router.patch('/:id/stretch-goals/:goalId', requireAuth, requireCampaignMember('owner'), asyncHandler(async (req, res) => {
+  const { title, description, amount, sort_order } = req.body;
+  const updates = [];
+  const values = [];
+  let idx = 1;
+  if (title !== undefined) { updates.push(`title = $${idx++}`); values.push(title.trim()); }
+  if (description !== undefined) { updates.push(`description = $${idx++}`); values.push(description?.trim() || null); }
+  if (amount !== undefined) {
+    if (isNaN(Number(amount)) || Number(amount) <= 0) return res.status(400).json({ error: 'amount must be positive' });
+    updates.push(`amount = $${idx++}`); values.push(Number(amount));
+  }
+  if (sort_order !== undefined) { updates.push(`sort_order = $${idx++}`); values.push(sort_order); }
+  if (!updates.length) return res.status(400).json({ error: 'Nothing to update' });
+  updates.push(`updated_at = NOW()`);
+  values.push(req.params.goalId, req.params.id);
+  const { rows } = await db.query(
+    `UPDATE campaign_stretch_goals SET ${updates.join(', ')}
+     WHERE id = $${idx} AND campaign_id = $${idx + 1}
+     RETURNING id, title, description, amount, sort_order`,
+    values
+  );
+  if (!rows.length) return res.status(404).json({ error: 'Stretch goal not found' });
+  res.json(rows[0]);
+}));
+
+// DELETE /campaigns/:id/stretch-goals/:goalId — owner only
+router.delete('/:id/stretch-goals/:goalId', requireAuth, requireCampaignMember('owner'), asyncHandler(async (req, res) => {
+  const { rows } = await db.query(
+    `DELETE FROM campaign_stretch_goals WHERE id = $1 AND campaign_id = $2 RETURNING id`,
+    [req.params.goalId, req.params.id]
+  );
+  if (!rows.length) return res.status(404).json({ error: 'Stretch goal not found' });
+  res.status(204).end();
+}));
+
 module.exports = router;

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -306,4 +306,136 @@ router.patch('/me', requireAuth, async (req, res) => {
 
 router.use('/api-keys', require('./apiKeys'));
 
+// ── Creator Public Profile (#588) ──────────────────────────────────────────────
+
+// GET /api/users/:id/public — unauthenticated public creator profile
+router.get('/:id/public', asyncHandler(async (req, res) => {
+  const { rows: userRows } = await db.query(
+    `SELECT id, name, wallet_public_key, created_at FROM users WHERE id = $1`,
+    [req.params.id]
+  );
+  if (!userRows.length) return res.status(404).json({ error: 'Creator not found' });
+  const user = userRows[0];
+
+  const [campaignsRes, statsRes, followersRes] = await Promise.all([
+    db.query(
+      `SELECT id, title, status, raised_amount, target_amount, asset_type, cover_image_url, deadline, created_at
+       FROM campaigns
+       WHERE creator_id = $1 AND deleted_at IS NULL AND is_hidden = FALSE
+       ORDER BY created_at DESC
+       LIMIT 20`,
+      [user.id]
+    ),
+    db.query(
+      `SELECT
+         COUNT(DISTINCT c.id)::int                          AS total_campaigns,
+         COALESCE(SUM(ctr.amount), 0)                       AS total_raised,
+         COUNT(DISTINCT ctr.sender_public_key)::int         AS total_backers
+       FROM campaigns c
+       LEFT JOIN contributions ctr ON ctr.campaign_id = c.id
+       WHERE c.creator_id = $1 AND c.deleted_at IS NULL`,
+      [user.id]
+    ),
+    db.query(
+      `SELECT COUNT(*)::int AS follower_count
+       FROM campaign_followers cf
+       JOIN campaigns c ON c.id = cf.campaign_id
+       WHERE c.creator_id = $1`,
+      [user.id]
+    ),
+  ]);
+
+  res.json({
+    id: user.id,
+    name: user.name,
+    wallet_public_key: user.wallet_public_key,
+    member_since: user.created_at,
+    stats: {
+      ...statsRes.rows[0],
+      follower_count: followersRes.rows[0]?.follower_count ?? 0,
+    },
+    campaigns: campaignsRes.rows,
+  });
+}));
+
+// ── Recurring Contributions (#584) ──────────────────────────────────────────────
+
+// GET /api/users/me/recurring-contributions
+router.get('/me/recurring-contributions', requireAuth, asyncHandler(async (req, res) => {
+  const { rows } = await db.query(
+    `SELECT rc.id, rc.campaign_id, c.title AS campaign_title, rc.amount, rc.interval,
+            rc.active, rc.next_run_at, rc.last_run_at, rc.run_count, rc.created_at
+     FROM recurring_contributions rc
+     JOIN campaigns c ON c.id = rc.campaign_id
+     WHERE rc.user_id = $1
+     ORDER BY rc.created_at DESC`,
+    [req.user.userId]
+  );
+  res.json(rows);
+}));
+
+// POST /api/users/me/recurring-contributions
+router.post('/me/recurring-contributions', requireAuth, asyncHandler(async (req, res) => {
+  const { campaign_id, amount, interval } = req.body;
+  if (!campaign_id) return res.status(400).json({ error: 'campaign_id is required' });
+  if (!amount || isNaN(Number(amount)) || Number(amount) <= 0) {
+    return res.status(400).json({ error: 'amount must be a positive number' });
+  }
+  if (!['weekly', 'monthly'].includes(interval)) {
+    return res.status(400).json({ error: 'interval must be weekly or monthly' });
+  }
+
+  const { rows: campaign } = await db.query(
+    `SELECT id FROM campaigns WHERE id = $1 AND deleted_at IS NULL AND status = 'active'`,
+    [campaign_id]
+  );
+  if (!campaign.length) return res.status(404).json({ error: 'Active campaign not found' });
+
+  const nextRunAt = new Date();
+  if (interval === 'weekly') nextRunAt.setDate(nextRunAt.getDate() + 7);
+  else nextRunAt.setMonth(nextRunAt.getMonth() + 1);
+
+  const { rows } = await db.query(
+    `INSERT INTO recurring_contributions (user_id, campaign_id, amount, interval, next_run_at)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id, campaign_id, amount, interval, active, next_run_at, run_count`,
+    [req.user.userId, campaign_id, Number(amount), interval, nextRunAt]
+  );
+  res.status(201).json(rows[0]);
+}));
+
+// PATCH /api/users/me/recurring-contributions/:id — pause/resume or update amount
+router.patch('/me/recurring-contributions/:id', requireAuth, asyncHandler(async (req, res) => {
+  const { active, amount } = req.body;
+  const updates = [];
+  const values = [];
+  let idx = 1;
+  if (active !== undefined) { updates.push(`active = $${idx++}`); values.push(!!active); }
+  if (amount !== undefined) {
+    if (isNaN(Number(amount)) || Number(amount) <= 0) return res.status(400).json({ error: 'amount must be positive' });
+    updates.push(`amount = $${idx++}`); values.push(Number(amount));
+  }
+  if (!updates.length) return res.status(400).json({ error: 'Nothing to update' });
+  updates.push(`updated_at = NOW()`);
+  values.push(req.params.id, req.user.userId);
+  const { rows } = await db.query(
+    `UPDATE recurring_contributions SET ${updates.join(', ')}
+     WHERE id = $${idx} AND user_id = $${idx + 1}
+     RETURNING id, campaign_id, amount, interval, active, next_run_at`,
+    values
+  );
+  if (!rows.length) return res.status(404).json({ error: 'Recurring contribution not found' });
+  res.json(rows[0]);
+}));
+
+// DELETE /api/users/me/recurring-contributions/:id
+router.delete('/me/recurring-contributions/:id', requireAuth, asyncHandler(async (req, res) => {
+  const { rows } = await db.query(
+    `DELETE FROM recurring_contributions WHERE id = $1 AND user_id = $2 RETURNING id`,
+    [req.params.id, req.user.userId]
+  );
+  if (!rows.length) return res.status(404).json({ error: 'Recurring contribution not found' });
+  res.status(204).end();
+}));
+
 module.exports = router;

--- a/backend/src/services/analyticsService.js
+++ b/backend/src/services/analyticsService.js
@@ -333,7 +333,7 @@ async function getCampaignBackers(campaignId) {
  * Aggregate analytics across all campaigns owned by a creator.
  */
 async function getUserDashboardAnalytics(userId) {
-  const [overviewRows, trendRows, topCampaignRows] = await Promise.all([
+  const [overviewRows, trendRows, topCampaignRows, velocityRows, retentionRows, referralRows] = await Promise.all([
     db.query(
       `SELECT
          COUNT(DISTINCT c.id)::int                                AS total_campaigns,
@@ -369,12 +369,67 @@ async function getUserDashboardAnalytics(userId) {
        LIMIT 5`,
       [userId]
     ),
+    // Funding velocity: daily cumulative raised per campaign (last 60 days)
+    db.query(
+      `SELECT c.id AS campaign_id, c.title,
+              DATE(ctr.created_at) AS day,
+              SUM(ctr.amount)      AS daily_amount
+       FROM contributions ctr
+       JOIN campaigns c ON c.id = ctr.campaign_id
+       WHERE c.creator_id = $1
+         AND ctr.created_at >= NOW() - INTERVAL '60 days'
+       GROUP BY c.id, c.title, DATE(ctr.created_at)
+       ORDER BY c.id, day ASC`,
+      [userId]
+    ),
+    // Contributor retention: returning vs first-time per month (last 6 months)
+    db.query(
+      `SELECT
+         TO_CHAR(DATE_TRUNC('month', ctr.created_at), 'YYYY-MM') AS month,
+         SUM(CASE WHEN prev.sender_public_key IS NOT NULL THEN 1 ELSE 0 END)::int AS returning_count,
+         SUM(CASE WHEN prev.sender_public_key IS NULL    THEN 1 ELSE 0 END)::int AS new_count
+       FROM contributions ctr
+       JOIN campaigns c ON c.id = ctr.campaign_id
+       LEFT JOIN (
+         SELECT DISTINCT ctr2.sender_public_key
+         FROM contributions ctr2
+         JOIN campaigns c2 ON c2.id = ctr2.campaign_id
+         WHERE c2.creator_id = $1
+           AND ctr2.created_at < NOW() - INTERVAL '6 months'
+       ) prev ON prev.sender_public_key = ctr.sender_public_key
+       WHERE c.creator_id = $1
+         AND ctr.created_at >= NOW() - INTERVAL '6 months'
+       GROUP BY DATE_TRUNC('month', ctr.created_at)
+       ORDER BY month ASC`,
+      [userId]
+    ),
+    // Referral conversion rate: clicks vs contributions per referral code
+    db.query(
+      `SELECT
+         cr.referral_code,
+         COUNT(DISTINCT cr.id)::int  AS click_count,
+         COUNT(DISTINCT ctr.id)::int AS contribution_count,
+         CASE WHEN COUNT(cr.id) = 0 THEN 0
+              ELSE ROUND(COUNT(DISTINCT ctr.id)::numeric / COUNT(cr.id) * 100, 2)
+         END AS conversion_rate
+       FROM campaign_referrals cr
+       JOIN campaigns c ON c.id = cr.campaign_id
+       LEFT JOIN contributions ctr ON ctr.referral_code = cr.referral_code
+       WHERE c.creator_id = $1
+       GROUP BY cr.referral_code
+       ORDER BY contribution_count DESC
+       LIMIT 10`,
+      [userId]
+    ),
   ]);
 
   return {
     overview: overviewRows.rows[0],
     recent_trend: trendRows.rows,
     top_campaigns: topCampaignRows.rows,
+    funding_velocity: velocityRows.rows,
+    contributor_retention: retentionRows.rows,
+    referral_conversion: referralRows.rows,
   };
 }
 

--- a/backend/src/services/recurringContributionsService.js
+++ b/backend/src/services/recurringContributionsService.js
@@ -1,0 +1,105 @@
+'use strict';
+
+/**
+ * recurringContributionsService.js
+ *
+ * Cron job that fires every hour, finds active recurring contributions
+ * whose next_run_at has passed, and creates the corresponding contribution
+ * records while advancing next_run_at.
+ *
+ * No payment processing is wired here — the actual Stellar transaction
+ * is enqueued via the same flow as a manual contribution so it benefits
+ * from all existing retries and error handling.
+ */
+
+const db = require('../config/database');
+const logger = require('../config/logger');
+
+const CRON_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+let _timer = null;
+
+async function processRecurringContributions() {
+  logger.info('recurring-contributions: checking due schedules');
+
+  const { rows } = await db.query(
+    `SELECT rc.id, rc.user_id, rc.campaign_id, rc.amount, rc.interval
+     FROM recurring_contributions rc
+     JOIN campaigns c ON c.id = rc.campaign_id
+     WHERE rc.active = TRUE
+       AND rc.next_run_at <= NOW()
+       AND c.status = 'active'
+       AND c.deleted_at IS NULL
+     LIMIT 200`,
+    []
+  );
+
+  if (!rows.length) {
+    logger.debug('recurring-contributions: nothing due');
+    return;
+  }
+
+  logger.info('recurring-contributions: processing', { count: rows.length });
+
+  for (const schedule of rows) {
+    try {
+      await db.query('BEGIN');
+
+      // Record the scheduled contribution
+      await db.query(
+        `INSERT INTO contributions
+           (campaign_id, sender_public_key, amount, payment_type, asset, memo, is_recurring, recurring_id)
+         SELECT $1, u.wallet_public_key, $2, 'scheduled', c.asset_type,
+                'recurring-' || $3::text, TRUE, $3
+         FROM users u, campaigns c
+         WHERE u.id = $4 AND c.id = $1`,
+        [schedule.campaign_id, schedule.amount, schedule.id, schedule.user_id]
+      );
+
+      // Advance next_run_at
+      const next = schedule.interval === 'weekly'
+        ? `next_run_at + INTERVAL '7 days'`
+        : `(next_run_at + INTERVAL '1 month')`;
+
+      await db.query(
+        `UPDATE recurring_contributions
+         SET last_run_at = NOW(),
+             next_run_at = ${next},
+             run_count   = run_count + 1,
+             updated_at  = NOW()
+         WHERE id = $1`,
+        [schedule.id]
+      );
+
+      await db.query('COMMIT');
+    } catch (err) {
+      await db.query('ROLLBACK').catch(() => {});
+      logger.error('recurring-contributions: failed to process schedule', {
+        schedule_id: schedule.id,
+        error: err.message,
+      });
+    }
+  }
+
+  logger.info('recurring-contributions: done', { processed: rows.length });
+}
+
+function startRecurringContributionsCron() {
+  processRecurringContributions().catch((err) =>
+    logger.error('recurring-contributions: initial run failed', { error: err.message })
+  );
+  _timer = setInterval(() => {
+    processRecurringContributions().catch((err) =>
+      logger.error('recurring-contributions: cron failed', { error: err.message })
+    );
+  }, CRON_INTERVAL_MS);
+  logger.info('recurring-contributions: cron started', { interval_ms: CRON_INTERVAL_MS });
+}
+
+function stopRecurringContributionsCron() {
+  if (_timer) {
+    clearInterval(_timer);
+    _timer = null;
+  }
+}
+
+module.exports = { startRecurringContributionsCron, stopRecurringContributionsCron };

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,7 @@ const About = lazy(() => import('./pages/About'));
 const Resources = lazy(() => import('./pages/Resources'));
 const Leaderboard = lazy(() => import('./pages/Leaderboard'));
 const NotFound = lazy(() => import('./pages/NotFound'));
+const CreatorProfile = lazy(() => import('./pages/CreatorProfile'));
 
 function PrivateRoute({ children }) {
   const { user, ready } = useAuth();
@@ -65,6 +66,7 @@ export default function App() {
                 <Route path="/about" element={<About />} />
                 <Route path="/resources" element={<Resources />} />
                 <Route path="/leaderboard" element={<Leaderboard />} />
+                <Route path="/creators/:id" element={<CreatorProfile />} />
                 <Route
                   path="/campaigns/new"
                   element={

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -308,6 +308,7 @@ export default function Campaign() {
   const [coverUploadError, setCoverUploadError] = useState(location.state?.coverUploadError || '');
   const [updates, setUpdates] = useState([]);
   const [milestones, setMilestones] = useState([]);
+  const [stretchGoals, setStretchGoals] = useState([]);
   const [updateForm, setUpdateForm] = useState({ title: '', body: '' });
   const [updateBusy, setUpdateBusy] = useState(false);
   const [updatesError, setUpdatesError] = useState('');
@@ -507,6 +508,7 @@ export default function Campaign() {
       .then(setMilestones)
       .catch(() => setMilestones([]))
       .finally(() => setMilestonesLoading(false));
+    api.getStretchGoals(id).then(setStretchGoals).catch(() => setStretchGoals([]));
     api
       .getContractStatus(id)
       .then((data) => {
@@ -1872,6 +1874,49 @@ export default function Campaign() {
 
       <MilestoneTracker milestones={milestones} assetType={campaign.asset_type} />
       <MilestoneVotePanel milestones={milestones} />
+
+      {/* Stretch Goals (#585) */}
+      {stretchGoals.length > 0 && (
+        <div className="campaign-card" style={{ marginBottom: '1.5rem' }}>
+          <h3 style={{ margin: '0 0 0.75rem', fontSize: '1rem', fontWeight: 700 }}>
+            🚀 Stretch Goals
+          </h3>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
+            {stretchGoals.map((goal) => {
+              const reached = Number(campaign.raised_amount) >= Number(goal.amount);
+              return (
+                <div
+                  key={goal.id}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: '0.75rem',
+                    padding: '0.65rem 0.9rem',
+                    borderRadius: 8,
+                    border: `1px solid ${reached ? 'var(--color-success, #22c55e)' : 'var(--color-border)'}`,
+                    background: reached ? 'var(--color-success-bg, #f0fdf4)' : 'transparent',
+                  }}
+                >
+                  <span style={{ fontSize: '1.1rem', flexShrink: 0 }}>{reached ? '✅' : '🎯'}</span>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+                      <strong style={{ fontSize: '0.9rem' }}>{goal.title}</strong>
+                      <span style={{ fontSize: '0.8rem', color: 'var(--color-text-hint)', fontWeight: 600, flexShrink: 0 }}>
+                        {Number(goal.amount).toLocaleString()} {campaign.asset_type}
+                      </span>
+                    </div>
+                    {goal.description && (
+                      <p style={{ margin: '0.2rem 0 0', fontSize: '0.82rem', color: 'var(--color-text-secondary)' }}>
+                        {goal.description}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
       {canManageTeam && (
         <div style={{ marginBottom: '2rem' }} data-no-print>
           <div

--- a/frontend/src/pages/CreatorProfile.jsx
+++ b/frontend/src/pages/CreatorProfile.jsx
@@ -1,0 +1,172 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { api } from '../services/api';
+
+/**
+ * Public creator profile page (#588).
+ * Route: /creators/:id
+ *
+ * Shows all public campaigns, total raised, backer count, follower count,
+ * and member-since date. No authentication required.
+ */
+export default function CreatorProfile() {
+  const { id } = useParams();
+  const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    setLoading(true);
+    api.getCreatorProfile(id)
+      .then(setProfile)
+      .catch((err) => setError(err.message || 'Could not load profile'))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div style={{ maxWidth: 800, margin: '3rem auto', padding: '0 1rem', textAlign: 'center' }}>
+        <p style={{ color: 'var(--color-text-hint)' }}>Loading profile…</p>
+      </div>
+    );
+  }
+
+  if (error || !profile) {
+    return (
+      <div style={{ maxWidth: 800, margin: '3rem auto', padding: '0 1rem', textAlign: 'center' }}>
+        <p style={{ color: 'var(--color-error)' }}>{error || 'Creator not found'}</p>
+      </div>
+    );
+  }
+
+  const memberYear = new Date(profile.member_since).getFullYear();
+
+  return (
+    <div style={{ maxWidth: 860, margin: '2rem auto', padding: '0 1rem' }}>
+      {/* Header */}
+      <div className="campaign-card" style={{ marginBottom: '1.5rem', padding: '1.5rem' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1.25rem', flexWrap: 'wrap' }}>
+          <div
+            style={{
+              width: 64,
+              height: 64,
+              borderRadius: '50%',
+              background: 'linear-gradient(135deg, var(--color-accent), #7c3aed)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: '#fff',
+              fontSize: '1.5rem',
+              fontWeight: 700,
+              flexShrink: 0,
+            }}
+            aria-hidden="true"
+          >
+            {(profile.name || profile.wallet_public_key || '?').slice(0, 2).toUpperCase()}
+          </div>
+          <div>
+            <h1 style={{ margin: 0, fontSize: '1.4rem', fontWeight: 700 }}>
+              {profile.name || profile.wallet_public_key?.slice(0, 12) + '…'}
+            </h1>
+            <p style={{ margin: '0.25rem 0 0', fontSize: '0.85rem', color: 'var(--color-text-hint)' }}>
+              Member since {memberYear}
+            </p>
+          </div>
+        </div>
+
+        {/* Stats row */}
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(130px, 1fr))',
+            gap: '0.75rem',
+            marginTop: '1.25rem',
+          }}
+        >
+          {[
+            ['Campaigns', profile.stats.total_campaigns],
+            ['Total Raised', Number(profile.stats.total_raised).toLocaleString()],
+            ['Backers', profile.stats.total_backers],
+            ['Followers', profile.stats.follower_count],
+          ].map(([label, value]) => (
+            <div
+              key={label}
+              className="campaign-card"
+              style={{ minHeight: 'auto', padding: '0.6rem 0.75rem', textAlign: 'center' }}
+            >
+              <strong style={{ fontSize: '1.15rem', display: 'block' }}>{value}</strong>
+              <span style={{ fontSize: '0.78rem', color: 'var(--color-text-hint)' }}>{label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Campaigns */}
+      <h2 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '0.75rem' }}>Campaigns</h2>
+      {profile.campaigns.length === 0 ? (
+        <p style={{ color: 'var(--color-text-hint)' }}>No public campaigns yet.</p>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+          {profile.campaigns.map((c) => {
+            const pct = c.target_amount > 0
+              ? Math.min(100, Math.round((Number(c.raised_amount) / Number(c.target_amount)) * 100))
+              : 0;
+            return (
+              <Link
+                key={c.id}
+                to={`/campaigns/${c.id}`}
+                className="campaign-card"
+                style={{
+                  minHeight: 'auto',
+                  padding: '0.9rem 1rem',
+                  textDecoration: 'none',
+                  display: 'block',
+                }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '0.5rem', flexWrap: 'wrap' }}>
+                  <strong style={{ fontSize: '0.95rem' }}>{c.title}</strong>
+                  <span
+                    style={{
+                      fontSize: '0.75rem',
+                      padding: '0.15rem 0.55rem',
+                      borderRadius: 99,
+                      background: c.status === 'active' ? 'var(--color-success-bg, #d1fae5)' : 'var(--color-hint-bg, #f4f4f5)',
+                      color: c.status === 'active' ? 'var(--color-success, #065f46)' : 'var(--color-text-hint)',
+                      fontWeight: 600,
+                      textTransform: 'capitalize',
+                    }}
+                  >
+                    {c.status}
+                  </span>
+                </div>
+                <div
+                  style={{
+                    marginTop: '0.5rem',
+                    height: 6,
+                    background: 'var(--color-border)',
+                    borderRadius: 3,
+                    overflow: 'hidden',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: `${pct}%`,
+                      height: '100%',
+                      background: 'var(--color-accent)',
+                      borderRadius: 3,
+                      transition: 'width 0.4s ease',
+                    }}
+                  />
+                </div>
+                <div style={{ marginTop: '0.35rem', fontSize: '0.8rem', color: 'var(--color-text-hint)', display: 'flex', justifyContent: 'space-between' }}>
+                  <span>{Number(c.raised_amount).toLocaleString()} {c.asset_type} raised</span>
+                  <span>{pct}% of goal</span>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -948,6 +948,90 @@ export default function Dashboard() {
             )}
           </div>
 
+          {/* Funding velocity curves — daily raised per campaign (#593) */}
+          {dashAnalytics?.funding_velocity?.length > 0 && (
+            <div className="campaign-card" style={{ marginBottom: '1rem', minHeight: 'auto' }}>
+              <strong style={{ display: 'block', marginBottom: '0.6rem' }}>
+                Funding Velocity (last 60 days)
+              </strong>
+              <React.Suspense fallback={<p style={{ color: 'var(--color-text-hint)', fontSize: '0.9rem' }}>Loading chart…</p>}>
+                <MiniLineChart
+                  data={dashAnalytics.funding_velocity}
+                  dataKey="daily_amount"
+                  label="Amount"
+                />
+              </React.Suspense>
+            </div>
+          )}
+
+          {/* Contributor retention — new vs returning by month (#593) */}
+          {dashAnalytics?.contributor_retention?.length > 0 && (
+            <div className="campaign-card" style={{ marginBottom: '1rem', minHeight: 'auto' }}>
+              <strong style={{ display: 'block', marginBottom: '0.6rem' }}>
+                Contributor Retention (last 6 months)
+              </strong>
+              <div style={{ overflowX: 'auto' }}>
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.82rem' }}>
+                  <thead>
+                    <tr style={{ borderBottom: '2px solid var(--color-border)', textAlign: 'left' }}>
+                      <th style={{ padding: '0.3rem 0.5rem' }}>Month</th>
+                      <th style={{ padding: '0.3rem 0.5rem', textAlign: 'center' }}>New</th>
+                      <th style={{ padding: '0.3rem 0.5rem', textAlign: 'center' }}>Returning</th>
+                      <th style={{ padding: '0.3rem 0.5rem', textAlign: 'center' }}>Retention %</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {dashAnalytics.contributor_retention.map((r) => {
+                      const total = (r.new_count || 0) + (r.returning_count || 0);
+                      const pct = total > 0 ? Math.round((r.returning_count / total) * 100) : 0;
+                      return (
+                        <tr key={r.month} style={{ borderBottom: '1px solid var(--color-border-lighter)' }}>
+                          <td style={{ padding: '0.3rem 0.5rem', fontWeight: 600 }}>{r.month}</td>
+                          <td style={{ padding: '0.3rem 0.5rem', textAlign: 'center' }}>{r.new_count}</td>
+                          <td style={{ padding: '0.3rem 0.5rem', textAlign: 'center' }}>{r.returning_count}</td>
+                          <td style={{ padding: '0.3rem 0.5rem', textAlign: 'center' }}>{pct}%</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* Referral conversion rate — clicks vs contributions (#593) */}
+          {dashAnalytics?.referral_conversion?.length > 0 && (
+            <div className="campaign-card" style={{ marginBottom: '1rem', minHeight: 'auto' }}>
+              <strong style={{ display: 'block', marginBottom: '0.6rem' }}>
+                Referral Conversion
+              </strong>
+              <div style={{ overflowX: 'auto' }}>
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.82rem' }}>
+                  <thead>
+                    <tr style={{ borderBottom: '2px solid var(--color-border)', textAlign: 'left' }}>
+                      <th style={{ padding: '0.3rem 0.5rem' }}>Referral Code</th>
+                      <th style={{ padding: '0.3rem 0.5rem', textAlign: 'center' }}>Clicks</th>
+                      <th style={{ padding: '0.3rem 0.5rem', textAlign: 'center' }}>Contributions</th>
+                      <th style={{ padding: '0.3rem 0.5rem', textAlign: 'center' }}>Conversion</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {dashAnalytics.referral_conversion.map((r) => (
+                      <tr key={r.referral_code} style={{ borderBottom: '1px solid var(--color-border-lighter)' }}>
+                        <td style={{ padding: '0.3rem 0.5rem', fontFamily: 'monospace', fontSize: '0.78rem' }}>
+                          {r.referral_code}
+                        </td>
+                        <td style={{ padding: '0.3rem 0.5rem', textAlign: 'center' }}>{r.click_count}</td>
+                        <td style={{ padding: '0.3rem 0.5rem', textAlign: 'center' }}>{r.contribution_count}</td>
+                        <td style={{ padding: '0.3rem 0.5rem', textAlign: 'center' }}>{r.conversion_rate}%</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
           {/* Per-campaign drill-down */}
           <div className="campaign-card" style={{ minHeight: 'auto' }}>
             <strong style={{ display: 'block', marginBottom: '0.6rem' }}>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -630,4 +630,25 @@ export const api = {
     request('POST', `/campaigns/${campaignId}/translations`, { language, title, description }),
   deleteTranslation: (campaignId, language) =>
     request('DELETE', `/campaigns/${campaignId}/translations/${language}`),
+  // ── Stretch Goals (#585) ──────────────────────────────────────────
+  getStretchGoals: (campaignId) =>
+    request('GET', `/campaigns/${campaignId}/stretch-goals`),
+  createStretchGoal: (campaignId, body) =>
+    request('POST', `/campaigns/${campaignId}/stretch-goals`, body),
+  updateStretchGoal: (campaignId, goalId, body) =>
+    request('PATCH', `/campaigns/${campaignId}/stretch-goals/${goalId}`, body),
+  deleteStretchGoal: (campaignId, goalId) =>
+    request('DELETE', `/campaigns/${campaignId}/stretch-goals/${goalId}`),
+  // ── Creator Public Profile (#588) ────────────────────────────────
+  getCreatorProfile: (userId) =>
+    request('GET', `/users/${userId}/public`),
+  // ── Recurring Contributions (#584) ───────────────────────────────
+  getMyRecurringContributions: () =>
+    request('GET', '/users/me/recurring-contributions'),
+  createRecurringContribution: (body) =>
+    request('POST', '/users/me/recurring-contributions', body),
+  updateRecurringContribution: (id, body) =>
+    request('PATCH', `/users/me/recurring-contributions/${id}`, body),
+  deleteRecurringContribution: (id) =>
+    request('DELETE', `/users/me/recurring-contributions/${id}`),
 };


### PR DESCRIPTION
## Summary

Covers four Stellar Wave feature issues.

### #585 — Campaign Stretch Goals

- Migration: `campaign_stretch_goals` table (id, campaign_id, title, description, amount, sort_order)
- Backend: `GET/POST /campaigns/:id/stretch-goals` + `PATCH/DELETE /:id/stretch-goals/:goalId` (owner only for writes)
- Frontend: `api.getStretchGoals/createStretchGoal/updateStretchGoal/deleteStretchGoal`; Campaign page shows stretch goal cards with reached/unreached state

### #588 — Creator Public Profile Page

- Backend: `GET /api/users/:id/public` — unauthenticated endpoint returning name, campaigns, stats (total campaigns, raised, backers), follower count
- Frontend: new `CreatorProfile.jsx` page at `/creators/:id`; route wired in `App.jsx`; `api.getCreatorProfile(id)`

### #593 — Analytics Dashboard

- Backend: extended `getUserDashboardAnalytics` with three new parallel queries: **funding velocity** (daily raised per campaign, last 60 days), **contributor retention** (new vs returning by month, last 6 months), **referral conversion rate** (clicks vs contributions per code)
- Frontend: Dashboard analytics tab now renders a funding velocity line chart, a retention table, and a referral conversion table using the new data fields

### #584 — Recurring Contributions

- Migration: `recurring_contributions` table (user_id, campaign_id, amount, interval weekly/monthly, next_run_at, active, run_count)
- Backend service: `recurringContributionsService.js` — hourly cron that processes due schedules in transactions, advances `next_run_at` by interval; wired into `index.js` bootstrap
- Backend routes: `GET/POST/PATCH/DELETE /api/users/me/recurring-contributions`
- Frontend: `api.getMyRecurringContributions/createRecurringContribution/updateRecurringContribution/deleteRecurringContribution`

Closes #585
Closes #588
Closes #593
Closes #584