### PR TITLE
implemented the cleanup for the Maps

### DIFF
--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -15,7 +15,7 @@ const { sendAlert } = require('../services/alerting');
 const cache = require('../utils/cache');
 const { Keypair } = require('@stellar/stellar-sdk');
 const { encryptSecret } = require('../services/walletService');
-const { watchCampaignWallet, addSSEClient, removeSSEClient } = require('../services/ledgerMonitor');
+const { watchCampaignWallet, addSSEClient, removeSSEClient, cleanupStreamForWallet } = require('../services/ledgerMonitor');
 const { emitWebhookEventForUser, WEBHOOK_EVENTS } = require('../services/webhookDispatcher');
 const { refreshCampaignStatus, refreshActiveCampaignStatuses } = require('../services/campaignStatusService');
 const { queueFailedCampaignRefunds } = require('../services/campaignStatusActions');
@@ -896,6 +896,9 @@ router.delete('/:id', requireAuth, requireCampaignMember('owner'), asyncHandler(
       details: stellarErr.message,
     });
   }
+
+  // Cleanup ledger stream registry and reconnect attempts for this wallet
+  cleanupStreamForWallet(campaign.wallet_public_key);
 
   const { rows: updated } = await db.query(
     `UPDATE campaigns SET deleted_at = NOW() WHERE id = $1 RETURNING id, title, deleted_at`,

--- a/backend/src/services/ledgerMonitor.js
+++ b/backend/src/services/ledgerMonitor.js
@@ -46,6 +46,26 @@ function removeSSEClient(campaignId, res) {
   }
 }
 
+/**
+ * Cleanup stream registry and reconnect attempts for a wallet.
+ * Called when streams are closed, campaigns are deleted, or reconnects are abandoned.
+ */
+function cleanupStreamForWallet(walletPublicKey) {
+  const entry = streamRegistry.get(walletPublicKey);
+  if (entry && typeof entry.close === "function") {
+    try {
+      entry.close();
+    } catch (err) {
+      logger.warn("Failed to close stream during cleanup", {
+        wallet_public_key: walletPublicKey,
+        error: err.message,
+      });
+    }
+  }
+  streamRegistry.delete(walletPublicKey);
+  reconnectAttempts.delete(walletPublicKey);
+}
+
 function broadcastCampaignUpdate(campaignId, data) {
   const clients = sseClients.get(campaignId);
   if (!clients || clients.size === 0) return;
@@ -60,6 +80,7 @@ function broadcastCampaignUpdate(campaignId, data) {
 }
 
 const MAX_RECONNECT_DELAY_MS = 60_000;
+const MAX_RECONNECT_ATTEMPTS = 10;
 
 function extractPagingToken(record) {
   if (!record || typeof record !== "object") return null;
@@ -491,6 +512,17 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
 }
 
   function scheduleStreamReconnect(campaignId, walletPublicKey, attempt) {
+    if (attempt > MAX_RECONNECT_ATTEMPTS) {
+      logger.error("Ledger stream reconnect abandoned after max attempts", {
+        wallet_public_key: walletPublicKey,
+        campaign_id: campaignId,
+        attempt,
+        max_attempts: MAX_RECONNECT_ATTEMPTS,
+      });
+      cleanupStreamForWallet(walletPublicKey);
+      return;
+    }
+
     const delay = Math.min(
       MAX_RECONNECT_DELAY_MS,
       1000 * 2 ** Math.max(0, attempt - 1),
@@ -556,15 +588,9 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
             campaign_id: campaignId,
             error: err.message,
           });
-          const snap = streamRegistry.get(walletPublicKey);
           const attempt = (reconnectAttempts.get(walletPublicKey) || 0) + 1;
           reconnectAttempts.set(walletPublicKey, attempt);
-          try {
-            if (snap && typeof snap.close === "function") snap.close();
-          } catch {
-            // ignore
-          }
-          streamRegistry.delete(walletPublicKey);
+          cleanupStreamForWallet(walletPublicKey);
           scheduleStreamReconnect(campaignId, walletPublicKey, attempt);
         },
       });
@@ -714,4 +740,5 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
     getLedgerStreamHealth,
     addSSEClient,
     removeSSEClient,
+    cleanupStreamForWallet,
   };


### PR DESCRIPTION
## Description

Fixes #397 — Reward tier `claimed_count` is now atomically decremented when a tier-backed contribution is made, preventing overselling of limited-edition reward tiers.

**The Problem**
The `claimed_count` (and hence computed `remaining`) on `reward_tiers` was only incremented asynchronously in the ledger monitor when Horizon detected the on-chain payment. The contribution route itself never decremented the count, so:
- Sold-out tiers continued showing availability in the UI
- Multiple backers could claim the last slot of a limited tier
- Creators could end up owing more physical rewards than they could fulfil

**The Fix**
A new `reserveTierSlot()` function in `rewardTierService.js` atomically increments `claimed_count` **inside the contribution route's database transaction** — before the Stellar transaction is even submitted. If the tier is already at capacity, the contribution is rejected with **HTTP 409 Sold out** and the entire transaction is rolled back.

## Changes

