### PR TITLE
feat: fraud detection fingerprinting, team roles UI, and faceted campaign search

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,6 +18,10 @@ JWT_EXPIRES_IN=7d
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 API_KEY_PEPPER=replace-with-a-different-random-256-bit-secret
 
+# OPTIONAL — pepper used to salt device fingerprints before storage (#595).
+# Falls back to API_KEY_PEPPER when unset. Keep secret; rotating it resets clustering.
+# DEVICE_FINGERPRINT_PEPPER=replace-with-another-random-256-bit-secret
+
 # ── Stellar ───────────────────────────────────────────────
 # 'testnet' for development, 'mainnet' for production
 STELLAR_NETWORK=testnet

--- a/backend/db/migrations/20260730_campaign_country_facet.sql
+++ b/backend/db/migrations/20260730_campaign_country_facet.sql
@@ -1,0 +1,9 @@
+-- Advanced faceted campaign search (#599): geographic location facet.
+-- Optional ISO-3166-ish country/region string set by the campaign creator.
+
+ALTER TABLE campaigns
+  ADD COLUMN IF NOT EXISTS country TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_campaigns_country
+  ON campaigns (country)
+  WHERE country IS NOT NULL;

--- a/backend/db/migrations/20260730_contribution_device_fingerprint.sql
+++ b/backend/db/migrations/20260730_contribution_device_fingerprint.sql
@@ -1,0 +1,16 @@
+-- Enhanced fraud detection: device fingerprinting (#595)
+-- Stores a salted HMAC of the client-supplied device fingerprint (never the raw value).
+-- Used to detect coordinated contributions originating from the same device cluster.
+
+ALTER TABLE contributions
+  ADD COLUMN IF NOT EXISTS device_fingerprint TEXT;
+
+-- Cluster lookups group contributions by (campaign, device); a partial index keeps it lean.
+CREATE INDEX IF NOT EXISTS contributions_device_fingerprint_idx
+  ON contributions (campaign_id, device_fingerprint)
+  WHERE device_fingerprint IS NOT NULL;
+
+-- Cross-campaign device clustering (coordinated campaigns from one device).
+CREATE INDEX IF NOT EXISTS contributions_device_fingerprint_global_idx
+  ON contributions (device_fingerprint)
+  WHERE device_fingerprint IS NOT NULL;

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -57,6 +57,7 @@ CREATE TABLE campaigns (
   fraud_score         INTEGER DEFAULT 0,
   fraud_signals       JSONB DEFAULT '{}'::jsonb,
   share_count         INTEGER NOT NULL DEFAULT 0,
+  country             TEXT,
   created_at          TIMESTAMPTZ DEFAULT NOW()
 );
 CREATE TABLE IF NOT EXISTS campaign_updates (
@@ -93,6 +94,7 @@ CREATE TABLE contributions (
   refunded            BOOLEAN NOT NULL DEFAULT FALSE,
   platform_fee_amount NUMERIC(20, 7),
   ip_address          TEXT,
+  device_fingerprint  TEXT,   -- salted HMAC of client device fingerprint (never raw)
   created_at          TIMESTAMPTZ DEFAULT NOW()
 );
 

--- a/backend/src/lib/campaignPermissions.js
+++ b/backend/src/lib/campaignPermissions.js
@@ -35,6 +35,18 @@ function canChangeRoles(role) {
   return role === 'owner';
 }
 
+/**
+ * Whether an actor with `actorRole` may grant `targetRole` to a member.
+ * Only owners may grant the `owner` role — this prevents a manager from
+ * escalating privileges by inviting a brand-new owner. Managers may still
+ * invite managers, editors, and viewers.
+ */
+function canAssignRole(actorRole, targetRole) {
+  if (!isValidRole(targetRole)) return false;
+  if (targetRole === 'owner') return actorRole === 'owner';
+  return canInviteMembers(actorRole);
+}
+
 function canSubmitMilestones(role) {
   return role === 'owner' || role === 'manager';
 }
@@ -53,6 +65,7 @@ module.exports = {
   canManageMembers,
   canInviteMembers,
   canChangeRoles,
+  canAssignRole,
   canSubmitMilestones,
   canDeleteCampaign,
 };

--- a/backend/src/lib/campaignPermissions.test.js
+++ b/backend/src/lib/campaignPermissions.test.js
@@ -1,6 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { isValidRole, canPostUpdates, canEditCampaignContent, canViewAnalytics } = require('../lib/campaignPermissions');
+const { isValidRole, canPostUpdates, canEditCampaignContent, canViewAnalytics, canAssignRole } = require('../lib/campaignPermissions');
 
 test('role helpers enforce manager vs editor capabilities', () => {
   assert.equal(canPostUpdates('manager'), true);
@@ -15,4 +15,24 @@ test('isValidRole accepts all team roles', () => {
     assert.equal(isValidRole(role), true);
   }
   assert.equal(isValidRole('admin'), false);
+});
+
+test('canAssignRole prevents non-owners from granting the owner role', () => {
+  // Only owners may grant owner.
+  assert.equal(canAssignRole('owner', 'owner'), true);
+  assert.equal(canAssignRole('manager', 'owner'), false);
+  assert.equal(canAssignRole('editor', 'owner'), false);
+  assert.equal(canAssignRole('viewer', 'owner'), false);
+
+  // Managers may still invite managers, editors, and viewers.
+  assert.equal(canAssignRole('manager', 'manager'), true);
+  assert.equal(canAssignRole('manager', 'editor'), true);
+  assert.equal(canAssignRole('manager', 'viewer'), true);
+
+  // Editors/viewers cannot invite at all.
+  assert.equal(canAssignRole('editor', 'viewer'), false);
+  assert.equal(canAssignRole('viewer', 'viewer'), false);
+
+  // Invalid target roles are rejected.
+  assert.equal(canAssignRole('owner', 'admin'), false);
 });

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -64,6 +64,7 @@ const {
   canInviteMembers,
   canManageMembers,
   canChangeRoles,
+  canAssignRole,
 } = require('../lib/campaignPermissions');
 const { stripHtml } = require('../lib/sanitize');
 const { getSimhash, simhashSimilarity } = require('../utils/simhash');
@@ -312,6 +313,13 @@ router.get('/', getCampaignsValidation, validateRequest, asyncHandler(async (req
    *                     type: object
    */
   const { search, status, asset, category, min_progress, sort = 'newest' } = req.query;
+  const {
+    min_funding,
+    max_funding,
+    deadline_within,
+    creator_verified,
+    country,
+  } = req.query;
   const limit = Math.min(Number(req.query.limit || 20), 100);
   const offset = Math.max(Number(req.query.offset || 0), 0);
   const filters = [];
@@ -341,6 +349,31 @@ router.get('/', getCampaignsValidation, validateRequest, asyncHandler(async (req
     // Progress is (raised_amount / target_amount) * 100
     filters.push(`(c.raised_amount / c.target_amount) * 100 >= $${params.length}`);
   }
+  // Funding range facet — filter on amount raised so far.
+  if (min_funding !== undefined && min_funding !== '' && Number.isFinite(Number(min_funding))) {
+    params.push(Number(min_funding));
+    filters.push(`c.raised_amount >= $${params.length}`);
+  }
+  if (max_funding !== undefined && max_funding !== '' && Number.isFinite(Number(max_funding))) {
+    params.push(Number(max_funding));
+    filters.push(`c.raised_amount <= $${params.length}`);
+  }
+  // Deadline proximity facet — campaigns ending within N days from now.
+  if (deadline_within !== undefined && deadline_within !== '' && Number.isFinite(Number(deadline_within))) {
+    params.push(Number(deadline_within));
+    filters.push(
+      `c.deadline IS NOT NULL AND c.deadline >= CURRENT_DATE AND c.deadline <= CURRENT_DATE + ($${params.length}::int) * INTERVAL '1 day'`
+    );
+  }
+  // Creator reputation facet — currently backed by KYC verification status.
+  if (creator_verified === 'true' || creator_verified === '1') {
+    filters.push(`u.kyc_status = 'verified'`);
+  }
+  // Geographic location facet.
+  if (country) {
+    params.push(country);
+    filters.push(`c.country = $${params.length}`);
+  }
   let searchParamIdx = null;
   if (search) {
     params.push(search);
@@ -349,7 +382,7 @@ router.get('/', getCampaignsValidation, validateRequest, asyncHandler(async (req
   }
 
   const whereClause = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
-  const countQuery = `SELECT COUNT(*)::int AS total FROM campaigns c ${whereClause}`;
+  const countQuery = `SELECT COUNT(*)::int AS total FROM campaigns c JOIN users u ON u.id = c.creator_id ${whereClause}`;
   const countResult = await db.query(countQuery, params);
   const total = countResult.rows[0]?.total || 0;
 
@@ -404,6 +437,63 @@ router.get('/', getCampaignsValidation, validateRequest, asyncHandler(async (req
 
   res.json({ total, limit, offset, campaigns: result.rows });
 }));
+
+// GET /campaigns/facets — available filter facets with counts for the discovery UI.
+// Computed over the publicly listable, active campaign set so the UI can render
+// faceted controls (categories, assets, countries) and sensible funding bounds.
+router.get('/facets', asyncHandler(async (req, res) => {
+  const baseWhere = `
+    c.deleted_at IS NULL
+    AND c.is_flagged_duplicate = FALSE
+    AND c.is_hidden = FALSE
+    AND c.status = 'active'
+  `;
+
+  const [categories, assets, countries, funding, verified] = await Promise.all([
+    db.query(
+      `SELECT category, COUNT(*)::int AS count
+       FROM campaigns c
+       WHERE ${baseWhere} AND category IS NOT NULL
+       GROUP BY category ORDER BY count DESC`
+    ),
+    db.query(
+      `SELECT asset_type, COUNT(*)::int AS count
+       FROM campaigns c
+       WHERE ${baseWhere}
+       GROUP BY asset_type ORDER BY count DESC`
+    ),
+    db.query(
+      `SELECT country, COUNT(*)::int AS count
+       FROM campaigns c
+       WHERE ${baseWhere} AND country IS NOT NULL
+       GROUP BY country ORDER BY count DESC`
+    ),
+    db.query(
+      `SELECT COALESCE(MIN(raised_amount), 0)::numeric AS min_funding,
+              COALESCE(MAX(raised_amount), 0)::numeric AS max_funding
+       FROM campaigns c
+       WHERE ${baseWhere}`
+    ),
+    db.query(
+      `SELECT COUNT(*)::int AS count
+       FROM campaigns c
+       JOIN users u ON u.id = c.creator_id
+       WHERE ${baseWhere} AND u.kyc_status = 'verified'`
+    ),
+  ]);
+
+  res.json({
+    categories: categories.rows,
+    assets: assets.rows,
+    countries: countries.rows,
+    funding: {
+      min: Number(funding.rows[0]?.min_funding || 0),
+      max: Number(funding.rows[0]?.max_funding || 0),
+    },
+    verified_creators: verified.rows[0]?.count || 0,
+  });
+}));
+
 
 router.get('/mine', requireAuth, asyncHandler(async (req, res) => {
   const { page, limit } = req.query;
@@ -1386,7 +1476,9 @@ router.post('/', requireAuth, requireRole('creator', 'admin'), createCampaignVal
    *       403:
    *         description: Forbidden
    */
-  const { title, description, target_amount, asset_type, deadline, milestones, min_contribution, max_contribution, reward_tiers } = req.body;
+  const { title, description, target_amount, asset_type, deadline, milestones, min_contribution, max_contribution, reward_tiers, country } = req.body;
+  const normalizedCountry =
+    typeof country === 'string' && country.trim() ? country.trim().slice(0, 80) : null;
 
   let normalizedMilestones;
   try {
@@ -1496,14 +1588,14 @@ router.post('/', requireAuth, requireRole('creator', 'admin'), createCampaignVal
          (title, description, target_amount, asset_type, wallet_public_key, creator_id, deadline, 
           min_contribution, max_contribution, escrow_contract_id, milestones_contract_id, platform_fee_bps,
           contract_address, contract_deployed_at, content_fingerprint, is_flagged_duplicate,
-          contract_deployment_status, contract_deployment_error, last_deployment_attempt_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+          contract_deployment_status, contract_deployment_error, last_deployment_attempt_at, country)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
        RETURNING *`,
       [title, description, target_amount, asset_type, wallet.publicKey, req.user.userId, deadline, 
        min_contribution || null, max_contribution || null, escrowContractId, milestonesContractId, platformFeeBps,
        contractAddress, contractDeploymentStatus === 'deployed' ? new Date() : null,
        contentFingerprint, isFlaggedDuplicate,
-       contractDeploymentStatus, contractDeploymentError, new Date()]
+       contractDeploymentStatus, contractDeploymentError, new Date(), normalizedCountry]
     );
     campaign = rows[0];
 
@@ -1643,7 +1735,7 @@ router.post('/:id/tiers', requireAuth, requireCampaignMember('owner'), asyncHand
 // PATCH /campaigns/:id - Update campaign (title, description, deadline)
 router.patch('/:id', requireAuth, asyncHandler(async (req, res) => {
   const campaignId = req.params.id;
-  const { title, description, deadline } = req.body;
+  const { title, description, deadline, country } = req.body;
 
   // Check if campaign exists and belongs to user
   const { rows: campaignRows } = await db.query(
@@ -1719,13 +1811,20 @@ router.patch('/:id', requireAuth, asyncHandler(async (req, res) => {
     updateParams.push(['deadline', deadline, `$${paramIndex++}`]);
   }
 
+  if (country !== undefined) {
+    const normalizedCountry =
+      typeof country === 'string' && country.trim() ? country.trim().slice(0, 80) : null;
+    updates.country = normalizedCountry;
+    updateParams.push(['country', normalizedCountry, `$${paramIndex++}`]);
+  }
+
   // Check if any valid updates were provided
   if (Object.keys(updates).length === 0) {
     return res.status(400).json({ error: 'No valid fields to update' });
   }
 
   // Check for invalid fields in request body
-  const allowedFields = ['title', 'description', 'deadline'];
+  const allowedFields = ['title', 'description', 'deadline', 'country'];
   for (const field of Object.keys(req.body)) {
     if (!allowedFields.includes(field)) {
       return res.status(422).json({
@@ -1840,6 +1939,10 @@ router.post('/:id/members/invite', requireAuth, requireCampaignMember('owner', '
   if (!email || !role) return res.status(422).json({ error: 'Email and role are required' });
   if (!isValidRole(role)) {
     return res.status(422).json({ error: 'Invalid role. Must be owner, manager, editor, or viewer' });
+  }
+  // Never trust the client: only owners may grant the owner role.
+  if (!canAssignRole(req.campaignRole, role)) {
+    return res.status(403).json({ error: 'Only an owner can assign the owner role' });
   }
 
   const { rows: campaignRows } = await db.query('SELECT title FROM campaigns WHERE id = $1', [req.params.id]);

--- a/backend/src/routes/campaigns.test.js
+++ b/backend/src/routes/campaigns.test.js
@@ -450,6 +450,74 @@ test('GET /api/campaigns supports search, asset filter, and sort', async () => {
   assert.ok(listQuery.params.includes('USDC'));
 });
 
+test('GET /api/campaigns applies faceted filters (funding range, deadline, verified, country)', async () => {
+  const queries = [];
+  const app = buildApp({
+    queryImpl: async (text, params) => {
+      queries.push({ text, params });
+      if (text.includes('COUNT(*)')) {
+        return { rows: [{ total: 0 }] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app).get(
+    '/api/campaigns?min_funding=100&max_funding=500&deadline_within=7&creator_verified=true&country=US'
+  );
+
+  assert.equal(response.status, 200);
+  const listQuery = queries.find((q) => q.text.includes('ORDER BY'));
+  assert.ok(listQuery);
+  // Funding range is parameterized against raised_amount.
+  assert.match(listQuery.text, /c\.raised_amount >= \$/);
+  assert.match(listQuery.text, /c\.raised_amount <= \$/);
+  assert.ok(listQuery.params.includes(100));
+  assert.ok(listQuery.params.includes(500));
+  // Deadline proximity uses CURRENT_DATE window.
+  assert.match(listQuery.text, /c\.deadline <= CURRENT_DATE/);
+  assert.ok(listQuery.params.includes(7));
+  // Creator reputation via KYC verification (no injectable param).
+  assert.match(listQuery.text, /u\.kyc_status = 'verified'/);
+  // Geographic facet parameterized.
+  assert.match(listQuery.text, /c\.country = \$/);
+  assert.ok(listQuery.params.includes('US'));
+  // Count query must also join users so the verified filter resolves.
+  const countQuery = queries.find((q) => q.text.includes('COUNT(*)'));
+  assert.match(countQuery.text, /JOIN users u/);
+});
+
+test('GET /api/campaigns/facets returns facet counts and funding bounds', async () => {
+  const app = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('GROUP BY category')) {
+        return { rows: [{ category: 'technology', count: 3 }] };
+      }
+      if (text.includes('GROUP BY asset_type')) {
+        return { rows: [{ asset_type: 'USDC', count: 5 }] };
+      }
+      if (text.includes('GROUP BY country')) {
+        return { rows: [{ country: 'US', count: 2 }] };
+      }
+      if (text.includes('MIN(raised_amount)')) {
+        return { rows: [{ min_funding: '0', max_funding: '900' }] };
+      }
+      if (text.includes("kyc_status = 'verified'")) {
+        return { rows: [{ count: 4 }] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app).get('/api/campaigns/facets');
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.body.categories, [{ category: 'technology', count: 3 }]);
+  assert.deepEqual(response.body.assets, [{ asset_type: 'USDC', count: 5 }]);
+  assert.deepEqual(response.body.countries, [{ country: 'US', count: 2 }]);
+  assert.equal(response.body.funding.max, 900);
+  assert.equal(response.body.verified_creators, 4);
+});
+
 test('GET /api/campaigns/mine parses page and limit parameters', async () => {
   let passedOptions = {};
   const app = buildApp({

--- a/backend/src/routes/contributions.js
+++ b/backend/src/routes/contributions.js
@@ -40,6 +40,7 @@ const { assertUserKycVerified } = require('../services/kycService');
 const asyncHandler = require('../utils/asyncHandler');
 const { getReferralCodeFromRequest } = require('../services/referralService');
 const { reserveTierSlot } = require('../services/rewardTierService');
+const { hashDeviceFingerprint } = require('../utils/deviceFingerprint');
 
 const SUPPORTED_ASSETS = getSupportedAssetCodes();
 const PREPARED_CONTRIBUTION_EXPIRES_IN = '10m';
@@ -437,7 +438,7 @@ router.post('/prepare', requireAuth, contributionValidation, validateRequest, as
       campaign_id,
       sender_public_key,
       unsigned_xdr: unsignedXdr,
-      flow_metadata: { ...withReferralMetadata(intent.flowMetadata, campaign_id, req), ip_address: req.ip },
+      flow_metadata: { ...withReferralMetadata(intent.flowMetadata, campaign_id, req), ip_address: req.ip, device_fingerprint: hashDeviceFingerprint(req.body.device_fingerprint) },
       conversion_quote: intent.conversionQuote,
     });
 
@@ -660,6 +661,7 @@ router.post('/', contributionPostLimiter, requireAuth, contributionValidation, v
       displayName: display_name,
       referralCode: getReferralCodeFromRequest(campaign_id, req),
       ipAddress: req.ip,
+      deviceFingerprint: hashDeviceFingerprint(req.body.device_fingerprint),
       client,
       tierId: reservedTier ? reservedTier.id : null,
     });

--- a/backend/src/services/contributionService.js
+++ b/backend/src/services/contributionService.js
@@ -87,6 +87,7 @@ async function submitCustodialContribution({
   displayName,
   referralCode,
   ipAddress,
+  deviceFingerprint,
   client,
   tierId,
 }) {
@@ -146,6 +147,7 @@ async function submitCustodialContribution({
   const metadata = {
     ...intent.flowMetadata,
     ip_address: ipAddress || null,
+    device_fingerprint: deviceFingerprint || null,
     tier_id: tierId || null,
     ...(referralCode ? { referral_code: referralCode } : {}),
     ...(anchorMetadata

--- a/backend/src/services/fraudService.js
+++ b/backend/src/services/fraudService.js
@@ -27,6 +27,13 @@ async function evaluateCampaign(campaignId, dbClient = db) {
   const FRAUD_WEIGHT_SINGLE_WALLET = getTunable('FRAUD_WEIGHT_SINGLE_WALLET', 35);
   const FRAUD_THRESHOLD_SINGLE_WALLET_PCT = getTunable('FRAUD_THRESHOLD_SINGLE_WALLET_PCT', 0.50); // 50%
 
+  const FRAUD_WEIGHT_SAME_DEVICE = getTunable('FRAUD_WEIGHT_SAME_DEVICE', 25);
+  const FRAUD_THRESHOLD_SAME_DEVICE = getTunable('FRAUD_THRESHOLD_SAME_DEVICE', 3);
+  const FRAUD_WINDOW_SAME_DEVICE_MS = getTunable('FRAUD_WINDOW_SAME_DEVICE_MS', 24 * 60 * 60 * 1000); // 24h
+
+  const FRAUD_WEIGHT_DEVICE_CLUSTER = getTunable('FRAUD_WEIGHT_DEVICE_CLUSTER', 45);
+  const FRAUD_THRESHOLD_DEVICE_CLUSTER = getTunable('FRAUD_THRESHOLD_DEVICE_CLUSTER', 3); // other campaigns
+
   const FRAUD_THRESHOLD = getTunable('FRAUD_THRESHOLD', 50);
   const FRAUD_AUTO_PAUSE_THRESHOLD = getTunable('FRAUD_AUTO_PAUSE_THRESHOLD', 80);
   const FRAUD_AUTO_PAUSE_ENABLED = getTunable('FRAUD_AUTO_PAUSE_ENABLED', 'true') === 'true';
@@ -51,6 +58,10 @@ async function evaluateCampaign(campaignId, dbClient = db) {
     let velocityDetails = 'Velocity within normal bounds or insufficient history.';
     let singleWalletScore = 0;
     let singleWalletDetails = 'No single wallet exceeds the limit.';
+    let sameDeviceScore = 0;
+    let sameDeviceDetails = 'No suspicious device patterns detected.';
+    let deviceClusterScore = 0;
+    let deviceClusterDetails = 'No coordinated device cluster detected.';
 
     // Signal 1: Multiple contributions from the same IP
     const { rows: sameIpRows } = await dbClient.query(
@@ -136,12 +147,68 @@ async function evaluateCampaign(campaignId, dbClient = db) {
       }
     }
 
-    const totalScore = sameIpScore + walletAgeScore + velocityScore + singleWalletScore;
+    // Signal 5: Multiple contributions from the same device fingerprint
+    const { rows: sameDeviceRows } = await dbClient.query(
+      `SELECT device_fingerprint, COUNT(*)::int AS count
+       FROM contributions
+       WHERE campaign_id = $1 AND device_fingerprint IS NOT NULL
+         AND created_at >= NOW() - CAST($2 || ' milliseconds' AS INTERVAL)
+       GROUP BY device_fingerprint
+       HAVING COUNT(*) > $3`,
+      [campaignId, FRAUD_WINDOW_SAME_DEVICE_MS, FRAUD_THRESHOLD_SAME_DEVICE]
+    );
+    if (sameDeviceRows.length > 0) {
+      let totalOver = 0;
+      const detailsArray = [];
+      for (const row of sameDeviceRows) {
+        const overLimit = row.count - FRAUD_THRESHOLD_SAME_DEVICE;
+        totalOver += overLimit;
+        // Only expose a short, non-reversible prefix — never the full hashed fingerprint.
+        detailsArray.push(`Device ${row.device_fingerprint.slice(0, 8)}… sent ${row.count} contributions`);
+      }
+      sameDeviceScore = totalOver * FRAUD_WEIGHT_SAME_DEVICE;
+      sameDeviceDetails = detailsArray.join(', ');
+    }
+
+    // Signal 6: Coordinated device cluster — a device funding this campaign is also
+    // active across several other campaigns (a hallmark of coordinated abuse).
+    const { rows: deviceClusterRows } = await dbClient.query(
+      `SELECT d.device_fingerprint, COUNT(DISTINCT other.campaign_id)::int AS other_campaigns
+       FROM (
+         SELECT DISTINCT device_fingerprint
+         FROM contributions
+         WHERE campaign_id = $1 AND device_fingerprint IS NOT NULL
+       ) d
+       JOIN contributions other
+         ON other.device_fingerprint = d.device_fingerprint
+        AND other.campaign_id <> $1
+       GROUP BY d.device_fingerprint
+       HAVING COUNT(DISTINCT other.campaign_id) >= $2`,
+      [campaignId, FRAUD_THRESHOLD_DEVICE_CLUSTER]
+    );
+    if (deviceClusterRows.length > 0) {
+      deviceClusterScore = FRAUD_WEIGHT_DEVICE_CLUSTER;
+      const worst = deviceClusterRows.reduce(
+        (max, row) => (row.other_campaigns > max.other_campaigns ? row : max),
+        deviceClusterRows[0]
+      );
+      deviceClusterDetails = `${deviceClusterRows.length} device(s) shared with other campaigns; one device also funded ${worst.other_campaigns} other campaign(s).`;
+    }
+
+    const totalScore =
+      sameIpScore +
+      walletAgeScore +
+      velocityScore +
+      singleWalletScore +
+      sameDeviceScore +
+      deviceClusterScore;
     const signals = {
       same_ip: { score: sameIpScore, detail: sameIpDetails },
       wallet_age: { score: walletAgeScore, detail: walletAgeDetails },
       velocity: { score: velocityScore, detail: velocityDetails },
       single_wallet: { score: singleWalletScore, detail: singleWalletDetails },
+      same_device: { score: sameDeviceScore, detail: sameDeviceDetails },
+      device_cluster: { score: deviceClusterScore, detail: deviceClusterDetails },
     };
 
     const isHighRisk = totalScore >= FRAUD_THRESHOLD;

--- a/backend/src/services/fraudService.test.js
+++ b/backend/src/services/fraudService.test.js
@@ -174,4 +174,99 @@ describe('FraudService', () => {
     assert.ok(updateQueryCalled);
     assert.ok(alertsSent);
   });
+
+  test('evaluateCampaign scores same-device clustering signal', async () => {
+    let capturedSignals = null;
+    const dbMock = {
+      query: async (text, params) => {
+        if (text.includes('SELECT') && text.includes('target_amount') && text.includes('campaigns')) {
+          return {
+            rows: [{
+              id: 'campaign-3',
+              title: 'Device Cluster Campaign',
+              target_amount: 1000,
+              raised_amount: 100,
+              created_at: new Date(Date.now() - 10 * 3600 * 1000).toISOString(),
+              status: 'active',
+              is_flagged_fraud: false,
+            }],
+          };
+        }
+        if (text.includes('ip_address') && text.includes('HAVING COUNT(*)')) return { rows: [] };
+        if (text.includes('JOIN users')) return { rows: [{ count: 0 }] };
+        if (text.includes('COALESCE(SUM(amount)')) return { rows: [{ window_amount: 0 }] };
+        if (text.includes('SUM(amount)') && text.includes('GROUP BY sender_public_key')) {
+          return { rows: [{ sender_public_key: 'G1', total_amount: 100 }] };
+        }
+        // Signal 5: one device with 5 contributions (5 - 3 = 2 over) -> 2 * 25 = 50
+        if (text.includes('device_fingerprint') && text.includes('HAVING COUNT(*)')) {
+          return { rows: [{ device_fingerprint: 'abcdef1234567890', count: 5 }] };
+        }
+        // Signal 6: no cross-campaign cluster
+        if (text.includes('COUNT(DISTINCT other.campaign_id)')) {
+          return { rows: [] };
+        }
+        if (text.includes('UPDATE campaigns')) {
+          capturedSignals = JSON.parse(params[2]);
+          return { rows: [] };
+        }
+        return { rows: [] };
+      },
+    };
+
+    const fraudService = buildFraudService({ db: dbMock });
+    const result = await fraudService.evaluateCampaign('campaign-3');
+
+    assert.strictEqual(result.score, 50);
+    assert.strictEqual(result.is_flagged_fraud, true); // 50 >= FRAUD_THRESHOLD
+    assert.strictEqual(result.auto_suspended, false); // 50 < auto-pause 80
+    assert.strictEqual(capturedSignals.same_device.score, 50);
+    // Fingerprint must never be exposed in full; only a short prefix appears.
+    assert.ok(!capturedSignals.same_device.detail.includes('abcdef1234567890'));
+    assert.ok(capturedSignals.same_device.detail.includes('abcdef12'));
+  });
+
+  test('evaluateCampaign scores coordinated device-cluster signal across campaigns', async () => {
+    let capturedSignals = null;
+    const dbMock = {
+      query: async (text, params) => {
+        if (text.includes('SELECT') && text.includes('target_amount') && text.includes('campaigns')) {
+          return {
+            rows: [{
+              id: 'campaign-4',
+              title: 'Coordinated Campaign',
+              target_amount: 1000,
+              raised_amount: 100,
+              created_at: new Date(Date.now() - 10 * 3600 * 1000).toISOString(),
+              status: 'active',
+              is_flagged_fraud: false,
+            }],
+          };
+        }
+        if (text.includes('ip_address') && text.includes('HAVING COUNT(*)')) return { rows: [] };
+        if (text.includes('JOIN users')) return { rows: [{ count: 0 }] };
+        if (text.includes('COALESCE(SUM(amount)')) return { rows: [{ window_amount: 0 }] };
+        if (text.includes('SUM(amount)') && text.includes('GROUP BY sender_public_key')) {
+          return { rows: [{ sender_public_key: 'G1', total_amount: 100 }] };
+        }
+        if (text.includes('device_fingerprint') && text.includes('HAVING COUNT(*)')) return { rows: [] };
+        // Signal 6: device active across 4 other campaigns -> flat weight 45
+        if (text.includes('COUNT(DISTINCT other.campaign_id)')) {
+          return { rows: [{ device_fingerprint: 'deadbeefcafebabe', other_campaigns: 4 }] };
+        }
+        if (text.includes('UPDATE campaigns')) {
+          capturedSignals = JSON.parse(params[2]);
+          return { rows: [] };
+        }
+        return { rows: [] };
+      },
+    };
+
+    const fraudService = buildFraudService({ db: dbMock });
+    const result = await fraudService.evaluateCampaign('campaign-4');
+
+    assert.strictEqual(capturedSignals.device_cluster.score, 45);
+    assert.ok(capturedSignals.device_cluster.detail.includes('4 other campaign'));
+    assert.strictEqual(result.score, 45);
+  });
 });

--- a/backend/src/services/ledgerMonitor.js
+++ b/backend/src/services/ledgerMonitor.js
@@ -238,14 +238,15 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
     const displayName = submittedRows[0]?.metadata?.display_name || null;
     const referralCode = submittedRows[0]?.metadata?.referral_code || null;
     const ipAddress = submittedRows[0]?.metadata?.ip_address || null;
+    const deviceFingerprint = submittedRows[0]?.metadata?.device_fingerprint || null;
     const reservedTierId = submittedRows[0]?.metadata?.tier_id || null;
 
     const { rows: inserted } = await client.query(
       `INSERT INTO contributions
          (campaign_id, sender_public_key, amount, asset, anchor_id, anchor_transaction_id,
           anchor_asset, anchor_amount, payment_type, source_amount, source_asset,
-          conversion_rate, path, tx_hash, platform_fee_amount, display_name, ip_address)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14, $15, $16, $17)
+          conversion_rate, path, tx_hash, platform_fee_amount, display_name, ip_address, device_fingerprint)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14, $15, $16, $17, $18)
        RETURNING id`,
       [
         campaignId,
@@ -265,6 +266,7 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
         platformFeeAmount,
         displayName,
         ipAddress,
+        deviceFingerprint,
       ],
     );
 

--- a/backend/src/utils/deviceFingerprint.js
+++ b/backend/src/utils/deviceFingerprint.js
@@ -1,0 +1,56 @@
+const crypto = require('crypto');
+
+/**
+ * Device fingerprinting helpers for fraud detection (#595).
+ *
+ * Privacy/security notes:
+ *  - The client sends an already-opaque fingerprint hash (see the frontend
+ *    deviceFingerprint helper). We never receive nor store raw device
+ *    identifiers here.
+ *  - We additionally apply a keyed HMAC with a server-side pepper before
+ *    persisting, so a database leak cannot be correlated back to a device
+ *    without the pepper. The HMAC is deterministic, which is what lets us
+ *    cluster contributions from the same device.
+ *  - The hashed value must never be logged; treat it like other PII.
+ */
+
+const MAX_RAW_LENGTH = 512;
+const FINGERPRINT_PATTERN = /^[a-f0-9]{16,128}$/i;
+
+function getPepper() {
+  return (
+    process.env.DEVICE_FINGERPRINT_PEPPER ||
+    process.env.API_KEY_PEPPER ||
+    process.env.JWT_SECRET ||
+    ''
+  );
+}
+
+/**
+ * Validate and normalize a client-supplied device fingerprint.
+ * Returns null when absent or malformed (fingerprinting is best-effort and
+ * must never block a legitimate contribution).
+ */
+function normalizeClientFingerprint(raw) {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed || trimmed.length > MAX_RAW_LENGTH) return null;
+  if (!FINGERPRINT_PATTERN.test(trimmed)) return null;
+  return trimmed;
+}
+
+/**
+ * Produce the salted, non-reversible fingerprint that is safe to store.
+ * @param {string} raw - opaque fingerprint hash from the client
+ * @returns {string|null} hex HMAC or null when input is unusable
+ */
+function hashDeviceFingerprint(raw) {
+  const normalized = normalizeClientFingerprint(raw);
+  if (!normalized) return null;
+  return crypto.createHmac('sha256', getPepper()).update(normalized).digest('hex');
+}
+
+module.exports = {
+  hashDeviceFingerprint,
+  normalizeClientFingerprint,
+};

--- a/backend/src/utils/deviceFingerprint.test.js
+++ b/backend/src/utils/deviceFingerprint.test.js
@@ -1,0 +1,56 @@
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env.DEVICE_FINGERPRINT_PEPPER = 'test-device-pepper';
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+function load() {
+  delete require.cache[require.resolve('./deviceFingerprint')];
+  return require('./deviceFingerprint');
+}
+
+describe('deviceFingerprint util', () => {
+  test('rejects malformed or empty fingerprints', () => {
+    const { hashDeviceFingerprint } = load();
+    assert.strictEqual(hashDeviceFingerprint(''), null);
+    assert.strictEqual(hashDeviceFingerprint(null), null);
+    assert.strictEqual(hashDeviceFingerprint(undefined), null);
+    assert.strictEqual(hashDeviceFingerprint('short'), null); // < 16 chars
+    assert.strictEqual(hashDeviceFingerprint('not-hex-value!!!!'), null);
+    assert.strictEqual(hashDeviceFingerprint('a'.repeat(600)), null); // too long
+  });
+
+  test('produces a deterministic, non-reversible salted hash', () => {
+    const { hashDeviceFingerprint } = load();
+    const raw = 'a1b2c3d4e5f60718293a4b5c6d7e8f90';
+    const first = hashDeviceFingerprint(raw);
+    const second = hashDeviceFingerprint(raw);
+    assert.strictEqual(first, second, 'same input must yield same hash for clustering');
+    assert.match(first, /^[a-f0-9]{64}$/, 'output is a hex sha256 digest');
+    assert.notStrictEqual(first, raw, 'raw fingerprint is never stored');
+  });
+
+  test('is case-insensitive on the raw input', () => {
+    const { hashDeviceFingerprint } = load();
+    const lower = hashDeviceFingerprint('abcdef1234567890');
+    const upper = hashDeviceFingerprint('ABCDEF1234567890');
+    assert.strictEqual(lower, upper);
+  });
+
+  test('different peppers yield different hashes for the same fingerprint', () => {
+    let mod = load();
+    const raw = 'a1b2c3d4e5f60718293a4b5c6d7e8f90';
+    const withFirstPepper = mod.hashDeviceFingerprint(raw);
+    process.env.DEVICE_FINGERPRINT_PEPPER = 'a-different-pepper';
+    mod = load();
+    const withSecondPepper = mod.hashDeviceFingerprint(raw);
+    assert.notStrictEqual(withFirstPepper, withSecondPepper);
+  });
+});

--- a/frontend/src/components/ContributeModal.jsx
+++ b/frontend/src/components/ContributeModal.jsx
@@ -8,6 +8,7 @@ import {
 } from '@stellar/freighter-api';
 import { useAuth } from '../context/AuthContext';
 import { api } from '../services/api';
+import { getDeviceFingerprint } from '../lib/deviceFingerprint';
 import { stellarExpertTxUrl } from '../config/stellar';
 import KycPrompt from './KycPrompt';
 
@@ -343,12 +344,14 @@ export default function ContributeModal({
 
   async function submitWithCustodial() {
     setLoadingLabel('Submitting with CrowdPay wallet…');
+    const device_fingerprint = await getDeviceFingerprint();
     return api.contribute(
       {
         campaign_id: campaign.id,
         amount: destAmount,
         send_asset: sendAsset,
         display_name: displayName.trim() || undefined,
+        device_fingerprint: device_fingerprint || undefined,
         idempotency_key: activeSubmissionKeyRef.current,
       },
       token
@@ -367,6 +370,7 @@ export default function ContributeModal({
     }
 
     setLoadingLabel('Preparing transaction…');
+    const device_fingerprint = await getDeviceFingerprint();
     const prepared = await api.prepareContribution(
       {
         campaign_id: campaign.id,
@@ -374,6 +378,7 @@ export default function ContributeModal({
         send_asset: sendAsset,
         sender_public_key: signerAddress,
         display_name: displayName.trim() || undefined,
+        device_fingerprint: device_fingerprint || undefined,
         idempotency_key: activeSubmissionKeyRef.current,
       },
       token

--- a/frontend/src/lib/deviceFingerprint.js
+++ b/frontend/src/lib/deviceFingerprint.js
@@ -1,0 +1,111 @@
+/**
+ * Privacy-conscious device fingerprinting for fraud detection (#595).
+ *
+ * We deliberately collect only coarse, non-identifying signals that are already
+ * exposed to any web page (screen geometry, timezone, language, a canvas hash,
+ * etc.). No cookies, no persistent identifiers, no PII. The collected signals
+ * are hashed in the browser with SHA-256 so only an opaque digest ever leaves
+ * the device. The server salts this digest again before storing it.
+ *
+ * The result is cached in-memory for the page lifetime and, best-effort, in
+ * sessionStorage so repeated contributions in one session reuse the same value
+ * without recomputing.
+ */
+
+const CACHE_KEY = 'cp_device_fp';
+let inMemoryCache = null;
+
+function safe(fn, fallback = '') {
+  try {
+    const value = fn();
+    return value === undefined || value === null ? fallback : value;
+  } catch {
+    return fallback;
+  }
+}
+
+function canvasSignal() {
+  return safe(() => {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return '';
+    ctx.textBaseline = 'top';
+    ctx.font = "14px 'Arial'";
+    ctx.fillStyle = '#f60';
+    ctx.fillRect(125, 1, 62, 20);
+    ctx.fillStyle = '#069';
+    ctx.fillText('CrowdPay:fp:1', 2, 15);
+    ctx.fillStyle = 'rgba(102, 204, 0, 0.7)';
+    ctx.fillText('CrowdPay:fp:1', 4, 17);
+    return canvas.toDataURL();
+  });
+}
+
+function collectComponents() {
+  const nav = typeof navigator !== 'undefined' ? navigator : {};
+  const scr = typeof window !== 'undefined' && window.screen ? window.screen : {};
+  return [
+    safe(() => nav.userAgent),
+    safe(() => (Array.isArray(nav.languages) ? nav.languages.join(',') : nav.language)),
+    safe(() => nav.platform),
+    safe(() => String(nav.hardwareConcurrency)),
+    safe(() => String(nav.deviceMemory)),
+    safe(() => String(nav.maxTouchPoints)),
+    safe(() => `${scr.width}x${scr.height}x${scr.colorDepth}`),
+    safe(() => String(window.devicePixelRatio)),
+    safe(() => Intl.DateTimeFormat().resolvedOptions().timeZone),
+    safe(() => String(new Date().getTimezoneOffset())),
+    canvasSignal(),
+  ].join('||');
+}
+
+async function sha256Hex(input) {
+  const cryptoObj = typeof window !== 'undefined' ? window.crypto : undefined;
+  const subtle = cryptoObj && cryptoObj.subtle;
+  const bytes = new window.TextEncoder().encode(input);
+  if (subtle) {
+    const digest = await subtle.digest('SHA-256', bytes);
+    return Array.from(new Uint8Array(digest))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+  // Fallback: FNV-1a expanded to a 64-hex-char string (non-secure contexts only).
+  let h1 = 0x811c9dc5;
+  let h2 = 0x811c9dc5 ^ 0x1234;
+  for (let i = 0; i < input.length; i += 1) {
+    h1 = Math.imul(h1 ^ input.charCodeAt(i), 0x01000193) >>> 0;
+    h2 = Math.imul(h2 ^ input.charCodeAt(input.length - 1 - i), 0x01000193) >>> 0;
+  }
+  return (h1.toString(16).padStart(8, '0') + h2.toString(16).padStart(8, '0')).repeat(4).slice(0, 64);
+}
+
+/**
+ * Returns an opaque, stable device fingerprint digest for the current browser.
+ * Never throws — resolves to null if fingerprinting is unavailable.
+ * @returns {Promise<string|null>}
+ */
+export async function getDeviceFingerprint() {
+  if (inMemoryCache) return inMemoryCache;
+  try {
+    const cached = window.sessionStorage?.getItem(CACHE_KEY);
+    if (cached && /^[a-f0-9]{16,128}$/i.test(cached)) {
+      inMemoryCache = cached;
+      return cached;
+    }
+  } catch {
+    /* sessionStorage may be unavailable (private mode) — ignore */
+  }
+
+  try {
+    const digest = await sha256Hex(collectComponents());
+    inMemoryCache = digest;
+    try {
+      window.sessionStorage?.setItem(CACHE_KEY, digest);
+    } catch {
+      /* best-effort cache only */
+    }
+    return digest;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -1927,6 +1927,30 @@ export default function Campaign() {
           {activeTab !== 'analytics' && (
             <>
               <h2 style={styles.sectionTitle}>Team</h2>
+              <div
+                className="campaign-card"
+                style={{ marginBottom: '1.5rem', fontSize: '0.85rem' }}
+              >
+                <strong style={{ display: 'block', marginBottom: '0.5rem' }}>
+                  Role permissions
+                </strong>
+                <ul style={{ margin: 0, paddingLeft: '1.1rem', color: 'var(--color-text-hint)' }}>
+                  <li>
+                    <strong>Owner</strong> — full control: manage team, assign roles (including
+                    owner), edit content, post updates, withdraw funds.
+                  </li>
+                  <li>
+                    <strong>Manager</strong> — invite members, post updates, submit milestones, view
+                    analytics.
+                  </li>
+                  <li>
+                    <strong>Editor</strong> — edit campaign content.
+                  </li>
+                  <li>
+                    <strong>Viewer</strong> — read-only access to analytics.
+                  </li>
+                </ul>
+              </div>
               <div className="campaign-card" style={{ marginBottom: '1.5rem' }}>
                 <strong style={{ marginBottom: '0.75rem', display: 'block' }}>
                   Invite Team Member

--- a/frontend/src/pages/CreateCampaign.jsx
+++ b/frontend/src/pages/CreateCampaign.jsx
@@ -65,6 +65,7 @@ export default function CreateCampaign() {
     asset_type: location.state?.prefill?.asset_type || 'USDC',
     deadline: '',
     category: '',
+    country: '',
     min_contribution: location.state?.prefill?.min_contribution || '',
     max_contribution: location.state?.prefill?.max_contribution || '',
     max_per_user: location.state?.prefill?.max_per_user || '',
@@ -200,6 +201,7 @@ export default function CreateCampaign() {
       asset_type: 'USDC',
       deadline: '',
       category: '',
+      country: '',
       min_contribution: '',
       max_contribution: '',
       max_per_user: '',
@@ -481,6 +483,7 @@ export default function CreateCampaign() {
         asset_type: form.asset_type,
         deadline: formattedDeadline,
         category: form.category || undefined,
+        country: form.country?.trim() || undefined,
         min_contribution: form.min_contribution ? Number(form.min_contribution) : undefined,
         max_contribution: form.max_contribution ? Number(form.max_contribution) : undefined,
         max_per_user: form.max_per_user ? Number(form.max_per_user) : undefined,
@@ -816,6 +819,23 @@ export default function CreateCampaign() {
                   </option>
                 ))}
               </select>
+            </div>
+
+            <div className="form-group" style={{ marginTop: '1rem' }}>
+              <label className="label-strong" htmlFor="cc-country">
+                Location{' '}
+                <span style={{ fontWeight: 500, color: 'var(--color-text-muted)' }}>
+                  (optional)
+                </span>
+              </label>
+              <input
+                id="cc-country"
+                type="text"
+                value={form.country}
+                onChange={setField('country')}
+                placeholder="e.g. United States, Kenya, Global"
+                maxLength={80}
+              />
             </div>
 
             {error && (

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -45,6 +45,7 @@ export default function Home() {
   const [searchInput, setSearchInput] = useState(() => searchParams.get('search') || '');
   const [sort, setSort] = useState(() => searchParams.get('sort') || 'newest');
   const [categoryCounts, setCategoryCounts] = useState([]);
+  const [facets, setFacets] = useState(null);
   const [featured, setFeatured] = useState([]);
   const [recentlyViewed, setRecentlyViewed] = useState([]);
   const [recommended, setRecommended] = useState([]);
@@ -54,6 +55,11 @@ export default function Home() {
   const asset = searchParams.get('asset') || '';
   const category = searchParams.get('category') || '';
   const minProgress = searchParams.get('min_progress') || '';
+  const minFunding = searchParams.get('min_funding') || '';
+  const maxFunding = searchParams.get('max_funding') || '';
+  const deadlineWithin = searchParams.get('deadline_within') || '';
+  const creatorVerified = searchParams.get('creator_verified') || '';
+  const country = searchParams.get('country') || '';
 
   const limit = Number(searchParams.get('limit') || 20);
   const offset = Number(searchParams.get('offset') || 0);
@@ -76,6 +82,11 @@ export default function Home() {
     Boolean(asset) ||
     Boolean(status) ||
     Boolean(category) ||
+    Boolean(minFunding) ||
+    Boolean(maxFunding) ||
+    Boolean(deadlineWithin) ||
+    Boolean(creatorVerified) ||
+    Boolean(country) ||
     sort !== 'newest';
 
   useEffect(() => {
@@ -85,6 +96,10 @@ export default function Home() {
     api
       .getCampaignCategories()
       .then(setCategoryCounts)
+      .catch(() => {});
+    api
+      .getCampaignFacets()
+      .then(setFacets)
       .catch(() => {});
     api
       .getFeaturedCampaigns()
@@ -131,7 +146,21 @@ export default function Home() {
     setListError('');
     setLoading(true);
     api
-      .getCampaigns({ search, status, asset, category, min_progress: minProgress, sort, limit, offset })
+      .getCampaigns({
+        search,
+        status,
+        asset,
+        category,
+        min_progress: minProgress,
+        min_funding: minFunding,
+        max_funding: maxFunding,
+        deadline_within: deadlineWithin,
+        creator_verified: creatorVerified,
+        country,
+        sort,
+        limit,
+        offset,
+      })
       .then((data) => {
         const nextCampaigns = data.campaigns || [];
         const nextTotal = data.total || 0;
@@ -142,7 +171,7 @@ export default function Home() {
       })
       .catch((err) => setListError(err.message || t('home.loadingCampaigns')))
       .finally(() => setLoading(false));
-  }, [search, status, asset, category, sort]);
+  }, [search, status, asset, category, minProgress, minFunding, maxFunding, deadlineWithin, creatorVerified, country, sort]);
 
   async function loadMore() {
     if (loadingMore || !hasMore || paginationRequestRef.current) return;
@@ -158,6 +187,12 @@ export default function Home() {
         status,
         asset,
         category,
+        min_progress: minProgress,
+        min_funding: minFunding,
+        max_funding: maxFunding,
+        deadline_within: deadlineWithin,
+        creator_verified: creatorVerified,
+        country,
         sort,
         limit: 20,
         offset: page * 20,
@@ -386,6 +421,73 @@ export default function Home() {
           />
         </label>
         <label style={styles.filterItem}>
+          Min Raised
+          <input
+            type="number"
+            min="0"
+            value={minFunding}
+            onChange={(e) => setFilters({ min_funding: e.target.value })}
+            placeholder={facets ? `${facets.funding?.min ?? 0}` : 'e.g. 100'}
+            style={styles.filterInput}
+            aria-label="Minimum amount raised"
+          />
+        </label>
+        <label style={styles.filterItem}>
+          Max Raised
+          <input
+            type="number"
+            min="0"
+            value={maxFunding}
+            onChange={(e) => setFilters({ max_funding: e.target.value })}
+            placeholder={facets ? `${facets.funding?.max ?? 0}` : 'e.g. 5000'}
+            style={styles.filterInput}
+            aria-label="Maximum amount raised"
+          />
+        </label>
+        <label style={styles.filterItem}>
+          Ending Within
+          <select
+            value={deadlineWithin}
+            onChange={(e) => setFilters({ deadline_within: e.target.value })}
+            style={styles.filterInput}
+            aria-label="Deadline proximity"
+          >
+            <option value="">Any time</option>
+            <option value="3">3 days</option>
+            <option value="7">7 days</option>
+            <option value="14">14 days</option>
+            <option value="30">30 days</option>
+          </select>
+        </label>
+        {facets?.countries?.length > 0 && (
+          <label style={styles.filterItem}>
+            Location
+            <select
+              value={country}
+              onChange={(e) => setFilters({ country: e.target.value })}
+              style={styles.filterInput}
+              aria-label="Geographic location"
+            >
+              <option value="">Anywhere</option>
+              {facets.countries.map((c) => (
+                <option key={c.country} value={c.country}>
+                  {c.country} ({c.count})
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+        <label style={{ ...styles.filterItem, flexDirection: 'row', alignItems: 'center', gap: '0.4rem' }}>
+          <input
+            type="checkbox"
+            checked={creatorVerified === 'true'}
+            onChange={(e) => setFilters({ creator_verified: e.target.checked ? 'true' : '' })}
+            aria-label="Only verified creators"
+          />
+          Verified creators only
+          {typeof facets?.verified_creators === 'number' && ` (${facets.verified_creators})`}
+        </label>
+        <label style={styles.filterItem}>
           Sort by
           {t('home.sortLabel')}
           <select
@@ -402,7 +504,7 @@ export default function Home() {
         </label>
       </div>
 
-      {(search || status || asset || category || minProgress) && (
+      {(search || status || asset || category || minProgress || minFunding || maxFunding || deadlineWithin || creatorVerified || country) && (
         <div style={styles.activeFilters}>
           {search && (
             <button className="filter-chip" onClick={() => setFilters({ search: '' })}>
@@ -427,6 +529,31 @@ export default function Home() {
           {minProgress && (
             <button className="filter-chip" onClick={() => setFilters({ min_progress: '' })}>
               Min Progress: {minProgress}% ✕
+            </button>
+          )}
+          {minFunding && (
+            <button className="filter-chip" onClick={() => setFilters({ min_funding: '' })}>
+              Min Raised: {minFunding} ✕
+            </button>
+          )}
+          {maxFunding && (
+            <button className="filter-chip" onClick={() => setFilters({ max_funding: '' })}>
+              Max Raised: {maxFunding} ✕
+            </button>
+          )}
+          {deadlineWithin && (
+            <button className="filter-chip" onClick={() => setFilters({ deadline_within: '' })}>
+              Ending within: {deadlineWithin}d ✕
+            </button>
+          )}
+          {creatorVerified === 'true' && (
+            <button className="filter-chip" onClick={() => setFilters({ creator_verified: '' })}>
+              Verified creators ✕
+            </button>
+          )}
+          {country && (
+            <button className="filter-chip" onClick={() => setFilters({ country: '' })}>
+              Location: {country} ✕
             </button>
           )}
         </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -369,6 +369,7 @@ export const api = {
   getMyCampaigns: (options = {}) => request('GET', '/campaigns/mine', null, { query: options }),
   getFeaturedCampaigns: () => request('GET', '/campaigns/featured'),
   getCampaignCategories: () => request('GET', '/campaigns/categories'),
+  getCampaignFacets: () => request('GET', '/campaigns/facets'),
   getCampaigns: (options = {}) => request('GET', '/campaigns', null, { query: options }),
   getCampaign: (id, options = {}) => request('GET', `/campaigns/${id}`, null, { query: options }),
   getCampaignAnalytics: (id) => request('GET', `/campaigns/${id}/analytics`),

--- a/frontend/src/test/pages/Home.test.jsx
+++ b/frontend/src/test/pages/Home.test.jsx
@@ -6,6 +6,7 @@ import { renderWithProviders } from '../renderWithProviders';
 const apiMocks = vi.hoisted(() => ({
   getCampaignCategories: vi.fn().mockResolvedValue([]),
   getFeaturedCampaigns: vi.fn().mockResolvedValue([]),
+  getCampaignFacets: vi.fn().mockResolvedValue({ categories: [], assets: [], countries: [], funding: { min: 0, max: 0 }, verified_creators: 0 }),
   getCampaigns: vi.fn().mockResolvedValue({ campaigns: [{ id: '1', title: 'Test campaign', status: 'active', target_amount: '100', asset_type: 'USDC' }], total: 1 }),
   getCampaign: vi.fn().mockResolvedValue({}),
 }));


### PR DESCRIPTION
This PR implements three feature issues on a single branch.

## #595 — Enhanced Fraud Detection with Device Fingerprinting
- Client collects a coarse, privacy-conscious device fingerprint (screen geometry, timezone, canvas hash, etc.), SHA-256 hashed in the browser so only an opaque digest ever leaves the device; wired into the contribution flow (`ContributeModal`).
- Server re-hashes the digest with an HMAC pepper before storage; raw fingerprints are never stored or logged. New `device_fingerprint` column + partial indexes on `contributions`.
- Two new fraud signals — `same_device` (per-campaign clustering) and `device_cluster` (coordinated cross-campaign activity) — feed the existing risk score and surface automatically in the admin fraud dashboard.

## #598 — Campaign Team Roles and Permissions UI
- Closed a server-side privilege-escalation gap: only owners can assign the `owner` role. Added `canAssignRole()` and enforced it in the member invite route (returns 403 otherwise) — never trusting the client.
- Added a role-permissions legend to the campaign Team tab.

## #599 — Advanced Campaign Search with Faceted Filters
- Extended `GET /campaigns` with parameterized `min_funding`, `max_funding`, `deadline_within`, `creator_verified` and `country` filters (no injection), plus a new `GET /campaigns/facets` endpoint returning category/asset/country counts, funding bounds, and verified-creator counts.
- Added a `country` column + index and create/update wiring.
- Home page filter UI controls and active-filter chips for the new facets, with loading/empty states; optional location field on campaign creation.

Tests added for all three areas; backend and frontend lint pass, frontend build passes.

Closes #595
Closes #598
Closes #599