### PR TITLE
perf(campaigns): memoize CampaignCard to reduce unnecessary re-render…

### DIFF
--- a/frontend/src/components/CampaignCard.jsx
+++ b/frontend/src/components/CampaignCard.jsx
@@ -48,7 +48,7 @@ const CATEGORY_LABELS = {
   other: 'Other',
 };
 
-export default function CampaignCard({ campaign, featured }) {
+function CampaignCard({ campaign, featured }) {
   const { t } = useTranslation();
   const pct = Math.min(100, (campaign.raised_amount / campaign.target_amount) * 100).toFixed(1);
   const fillColor = progressColor(parseFloat(pct), campaign.status);
@@ -157,6 +157,8 @@ export default function CampaignCard({ campaign, featured }) {
     </Link>
   );
 }
+
+export default React.memo(CampaignCard);
 
 const styles = {
   card: {


### PR DESCRIPTION
This PR improves rendering performance by memoizing the CampaignCard component, preventing unnecessary re-renders when its props have not changed.

What was implemented
Wrapped CampaignCard with React.memo.
Uses React's default shallow prop comparison to skip redundant renders when component props remain unchanged.
Preserves the existing component behavior while improving rendering efficiency.
Benefits
Reduces unnecessary component re-renders.
Improves performance when rendering lists of campaign cards.
Keeps the implementation simple by relying on React's built-in shallow comparison.
Validation
Code implementation is complete on branch fix/issue-581-campaign-card-memo.
Local tests could not be executed because node_modules was unavailable and npm install was interrupted.
Full validation is expected to be performed by the project's GitHub CI pipeline.

Closes #581