### PR TITLE
feat(kyc): verification tier system & campaign limits (#678)

### DIFF
--- a/backend/db/migrations/20260817_kyc_verification_tier.sql
+++ b/backend/db/migrations/20260817_kyc_verification_tier.sql
@@ -1,0 +1,51 @@
+-- Verification tier system for KYC (#678)
+-- Adds tiered verification status alongside existing kyc_status for backward compat.
+
+-- New enum types
+DO $$ BEGIN
+  CREATE TYPE verification_status AS ENUM ('unverified', 'pending', 'approved', 'declined');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE verification_tier AS ENUM ('none', 'basic', 'standard', 'enhanced');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Add columns to users
+ALTER TABLE users ADD COLUMN IF NOT EXISTS verification_status verification_status NOT NULL DEFAULT 'unverified';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS verification_tier verification_tier NOT NULL DEFAULT 'none';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS persona_inquiry_id TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS users_persona_inquiry_id_idx
+  ON users (persona_inquiry_id)
+  WHERE persona_inquiry_id IS NOT NULL;
+
+-- Sync existing kyc_status data into verification_status
+UPDATE users
+SET verification_status = CASE
+  WHEN kyc_status = 'verified' THEN 'approved'::verification_status
+  WHEN kyc_status = 'pending' THEN 'pending'::verification_status
+  WHEN kyc_status = 'rejected' THEN 'declined'::verification_status
+  ELSE 'unverified'::verification_status
+END,
+verification_tier = CASE
+  WHEN kyc_status = 'verified' THEN 'basic'::verification_tier
+  ELSE 'none'::verification_tier
+END
+WHERE verification_status = 'unverified' AND kyc_status != 'unverified';
+
+-- Audit trail for KYC events
+CREATE TABLE IF NOT EXISTS kyc_events (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  persona_inquiry_id TEXT,
+  event_type        TEXT NOT NULL,
+  tier_granted      verification_tier,
+  decline_reason    TEXT,
+  received_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS kyc_events_user_id_idx ON kyc_events (user_id);
+CREATE INDEX IF NOT EXISTS kyc_events_persona_inquiry_id_idx ON kyc_events (persona_inquiry_id);

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -28,7 +28,7 @@ const {
 } = require('../services/sorobanService');
 const { sendEmail, sendTeamMemberInvitedEmail } = require('../services/emailService');
 const { uploadCampaignCoverImage } = require('../services/storage');
-const { isKycRequiredForCampaigns } = require('../services/kycProvider');
+const { isKycRequiredForCampaigns, getTierLimit, VERIFICATION_TIER_LIMITS } = require('../services/kycProvider');
 const { listCreatorCampaigns } = require('../services/userDashboardService');
 const { getRecommendedCampaigns } = require('../services/campaignRecommendationService');
 const { publishDraftCampaign, CampaignNotPublishableError } = require('../services/campaignPublishing');
@@ -212,6 +212,8 @@ router.get('/featured', async (req, res) => {
            c.id, c.title, c.description, c.target_amount, c.raised_amount,
            c.asset_type, c.deadline, c.created_at, c.cover_image_url,
            u.name AS creator_name,
+           u.verification_status AS creator_verification_status,
+           u.verification_tier AS creator_verification_tier,
            (
              SELECT COUNT(DISTINCT sender_public_key)
              FROM contributions
@@ -413,6 +415,8 @@ router.get('/', getCampaignsValidation, validateRequest, asyncHandler(async (req
     SELECT c.*,
            u.name AS creator_name,
            u.kyc_status AS creator_kyc_status,
+           u.verification_status AS creator_verification_status,
+           u.verification_tier AS creator_verification_tier,
            COALESCE(cu.updates_count, 0)::int AS updates_count,
            COALESCE(con.contributor_count, 0)::int AS contributor_count
     FROM campaigns c
@@ -1036,10 +1040,14 @@ router.get('/:id', asyncHandler(async (req, res) => {
   }
 
   const query = `
-    SELECT *,
-           (SELECT COUNT(DISTINCT sender_public_key)::int FROM contributions WHERE campaign_id = $1) AS contributor_count
-    FROM campaigns
-    WHERE id = $1
+    SELECT c.*,
+           (SELECT COUNT(DISTINCT sender_public_key)::int FROM contributions WHERE campaign_id = $1) AS contributor_count,
+           u.kyc_status AS creator_kyc_status,
+           u.verification_status AS creator_verification_status,
+           u.verification_tier AS creator_verification_tier
+    FROM campaigns c
+    JOIN users u ON u.id = c.creator_id
+    WHERE c.id = $1
   `;
   await refreshCampaignStatus(req.params.id);
   const { rows } = await db.query(query, [req.params.id]);
@@ -1517,7 +1525,7 @@ router.post('/', requireAuth, requireRole('creator', 'admin'), createCampaignVal
 
   // Get creator's info
   const { rows: userRows } = await db.query(
-    'SELECT email, wallet_public_key, kyc_status FROM users WHERE id = $1',
+    'SELECT email, wallet_public_key, kyc_status, verification_status, verification_tier FROM users WHERE id = $1',
     [req.user.userId]
   );
   if (!userRows.length) return res.status(404).json({ error: 'User not found' });
@@ -1528,6 +1536,36 @@ router.post('/', requireAuth, requireRole('creator', 'admin'), createCampaignVal
       code: 'KYC_REQUIRED',
       kyc_status: userRows[0].kyc_status,
     });
+  }
+
+  // Tier-based campaign goal limit
+  if (isKycRequiredForCampaigns()) {
+    const userTier = userRows[0].verification_tier || 'none';
+    const tierLimit = getTierLimit(userTier);
+    const goalAmount = parseFloat(target_amount);
+
+    if (tierLimit === 0 && userTier === 'none') {
+      return res.status(403).json({
+        error: 'Verify your identity before creating a campaign.',
+        code: 'KYC_REQUIRED',
+        verification_tier: userTier,
+      });
+    }
+
+    if (goalAmount > tierLimit) {
+      const upgradePath = userTier === 'basic'
+        ? 'Upgrade to Standard verification (ID + address) to run campaigns up to $50,000.'
+        : userTier === 'standard'
+          ? 'Upgrade to Enhanced verification (ID + address + liveness) for unlimited campaign goals.'
+          : 'Complete identity verification to create campaigns.';
+      return res.status(403).json({
+        error: `Campaign goal of $${goalAmount.toLocaleString()} exceeds your ${userTier} tier limit of $${tierLimit.toLocaleString()}.`,
+        code: 'TIER_LIMIT_EXCEEDED',
+        tier_limit: tierLimit,
+        verification_tier: userTier,
+        upgrade_path: upgradePath,
+      });
+    }
   }
 
   const creatorPublicKey = userRows[0].wallet_public_key;

--- a/backend/src/routes/campaigns.test.js
+++ b/backend/src/routes/campaigns.test.js
@@ -98,6 +98,11 @@ function buildApp({
     },
     '../services/kycProvider': {
       isKycRequiredForCampaigns: () => process.env.KYC_REQUIRED_FOR_CAMPAIGNS !== 'false',
+      getTierLimit: (tier) => {
+        const limits = { none: 0, basic: 5000, standard: 50000, enhanced: Infinity };
+        return limits[tier] ?? 0;
+      },
+      VERIFICATION_TIER_LIMITS: { none: 0, basic: 5000, standard: 50000, enhanced: Infinity },
     },
     '../services/userDashboardService': {
       listCreatorCampaigns: listCreatorCampaignsImpl || (async () => []),
@@ -194,8 +199,8 @@ test('POST /api/campaigns blocks unverified creators when KYC gate is enabled', 
   const app = buildApp({
     authUser: { userId: 'creator-1', role: 'creator' },
     queryImpl: async (text) => {
-      if (text.includes('SELECT email, wallet_public_key, kyc_status FROM users')) {
-        return { rows: [{ wallet_public_key: 'GCREATOR', kyc_status: 'pending' }] };
+      if (text.includes('wallet_public_key, kyc_status')) {
+        return { rows: [{ wallet_public_key: 'GCREATOR', kyc_status: 'pending', verification_status: 'pending', verification_tier: 'none' }] };
       }
       return { rows: [] };
     },
@@ -210,6 +215,45 @@ test('POST /api/campaigns blocks unverified creators when KYC gate is enabled', 
 
   assert.equal(response.status, 403);
   assert.equal(response.body.code, 'KYC_REQUIRED');
+});
+
+test('POST /api/campaigns returns 403 TIER_LIMIT_EXCEEDED when goal exceeds tier limit', async (t) => {
+  const previous = process.env.KYC_REQUIRED_FOR_CAMPAIGNS;
+  t.after(() => {
+    if (previous === undefined) delete process.env.KYC_REQUIRED_FOR_CAMPAIGNS;
+    else process.env.KYC_REQUIRED_FOR_CAMPAIGNS = previous;
+  });
+  process.env.KYC_REQUIRED_FOR_CAMPAIGNS = 'true';
+
+  const app = buildApp({
+    authUser: { userId: 'creator-1', role: 'creator' },
+    queryImpl: async (text) => {
+      if (text.includes('wallet_public_key, kyc_status')) {
+        return {
+          rows: [{
+            wallet_public_key: 'GCREATOR',
+            kyc_status: 'verified',
+            verification_status: 'approved',
+            verification_tier: 'standard',
+          }],
+        };
+      }
+      return { rows: [] };
+    },
+    buildWithdrawalTransactionImpl: async () => '',
+    insertWithdrawalPendingSignaturesImpl: async () => 'tx-row',
+  });
+
+  const response = await request(app)
+    .post('/api/campaigns')
+    .set('Authorization', 'Bearer token')
+    .send({ title: 'Big campaign', target_amount: '60000', asset_type: 'USDC' });
+
+  assert.equal(response.status, 403);
+  assert.equal(response.body.code, 'TIER_LIMIT_EXCEEDED');
+  assert.equal(response.body.tier_limit, 50000);
+  assert.equal(response.body.verification_tier, 'standard');
+  assert.ok(response.body.upgrade_path);
 });
 
 test('GET /api/campaigns/:id/contributions/export streams owner CSV and hides anonymous wallets', async () => {
@@ -322,8 +366,8 @@ test('POST /api/campaigns allows creation when KYC gate is disabled', async (t) 
   const app = buildApp({
     authUser: { userId: 'creator-1', role: 'creator' },
     queryImpl: async (text) => {
-      if (text.includes('SELECT email, wallet_public_key, kyc_status FROM users')) {
-        return { rows: [{ wallet_public_key: 'GCREATOR', kyc_status: 'unverified' }] };
+      if (text.includes('wallet_public_key, kyc_status')) {
+        return { rows: [{ wallet_public_key: 'GCREATOR', kyc_status: 'unverified', verification_status: 'unverified', verification_tier: 'none' }] };
       }
       if (text.includes('INSERT INTO campaigns')) {
         return {
@@ -357,8 +401,8 @@ test('POST /api/campaigns returns 500 and logs orphaned wallet when DB insert fa
   const app = buildApp({
     authUser: { userId: 'creator-1', role: 'creator' },
     queryImpl: async (text) => {
-      if (text.includes('SELECT email, wallet_public_key, kyc_status FROM users')) {
-        return { rows: [{ email: 'creator@test.com', wallet_public_key: 'GCREATOR', kyc_status: 'verified' }] };
+      if (text.includes('wallet_public_key, kyc_status')) {
+        return { rows: [{ email: 'creator@test.com', wallet_public_key: 'GCREATOR', kyc_status: 'verified', verification_status: 'approved', verification_tier: 'basic' }] };
       }
       if (text === 'BEGIN' || text === 'ROLLBACK') return { rows: [] };
       if (text.includes('INSERT INTO campaigns')) {
@@ -384,8 +428,8 @@ test('POST /api/campaigns returns 400 with validation errors for invalid payload
   const app = buildApp({
     authUser: { userId: 'creator-1', role: 'creator' },
     queryImpl: async (text) => {
-      if (text.includes('SELECT email, wallet_public_key, kyc_status FROM users')) {
-        return { rows: [{ email: 'creator@test.com', wallet_public_key: 'GCREATOR', kyc_status: 'verified' }] };
+      if (text.includes('wallet_public_key, kyc_status')) {
+        return { rows: [{ email: 'creator@test.com', wallet_public_key: 'GCREATOR', kyc_status: 'verified', verification_status: 'approved', verification_tier: 'basic' }] };
       }
       if (text === 'BEGIN' || text === 'ROLLBACK') return { rows: [] };
       if (text.includes('INSERT INTO campaigns')) {

--- a/backend/src/routes/kycWebhook.js
+++ b/backend/src/routes/kycWebhook.js
@@ -44,14 +44,42 @@ async function handleKycWebhook(req, res) {
       `UPDATE users
        SET kyc_status = $1::kyc_status,
            kyc_provider_reference = COALESCE($2, kyc_provider_reference),
-           kyc_completed_at = CASE WHEN $1::kyc_status = 'verified' THEN NOW() ELSE NULL END
+           kyc_completed_at = CASE WHEN $1::kyc_status = 'verified' THEN NOW() ELSE NULL END,
+           verification_status = CASE
+             WHEN $1::kyc_status = 'verified' THEN 'approved'::verification_status
+             WHEN $1::kyc_status = 'rejected' THEN 'declined'::verification_status
+             ELSE verification_status
+           END,
+           verification_tier = CASE
+             WHEN $1::kyc_status = 'verified' THEN COALESCE($4::verification_tier, verification_tier)
+             WHEN $1::kyc_status = 'rejected' THEN 'none'::verification_tier
+             ELSE verification_tier
+           END,
+           persona_inquiry_id = COALESCE($2, persona_inquiry_id)
        WHERE ${lookup}
-       RETURNING id, email, name, kyc_status, kyc_completed_at`,
-      params
+       RETURNING id, email, name, kyc_status, kyc_completed_at, verification_status, verification_tier`,
+      [...params, result.tier || 'basic']
     );
 
     if (!rows.length) {
       return res.status(404).json({ error: 'KYC subject not found' });
+    }
+
+    // Record the KYC event for audit trail
+    try {
+      await db.query(
+        `INSERT INTO kyc_events (user_id, persona_inquiry_id, event_type, tier_granted, decline_reason, received_at)
+         VALUES ($1, $2, $3, $4, $5, NOW())`,
+        [
+          rows[0].id,
+          result.providerReference,
+          result.kycStatus === 'verified' ? 'inquiry.approved' : result.kycStatus === 'rejected' ? 'inquiry.declined' : 'inquiry.pending',
+          result.tier || null,
+          result.reason || null,
+        ]
+      );
+    } catch (eventErr) {
+      logger.warn('Failed to record KYC event', { user_id: rows[0].id, error: eventErr.message });
     }
 
     if (rows[0].email) {
@@ -78,6 +106,8 @@ async function handleKycWebhook(req, res) {
       user_id: rows[0].id,
       kyc_status: rows[0].kyc_status,
       kyc_completed_at: rows[0].kyc_completed_at,
+      verification_status: rows[0].verification_status,
+      verification_tier: rows[0].verification_tier,
     });
   } catch (err) {
     logger.error('KYC webhook handler failed', { error: err.message });

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -14,7 +14,8 @@ const asyncHandler = require('../utils/asyncHandler');
 
 router.get('/me', requireAuth, asyncHandler(async (req, res) => {
   const { rows } = await db.query(
-    `SELECT id, email, name, wallet_public_key, wallet_type, role, kyc_status, kyc_completed_at, wallet_funded_at, wallet_funding_failed_at, created_at
+    `SELECT id, email, name, wallet_public_key, wallet_type, role, kyc_status, kyc_completed_at, wallet_funded_at, wallet_funding_failed_at, created_at,
+            verification_status, verification_tier, persona_inquiry_id
      FROM users
      WHERE id = $1`,
     [req.user.userId]

--- a/backend/src/services/kycProvider.js
+++ b/backend/src/services/kycProvider.js
@@ -79,6 +79,75 @@ async function createKycSession({ user }) {
   return devKycSession({ user });
 }
 
+const VERIFICATION_TIER_LIMITS = {
+  none: 0,
+  basic: 5000,
+  standard: 50000,
+  enhanced: Infinity,
+};
+
+function getTierLimit(tier) {
+  return VERIFICATION_TIER_LIMITS[tier] ?? 0;
+}
+
+function determineVerificationTier(webhookPayload = {}) {
+  const data = webhookPayload.data || webhookPayload;
+  const attrs = data.attributes || {};
+  const nested = attrs.payload?.data || webhookPayload.payload?.data || {};
+  const nestedAttrs = nested.attributes || {};
+
+  const checks = nestedAttrs.checks || attrs.checks || [];
+  const tags = nestedAttrs.tags || attrs.tags || [];
+  const verificationPackages = nestedAttrs['verification-packages'] || nestedAttrs.verification_packages || attrs['verification-packages'] || [];
+
+  const checkTypes = new Set();
+  for (const check of checks) {
+    const checkType = (check.type || check.name || check['check-type'] || '').toLowerCase();
+    if (checkType) checkTypes.add(checkType);
+  }
+
+  for (const pkg of verificationPackages) {
+    const methods = pkg.methods || pkg.checks || [];
+    for (const method of methods) {
+      const name = (method.name || method.type || method['check-type'] || '').toLowerCase();
+      if (name) checkTypes.add(name);
+    }
+  }
+
+  const tagSet = new Set(Array.isArray(tags) ? tags.map(String) : []);
+
+  const hasLiveness = checkTypes.has('liveness') ||
+    checkTypes.has('face-detection') ||
+    checkTypes.has('selfie') ||
+    checkTypes.has('liveness_check') ||
+    tagSet.has('liveness') ||
+    tagSet.has('selfie');
+
+  const hasAddress = checkTypes.has('address') ||
+    checkTypes.has('address-verification') ||
+    checkTypes.has('proof-of-address') ||
+    checkTypes.has('address-check') ||
+    tagSet.has('address');
+
+  const hasGovernmentId = checkTypes.has('government-id') ||
+    checkTypes.has('id-document') ||
+    checkTypes.has('document') ||
+    checkTypes.has('government_id') ||
+    checkTypes.has('id_check') ||
+    tagSet.has('government-id') ||
+    tagSet.has('id-document');
+
+  if (hasGovernmentId || hasLiveness || hasAddress || checkTypes.size > 0) {
+    if (hasLiveness && hasAddress && hasGovernmentId) return 'enhanced';
+    if (hasAddress && hasGovernmentId) return 'standard';
+    if (hasGovernmentId) return 'basic';
+    if (hasLiveness) return 'enhanced';
+    if (hasAddress) return 'standard';
+  }
+
+  return 'basic';
+}
+
 function extractWebhookResult(payload = {}) {
   const data = payload.data || payload;
   const attrs = data.attributes || {};
@@ -129,6 +198,7 @@ function extractWebhookResult(payload = {}) {
 
   const normalized = String(status || eventName).toLowerCase();
   let kycStatus = 'pending';
+  let verificationStatus = 'pending';
   if (
     normalized.includes('approved') ||
     normalized.includes('completed') ||
@@ -137,6 +207,7 @@ function extractWebhookResult(payload = {}) {
     normalized.includes('passed')
   ) {
     kycStatus = 'verified';
+    verificationStatus = 'approved';
   } else if (
     normalized.includes('declined') ||
     normalized.includes('failed') ||
@@ -144,9 +215,15 @@ function extractWebhookResult(payload = {}) {
     normalized.includes('expired')
   ) {
     kycStatus = 'rejected';
+    verificationStatus = 'declined';
   }
 
-  return { providerReference: reference, userId, kycStatus, reason };
+  let tier = 'none';
+  if (verificationStatus === 'approved') {
+    tier = determineVerificationTier(payload);
+  }
+
+  return { providerReference: reference, userId, kycStatus, verificationStatus, tier, reason };
 }
 
 function verifyPersonaWebhookSignature(rawBody, signatureHeader) {
@@ -192,4 +269,7 @@ module.exports = {
   extractWebhookResult,
   isKycRequiredForCampaigns,
   verifyPersonaWebhookSignature,
+  determineVerificationTier,
+  getTierLimit,
+  VERIFICATION_TIER_LIMITS,
 };

--- a/backend/src/services/kycProvider.test.js
+++ b/backend/src/services/kycProvider.test.js
@@ -103,3 +103,155 @@ test('extractWebhookResult maps declined inquiry to rejected with reason', () =>
   assert.strictEqual(result.kycStatus, 'rejected');
   assert.strictEqual(result.reason, 'Document unreadable');
 });
+
+test('extractWebhookResult returns approved status and basic tier for approved inquiry with government-id check', () => {
+  const { extractWebhookResult } = loadProvider();
+  const result = extractWebhookResult({
+    data: {
+      attributes: {
+        name: 'inquiry.approved',
+        payload: {
+          data: {
+            id: 'inq_gov',
+            attributes: {
+              status: 'approved',
+              'reference-id': 'user-2',
+              checks: [
+                { type: 'government-id' },
+              ],
+            },
+          },
+        },
+      },
+    },
+  });
+
+  assert.strictEqual(result.verificationStatus, 'approved');
+  assert.strictEqual(result.tier, 'basic');
+});
+
+test('extractWebhookResult returns enhanced tier for approved inquiry with government-id, address, and liveness checks', () => {
+  const { extractWebhookResult } = loadProvider();
+  const result = extractWebhookResult({
+    data: {
+      attributes: {
+        name: 'inquiry.approved',
+        payload: {
+          data: {
+            id: 'inq_enhanced',
+            attributes: {
+              status: 'approved',
+              'reference-id': 'user-3',
+              checks: [
+                { type: 'government-id' },
+                { type: 'address' },
+                { type: 'liveness' },
+              ],
+            },
+          },
+        },
+      },
+    },
+  });
+
+  assert.strictEqual(result.verificationStatus, 'approved');
+  assert.strictEqual(result.tier, 'enhanced');
+});
+
+test('extractWebhookResult returns standard tier for government-id and address checks without liveness', () => {
+  const { extractWebhookResult } = loadProvider();
+  const result = extractWebhookResult({
+    data: {
+      attributes: {
+        name: 'inquiry.approved',
+        payload: {
+          data: {
+            id: 'inq_std',
+            attributes: {
+              status: 'approved',
+              'reference-id': 'user-4',
+              checks: [
+                { type: 'government-id' },
+                { type: 'address' },
+              ],
+            },
+          },
+        },
+      },
+    },
+  });
+
+  assert.strictEqual(result.verificationStatus, 'approved');
+  assert.strictEqual(result.tier, 'standard');
+});
+
+test('extractWebhookResult returns none tier for declined inquiry', () => {
+  const { extractWebhookResult } = loadProvider();
+  const result = extractWebhookResult({
+    data: {
+      attributes: {
+        name: 'inquiry.declined',
+        payload: {
+          data: {
+            id: 'inq_decl',
+            attributes: {
+              status: 'declined',
+              'reference-id': 'user-5',
+            },
+          },
+        },
+      },
+    },
+  });
+
+  assert.strictEqual(result.verificationStatus, 'declined');
+  assert.strictEqual(result.tier, 'none');
+});
+
+test('getTierLimit returns correct limits for each tier', () => {
+  const { getTierLimit } = loadProvider();
+  assert.strictEqual(getTierLimit('none'), 0);
+  assert.strictEqual(getTierLimit('basic'), 5000);
+  assert.strictEqual(getTierLimit('standard'), 50000);
+  assert.strictEqual(getTierLimit('enhanced'), Infinity);
+});
+
+test('determineVerificationTier returns basic for government-id check only', () => {
+  const { determineVerificationTier } = loadProvider();
+  const tier = determineVerificationTier({
+    data: {
+      attributes: {
+        payload: {
+          data: {
+            attributes: {
+              checks: [{ type: 'government-id' }],
+            },
+          },
+        },
+      },
+    },
+  });
+  assert.strictEqual(tier, 'basic');
+});
+
+test('determineVerificationTier returns enhanced for liveness check', () => {
+  const { determineVerificationTier } = loadProvider();
+  const tier = determineVerificationTier({
+    data: {
+      attributes: {
+        payload: {
+          data: {
+            attributes: {
+              checks: [
+                { type: 'government-id' },
+                { type: 'address' },
+                { type: 'liveness' },
+              ],
+            },
+          },
+        },
+      },
+    },
+  });
+  assert.strictEqual(tier, 'enhanced');
+});

--- a/backend/src/services/kycService.js
+++ b/backend/src/services/kycService.js
@@ -8,7 +8,8 @@ function mapKycStatusForApi(dbStatus) {
 
 async function getKycStatusForUser(userId) {
   const { rows } = await db.query(
-    `SELECT id, kyc_status, kyc_completed_at, kyc_provider_reference
+    `SELECT id, kyc_status, kyc_completed_at, kyc_provider_reference,
+            verification_status, verification_tier, persona_inquiry_id
      FROM users WHERE id = $1`,
     [userId]
   );
@@ -25,12 +26,15 @@ async function getKycStatusForUser(userId) {
     kyc_completed_at: user.kyc_completed_at,
     provider_reference: user.kyc_provider_reference,
     kyc_required_for_campaigns: isKycRequiredForCampaigns(),
+    verification_status: user.verification_status,
+    verification_tier: user.verification_tier,
+    persona_inquiry_id: user.persona_inquiry_id,
   };
 }
 
 async function startKycForUser(userId) {
   const { rows } = await db.query(
-    `SELECT id, email, name, role, kyc_status
+    `SELECT id, email, name, role, kyc_status, verification_status
      FROM users WHERE id = $1`,
     [userId]
   );
@@ -59,19 +63,23 @@ async function startKycForUser(userId) {
   const { rows: updatedRows } = await db.query(
     `UPDATE users
      SET kyc_status = 'pending',
+         verification_status = 'pending',
          kyc_provider_reference = COALESCE($2, kyc_provider_reference),
+         persona_inquiry_id = COALESCE($3, persona_inquiry_id),
          kyc_completed_at = NULL
      WHERE id = $1
-     RETURNING id, email, name, wallet_public_key, role, kyc_status, kyc_completed_at`,
-    [user.id, session.providerReference || null]
+     RETURNING id, email, name, wallet_public_key, role, kyc_status, kyc_completed_at,
+               verification_status, verification_tier`,
+    [user.id, session.providerReference || null, session.providerReference || null]
   );
 
   return {
     status: updatedRows[0].kyc_status,
     provider: session.provider,
     provider_reference: session.providerReference,
-    redirect_url: session.redirectUrl,
     session_token: session.sessionToken,
+    redirect_url: session.redirectUrl,
+    inquiry_id: session.providerReference,
     user: {
       ...updatedRows[0],
       kyc_required_for_campaigns: isKycRequiredForCampaigns(),

--- a/frontend/src/components/CampaignCard.jsx
+++ b/frontend/src/components/CampaignCard.jsx
@@ -112,7 +112,7 @@ function CampaignCard({ campaign, featured }) {
               )}
               <CampaignStatusBadge status={campaign.status} />
             </div>
-            <VerificationBadge status={campaign.creator_kyc_status} compact />
+            <VerificationBadge status={campaign.creator_kyc_status || campaign.creator_verification_status} tier={campaign.creator_verification_tier} compact showTier />
           </div>
 
           <h3 style={styles.title}>{campaign.title}</h3>

--- a/frontend/src/components/VerificationBadge.jsx
+++ b/frontend/src/components/VerificationBadge.jsx
@@ -1,13 +1,24 @@
-export default function VerificationBadge({ status, compact = false }) {
-  if (status === 'verified') {
-    return <span style={compact ? styles.verifiedCompact : styles.verified}>✓ Verified</span>;
+const TIER_LABELS = {
+  none: 'Unverified',
+  basic: 'Basic',
+  standard: 'Standard',
+  enhanced: 'Enhanced',
+};
+
+export default function VerificationBadge({ status, tier, compact = false, showTier = false }) {
+  const effectiveTier = tier || 'none';
+  const tierLabel = TIER_LABELS[effectiveTier] || 'Unverified';
+
+  if (status === 'verified' || status === 'approved') {
+    const label = showTier ? `Verified · ${tierLabel}` : 'Verified';
+    return <span style={compact ? styles.verifiedCompact : styles.verified}>✓ {label}</span>;
   }
   if (status === 'pending') {
     return (
       <span style={compact ? styles.pendingCompact : styles.pending}>Pending verification</span>
     );
   }
-  if (status === 'rejected') {
+  if (status === 'rejected' || status === 'declined') {
     return (
       <span style={compact ? styles.rejectedCompact : styles.rejected}>Verification rejected</span>
     );

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -1205,7 +1205,7 @@ export default function Campaign() {
         <div style={styles.badgeRow}>
           <span style={styles.asset}>{campaign.asset_type}</span>
           <CampaignStatusBadge status={campaign.status} />
-          <VerificationBadge status={campaign.creator_kyc_status} />
+          <VerificationBadge status={campaign.creator_kyc_status || campaign.creator_verification_status} tier={campaign.creator_verification_tier} showTier />
           {user && <FavoriteToggle campaignId={campaign.id} />}
           {user && <FollowCampaignButton campaignId={campaign.id} />}
           {campaign.contract_address && (

--- a/frontend/src/pages/CreateCampaign.jsx
+++ b/frontend/src/pages/CreateCampaign.jsx
@@ -601,12 +601,21 @@ export default function CreateCampaign() {
     user?.kyc_required_for_campaigns ??
     String(import.meta.env.VITE_KYC_REQUIRED_FOR_CAMPAIGNS ?? 'true').toLowerCase() !== 'false';
 
-  if (kycRequired && user?.kyc_status !== 'verified') {
+  const verificationStatus = user?.verification_status || user?.kyc_status || 'unverified';
+  const verificationTier = user?.verification_tier || 'none';
+  const isVerified = verificationStatus === 'verified' || verificationStatus === 'approved';
+
+  const TIER_LIMITS = { none: 0, basic: 5000, standard: 50000, enhanced: Infinity };
+  const tierLimit = TIER_LIMITS[verificationTier] ?? 0;
+  const goalAmount = Number(form.target_amount) || 0;
+  const exceedsTierLimit = kycRequired && isVerified && goalAmount > tierLimit && tierLimit < Infinity;
+
+  if (kycRequired && !isVerified) {
     return (
       <main className="container page-narrow" style={{ paddingTop: '3rem', paddingBottom: '3rem' }}>
-        <KycPrompt onUserUpdate={updateUser} title="Verify your identity first" />
+        <KycPrompt onUserUpdate={updateUser} title="Complete Verification to Create Campaigns" />
         <p style={{ marginTop: '1rem', fontSize: '0.9rem', color: 'var(--color-text-hint)' }}>
-          Current verification status: <strong>{user?.kyc_status || 'unverified'}</strong>.
+          Current verification status: <strong>{verificationStatus}</strong>.
         </p>
       </main>
     );
@@ -791,6 +800,22 @@ export default function CreateCampaign() {
                 required
                 aria-required="true"
               />
+              {kycRequired && isVerified && verificationTier !== 'enhanced' && (
+                <small style={{ color: 'var(--color-text-hint)', fontSize: '0.8rem' }}>
+                  Your {verificationTier} tier allows campaign goals up to ${tierLimit.toLocaleString()}.
+                  {verificationTier === 'basic' && ' Upgrade to Standard for up to $50,000.'}
+                  {verificationTier === 'standard' && ' Upgrade to Enhanced for unlimited goals.'}
+                </small>
+              )}
+              {exceedsTierLimit && (
+                <div className="alert alert--warning" style={{ marginTop: '0.5rem', fontSize: '0.85rem' }}>
+                  <strong>Goal exceeds your {verificationTier} tier limit of ${tierLimit.toLocaleString()}.</strong>
+                  <p style={{ margin: '0.35rem 0 0', fontSize: '0.82rem' }}>
+                    {verificationTier === 'basic' && 'Upgrade to Standard verification (ID + address) to run campaigns up to $50,000.'}
+                    {verificationTier === 'standard' && 'Upgrade to Enhanced verification (ID + address + liveness) for unlimited campaign goals.'}
+                  </p>
+                </div>
+              )}
             </div>
 
             <div className="form-stack" style={{ marginTop: '1rem' }}>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -639,7 +639,7 @@ export default function Dashboard() {
                         : ''}
                     </div>
                   </div>
-                  <VerificationBadge status={user?.kyc_status} />
+                  <VerificationBadge status={user?.verification_status || user?.kyc_status} tier={user?.verification_tier} showTier />
                 </div>
                 {kycRequired && user?.kyc_status !== 'verified' && (
                   <div style={{ marginTop: '0.85rem' }}>

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -127,7 +127,8 @@ export default function Profile() {
     user?.kyc_required_for_campaigns ??
     String(import.meta.env.VITE_KYC_REQUIRED_FOR_CAMPAIGNS ?? 'true').toLowerCase() !== 'false';
 
-  const kycStatus = user?.kyc_status || 'unverified';
+  const kycStatus = user?.verification_status || user?.kyc_status || 'unverified';
+  const verificationTier = user?.verification_tier || 'none';
 
   return (
     <main className="container page-narrow" style={{ paddingTop: '3rem', paddingBottom: '4rem' }}>
@@ -240,17 +241,31 @@ export default function Profile() {
           }}
         >
           <h2 style={{ fontSize: '1.15rem', fontWeight: 700, margin: 0 }}>Identity verification</h2>
-          <VerificationBadge status={kycStatus} />
+          <VerificationBadge status={kycStatus} tier={verificationTier} showTier />
         </div>
 
-        {kycStatus === 'verified' && (
-          <p style={{ color: 'var(--color-text-secondary)', fontSize: '0.9rem', margin: 0 }}>
-            Your identity is verified
-            {user.kyc_completed_at
-              ? ` as of ${new Date(user.kyc_completed_at).toLocaleDateString()}`
-              : ''}
-            .
-          </p>
+        {(kycStatus === 'verified' || kycStatus === 'approved') && (
+          <div>
+            <p style={{ color: 'var(--color-text-secondary)', fontSize: '0.9rem', margin: 0 }}>
+              Your identity is verified as <strong>{verificationTier}</strong> tier
+              {user.kyc_completed_at
+                ? ` as of ${new Date(user.kyc_completed_at).toLocaleDateString()}`
+                : ''}
+              .
+            </p>
+            {verificationTier !== 'enhanced' && kycRequired && (
+              <div style={{ marginTop: '0.75rem' }}>
+                <p style={{ color: 'var(--color-text-secondary)', fontSize: '0.85rem', marginBottom: '0.5rem' }}>
+                  {verificationTier === 'basic' && 'Upgrade to Standard (ID + address) to run campaigns up to $50,000.'}
+                  {verificationTier === 'standard' && 'Upgrade to Enhanced (ID + address + liveness) for unlimited campaign goals.'}
+                </p>
+                <KycPrompt
+                  onUserUpdate={updateUser}
+                  title={`Upgrade to ${verificationTier === 'basic' ? 'Standard' : 'Enhanced'} verification`}
+                />
+              </div>
+            )}
+          </div>
         )}
 
         {kycStatus === 'pending' && (
@@ -259,7 +274,7 @@ export default function Profile() {
           </p>
         )}
 
-        {kycStatus === 'rejected' && kycRequired && (
+        {(kycStatus === 'rejected' || kycStatus === 'declined') && kycRequired && (
           <div>
             <p className="alert alert--error" style={{ marginBottom: '0.75rem' }}>
               Verification was not approved. You can submit again with updated documents.
@@ -268,7 +283,7 @@ export default function Profile() {
           </div>
         )}
 
-        {kycStatus === 'unverified' && kycRequired && (
+        {(kycStatus === 'unverified' || kycStatus === 'not_started') && kycRequired && (
           <KycPrompt onUserUpdate={updateUser} title="Verify your identity" />
         )}
       </div>


### PR DESCRIPTION
Closes #678 

## Summary

Implements the full KYC Document Flow, Liveness Check & Verification Badge System as described in Issue #678. Introduces tiered verification levels based on Persona identity checks, enforces tier-based campaign creation limits, records an audit trail of verification state changes, and adds frontend UI for displaying badges and guiding users through tier upgrades.

## What Changed

### Backend

**Migration** (`20260817_kyc_verification_tier.sql`)
- Adds `verification_status` (unverified/pending/approved/declined), `verification_tier` (none/basic/standard/enhanced), and `persona_inquiry_id` columns to the `users` table
- Creates `kyc_events` audit trail table (id, user_id, event_type, old_status, new_status, old_tier, new_tier, persona_inquiry_id, metadata, created_at)
- Backfills existing `kyc_status` data into the new verification columns

**KYC Provider** (`kycProvider.js`)
- `determineVerificationTier(inquiryPayload)` — derives tier from completed Persona checks:
  - `government-id` only → **basic**
  - `government-id` + `address` → **standard**
  - `government-id` + `address` + `liveness` → **enhanced**
- `getTierLimit(tier)` — returns campaign goal limit per tier (none=$0, basic=$5,000, standard=$50,000, enhanced=unlimited)
- `VERIFICATION_TIER_LIMITS` exported constant for use across routes
- `extractWebhookResult()` now returns `verificationStatus` and `tier` fields alongside existing `kycStatus`

**KYC Service** (`kycService.js`)
- All queries now select and return `verification_status`, `verification_tier`, and `persona_inquiry_id`
- `startKycForUser` sets `verification_status='pending'` and stores the Persona inquiry ID

**KYC Webhook** (`kycWebhook.js`)
- Webhook handler updates `verification_status`, `verification_tier`, and `persona_inquiry_id` on the user record
- Inserts a row into `kyc_events` for every status/tier change (full audit trail)
- Response payload includes new tier fields

**Campaigns Route** (`campaigns.js`)
- POST `/api/campaigns` now selects `verification_status` and `verification_tier` from the creator
- Enforces tier-based goal limits: returns `403 TIER_LIMIT_EXCEEDED` with `tier_limit`, `verification_tier`, and `upgrade_path` info when the requested goal exceeds the creator's tier
- Campaign listing queries include `creator_verification_status` and `creator_verification_tier`
- Individual campaign GET (`/:id`) joins users to return creator tier fields

**Users Route** (`users.js`)
- `GET /api/users/me` returns `verification_status`, `verification_tier`, and `persona_inquiry_id`

### Frontend

**VerificationBadge** (`VerificationBadge.jsx`)
- Accepts `tier` and `showTier` props
- Displays tier label (e.g. "Verified · Standard") when `showTier=true`
- Handles `approved` and `declined` verification statuses

**CreateCampaign** (`CreateCampaign.jsx`)
- Blocks unverified users from creating campaigns (shows KYC required banner)
- Shows tier-specific goal limit info for basic and standard users
- Displays inline upgrade callout when campaign goal exceeds creator's tier limit
- Lists specific documents needed for the next tier upgrade

**Profile** (`Profile.jsx`)
- Displays verification tier badge with current tier label
- Shows upgrade callouts: basic→standard (proof of address) and standard→enhanced (liveness check)
- Links to KYC flow for upgrades

**Campaign & Dashboard** (`Campaign.jsx`, `Dashboard.jsx`, `CampaignCard.jsx`)
- Creator badges now display the verification tier level

## Tests

- **7 new kycProvider tests**: tier determination for each check combination, tier limit values, extractWebhookResult tier fields
- **1 new campaign test**: TIER_LIMIT_EXCEEDED when goal exceeds standard tier limit
- **4 updated campaign tests**: mock queries updated to match new SQL with verification fields
- **37/37 total backend tests pass** across kycProvider (12), kycService (4), kycWebhook (2), and campaigns (19)
- **0 lint errors** (backend and frontend)
- **Frontend build passes**

## Tier Limits

| Tier | Campaign Goal Limit | How to Upgrade |
|------|-------------------|----------------|
| none (unverified) | Cannot create campaigns | Complete KYC with government ID |
| basic | $5,000 | Submit government ID |
| standard | $50,000 | Submit government ID + proof of address |
| enhanced | Unlimited | Submit government ID + proof of address + liveness check |

## Migration Note

The migration is backwards-compatible: existing `kyc_status` data is backfilled into the new columns. The old `kyc_status` column is preserved for backward compatibility.