### `backend/src/services/rewardTierService.js`
- **`reserveTierSlot(client, { tierId, campaignId })`** — Atomically increments `claimed_count` via `UPDATE ... WHERE (tier_limit IS NULL OR claimed_count < tier_limit) RETURNING`. Returns the tier row on success, or `null` if sold out.
- **`assignTierToContribution(client, { ..., tierId })`** — Extended to accept an optional `tierId`. When provided, only creates the `contribution_rewards` join row (idempotent via `ON CONFLICT DO NOTHING`) without double-incrementing `claimed_count`, since the route already reserved the slot.

### `backend/src/routes/contributions.js`
- Custodial `POST /` route now extracts optional `tier_id` from `req.body`
- Validates the tier belongs to the campaign (pre-flight `SELECT`)
- Calls `reserveTierSlot()` inside the existing transaction, **before** submitting to Stellar
- Returns **HTTP 409** with `{ error: "This reward tier is sold out", tier_id }` if the tier is at capacity
- Passes `tierId` through to `submitCustodialContribution` so it flows into metadata

### `backend/src/services/contributionService.js`
- Accepts new `tierId` parameter and includes it in `stellar_transactions.metadata` as `tier_id`

### `backend/src/services/ledgerMonitor.js`
- Reads `tier_id` from `stellar_transactions.metadata` and passes it to `assignTierToContribution`, ensuring pre-reserved tiers are honoured without double-counting `claimed_count`

### `backend/src/middleware/validation.js`
- Added optional `tier_id` validation (UUID format) to `contributionValidation`

## How It Works End-to-End
I've implemented the cleanup for the Maps in ledgerMonitor.js. Here's a summary of the changes:

Changes Made
1. Added cleanup helper function (ledgerMonitor.js:49-67)

Created cleanupStreamForWallet(walletPublicKey) function that:
Closes the stream if it exists
Deletes entry from streamRegistry
Deletes entry from reconnectAttempts
2. Updated stream error handler (ledgerMonitor.js:573-583)

Replaced manual map deletion with call to cleanupStreamForWallet
Simplified the error handling logic
3. Exported cleanup function (ledgerMonitor.js:731)

Added cleanupStreamForWallet to module exports for use in other files
4. Added cleanup in campaign deletion (campaigns.js:18, 900-901)

Imported cleanupStreamForWallet from ledgerMonitor
Added cleanup call after wallet is revoked/closed in the DELETE route
5. Added max reconnect attempts check (ledgerMonitor.js:83, 515-524)

Added MAX_RECONNECT_ATTEMPTS = 10 constant
Added check in scheduleStreamReconnect to abandon reconnect after max attempts
Calls cleanupStreamForWallet when max attempts exceeded
The implementation ensures that:

Stream registry and reconnect attempts maps are cleaned up when streams close
Maps are cleaned up when campaigns are deleted
Maps are cleaned up when reconnect attempts are abandoned
Memory no longer accumulates stale entries indefinitely
Feedback submitted

```
User contributes (with tier_id)
  │
  ├─ 1. Route validates tier exists & belongs to campaign (pre-flight)
  │
  ├─ 2. BEGIN transaction
  │     ├─ Advisory lock (campaign + user)
  │     ├─ Check per-user cap
  │     ├─ reserveTierSlot() → UPDATE reward_tiers SET claimed_count++ 
  │     │                        WHERE id = tier_id AND claimed_count < tier_limit
  │     │                        RETURNING id
  │     │     └─ If 0 rows → ROLLBACK, respond 409 Sold out 🚫
  │     ├─ Submit Stellar transaction
  │     ├─ Insert stellar_transactions record (metadata.tier_id set)
  │     └─ COMMIT ✅
  │
  └─ 3. (async) Ledger monitor indexes on-chain payment
        ├─ Insert contributions row
        ├─ assignTierToContribution(tierId) → creates contribution_rewards
        │   (idempotent via ON CONFLICT DO NOTHING, no double-increment)
        └─ Update campaign raised_amount
```

## Acceptance Criteria

| Criteria | Status |
|----------|--------|
| Tier `claimed_count` decrements atomically with each contribution | ✅ `UPDATE ... SET claimed_count = claimed_count + 1` inside route transaction |
| Contribution rejected with 409 when tier is sold out | ✅ `reserveTierSlot()` returns null → `res.status(409)` |
| Concurrent contributions for the last slot handled correctly (only one succeeds) | ✅ Atomic `UPDATE ... WHERE claimed_count < tier_limit` with PostgreSQL row-level locking inside transaction |
| Tier sold-out state reflected in UI immediately | ✅ `claimed_count` is updated atomically in the route, so the next `listTiersWithAvailability()` query reflects the correct `remaining` |

## Testing

- [ ] Unit test `reserveTierSlot()` — success path
- [ ] Unit test `reserveTierSlot()` — sold-out path returns null
- [ ] Unit test `assignTierToContribution()` with explicit `tierId` — no double-increment
- [ ] Integration: contribute with valid `tier_id`, verify `claimed_count` incremented
- [ ] Integration: contribute with sold-out `tier_id`, verify 409 response
- [ ] Integration: concurrent contributions for last slot, verify exactly one 202 and one 409

Closes #648
Closes #644
Closes #643
Closes #646