### PR TITLE
Feat/issue 675 referral affiliate system

### DIFF
--- a/backend/db/migrations/20260818_referral_affiliate_program.sql
+++ b/backend/db/migrations/20260818_referral_affiliate_program.sql
@@ -1,0 +1,35 @@
+-- Campaign referral & affiliate system (Issue #675)
+--
+-- Creators opt a campaign into referrals by creating a referral_programs row.
+-- Any registered user can then claim a referral_links row carrying a unique
+-- 8-character code; contributions made through that link are attributed via
+-- contributions.referral_link_id and paid out as commission at withdrawal time.
+
+CREATE TABLE referral_programs (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id           UUID NOT NULL UNIQUE REFERENCES campaigns(id) ON DELETE CASCADE,
+  commission_percentage NUMERIC(5, 2) NOT NULL CHECK (commission_percentage >= 1 AND commission_percentage <= 20),
+  max_referrers         INTEGER NOT NULL CHECK (max_referrers >= 1 AND max_referrers <= 100),
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE referral_links (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id     UUID NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  code            TEXT NOT NULL UNIQUE CHECK (code ~ '^[A-Za-z0-9]{8}$'),
+  -- Commission already included in a submitted withdrawal, so repeat
+  -- withdrawals never pay the same referrer twice.
+  commission_paid NUMERIC(20, 7) NOT NULL DEFAULT 0,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (campaign_id, user_id)
+);
+
+CREATE INDEX referral_links_campaign_idx ON referral_links (campaign_id);
+CREATE INDEX referral_links_user_idx ON referral_links (user_id);
+
+ALTER TABLE contributions ADD COLUMN referral_link_id UUID REFERENCES referral_links(id);
+
+CREATE INDEX contributions_referral_link_idx
+  ON contributions (referral_link_id)
+  WHERE referral_link_id IS NOT NULL;

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -67,6 +67,12 @@ const {
   canChangeRoles,
   canAssignRole,
 } = require('../lib/campaignPermissions');
+const {
+  createReferralProgram,
+  createReferralLink,
+  getReferralProgram,
+  listCampaignReferrers,
+} = require('../services/referral');
 const { stripHtml } = require('../lib/sanitize');
 const { getSimhash, simhashSimilarity } = require('../utils/simhash');
 const { parsePagination } = require('../utils/pagination');
@@ -2298,6 +2304,56 @@ router.get('/:id/referrals', requireAuth, requireCampaignMember('owner'), asyncH
     [req.params.id]
   );
   res.json(rows);
+}));
+
+// ── Referral & affiliate program (#675) ──────────────────────────────────────
+
+// POST /campaigns/:id/referrals — creator enables referrals on the campaign
+router.post('/:id/referrals', requireAuth, requireCampaignMember('owner'), asyncHandler(async (req, res) => {
+  const { commissionPercentage, maxReferrers } = req.body || {};
+  try {
+    const program = await createReferralProgram(req.params.id, { commissionPercentage, maxReferrers });
+    res.status(201).json(program);
+  } catch (err) {
+    if (err.statusCode === 400) {
+      return res.status(400).json({ error: err.message, code: err.code });
+    }
+    throw err;
+  }
+}));
+
+// GET /campaigns/:id/referrals/program — public program terms
+router.get('/:id/referrals/program', asyncHandler(async (req, res) => {
+  const program = await getReferralProgram(req.params.id);
+  if (!program) return res.status(404).json({ error: 'This campaign does not have a referral program' });
+  const { rows } = await db.query(
+    'SELECT COUNT(*)::int AS total FROM referral_links WHERE campaign_id = $1',
+    [req.params.id]
+  );
+  res.json({ ...program, referrer_count: rows[0]?.total || 0 });
+}));
+
+// POST /campaigns/:id/referrals/links — any registered user claims a referrer link
+router.post('/:id/referrals/links', requireAuth, asyncHandler(async (req, res) => {
+  try {
+    const { code, shareUrl, created } = await createReferralLink({
+      campaignId: req.params.id,
+      userId: req.user.userId,
+    });
+    res.status(created ? 201 : 200).json({ code, shareUrl });
+  } catch (err) {
+    if (err.statusCode === 409 || err.statusCode === 404) {
+      return res.status(err.statusCode).json({ error: err.message, code: err.code });
+    }
+    throw err;
+  }
+}));
+
+// GET /campaigns/:id/referrals/commissions — creator-only referrer breakdown
+router.get('/:id/referrals/commissions', requireAuth, requireCampaignMember('owner'), asyncHandler(async (req, res) => {
+  const data = await listCampaignReferrers(req.params.id);
+  if (!data.program) return res.status(404).json({ error: 'This campaign does not have a referral program' });
+  res.json(data);
 }));
 
 // POST /campaigns/:id/share — increment share_count

--- a/backend/src/routes/campaigns.referralProgram.test.js
+++ b/backend/src/routes/campaigns.referralProgram.test.js
@@ -1,0 +1,232 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const request = require('supertest');
+const proxyquire = require('proxyquire').noCallThru();
+const { Keypair } = require('@stellar/stellar-sdk');
+
+if (!process.env.PLATFORM_SECRET_KEY) {
+  process.env.PLATFORM_SECRET_KEY = Keypair.random().secret();
+}
+if (!process.env.USDC_ISSUER) {
+  process.env.USDC_ISSUER = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+}
+
+function buildApp({ queryImpl = async () => ({ rows: [] }), referralStub = {}, authUser }) {
+  const router = proxyquire('./campaigns', {
+    '../services/campaignStatusService': {
+      refreshCampaignStatus: async () => ({ failed: null, funded: null }),
+      refreshActiveCampaignStatuses: async () => ({ failed: [], funded: [] }),
+    },
+    '../services/campaignStatusActions': {
+      queueFailedCampaignRefunds: async () => ({ refundsCreated: 0, refunds: [] }),
+    },
+    '../config/database': {
+      query: queryImpl,
+      connect: async () => ({ query: queryImpl, release: async () => {} }),
+    },
+    '../services/referral': {
+      createReferralProgram: async () => ({}),
+      createReferralLink: async () => ({}),
+      getReferralProgram: async () => null,
+      listCampaignReferrers: async () => ({ program: null, referrers: [] }),
+      ...referralStub,
+    },
+    '../services/stellarService': {
+      createCampaignWallet: async () => ({ publicKey: 'GPK', secret: 'S' }),
+      getCampaignBalance: async () => ({}),
+      getSupportedAssetCodes: () => ['XLM', 'USDC'],
+      buildWithdrawalTransaction: async () => '',
+    },
+    '../services/ledgerMonitor': { watchCampaignWallet: async () => {} },
+    '../services/stellarTransactionService': {
+      insertWithdrawalPendingSignatures: async () => 'tx-row',
+    },
+    '../config/logger': { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} },
+    '../services/sorobanService': {
+      deployCampaignContracts: async () => ({ escrowContractId: 'C', milestonesContractId: 'C' }),
+      invokeContract: async () => null,
+      encodeMilestone: () => ({}),
+      nativeToScVal: (v) => v,
+      scvAddressFromString: (s) => s,
+    },
+    '../services/emailService': { sendEmail: async () => {} },
+    '../services/alerting': { sendAlert: () => {} },
+    '../services/walletService': { encryptSecret: () => 'encrypted-secret' },
+    '../services/webhookDispatcher': {
+      emitWebhookEventForUser: async () => {},
+      WEBHOOK_EVENTS: {},
+    },
+    '../services/storage': { uploadCampaignCoverImage: async () => '/images/cover.jpg' },
+    '../services/kycProvider': { isKycRequiredForCampaigns: () => false },
+    '../services/userDashboardService': { listCreatorCampaigns: async () => [] },
+    '../services/campaignAnalyticsService': {
+      getCampaignAnalytics: async () => ({}),
+      getCampaignContributors: async () => ({}),
+    },
+    '../middleware/validation': {
+      createCampaignValidation: [],
+      createCampaignUpdateValidation: [],
+      getCampaignsValidation: [],
+      validateRequest: (_req, _res, next) => next(),
+    },
+    '../utils/asyncHandler': (fn) => (req, res, next) => fn(req, res, next).catch(next),
+    '../middleware/auth': {
+      requireAuth: (req, _res, next) => {
+        req.user = authUser || { userId: 'creator-1', role: 'creator' };
+        next();
+      },
+      requireRole: () => (_req, _res, next) => next(),
+    },
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use(cookieParser());
+  app.use('/api/campaigns', router);
+  return app;
+}
+
+const ownerQuery = async (text) => {
+  if (text.includes('SELECT creator_id FROM campaigns')) {
+    return { rows: [{ creator_id: 'creator-1' }] };
+  }
+  return { rows: [] };
+};
+
+test('POST /api/campaigns/:id/referrals enables referrals for the campaign', async () => {
+  let received;
+  const app = buildApp({
+    queryImpl: ownerQuery,
+    referralStub: {
+      createReferralProgram: async (campaignId, options) => {
+        received = { campaignId, options };
+        return {
+          id: 'prog-1',
+          campaign_id: campaignId,
+          commission_percentage: '5.00',
+          max_referrers: 10,
+        };
+      },
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/campaigns/camp-1/referrals')
+    .set('Authorization', 'Bearer token')
+    .send({ commissionPercentage: 5, maxReferrers: 10 });
+
+  assert.equal(response.status, 201);
+  assert.equal(response.body.id, 'prog-1');
+  assert.equal(received.campaignId, 'camp-1');
+  assert.deepEqual(received.options, { commissionPercentage: 5, maxReferrers: 10 });
+});
+
+test('POST /api/campaigns/:id/referrals rejects an out-of-range commission percentage', async () => {
+  const app = buildApp({
+    queryImpl: ownerQuery,
+    referralStub: {
+      createReferralProgram: async () => {
+        const err = new Error('commissionPercentage must be between 1 and 20');
+        err.statusCode = 400;
+        err.code = 'INVALID_COMMISSION_PERCENTAGE';
+        throw err;
+      },
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/campaigns/camp-1/referrals')
+    .set('Authorization', 'Bearer token')
+    .send({ commissionPercentage: 50, maxReferrers: 10 });
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.code, 'INVALID_COMMISSION_PERCENTAGE');
+});
+
+test('POST /api/campaigns/:id/referrals/links returns a code and share url', async () => {
+  const app = buildApp({
+    authUser: { userId: 'user-9', role: 'contributor' },
+    referralStub: {
+      createReferralLink: async ({ campaignId, userId }) => {
+        assert.equal(campaignId, 'camp-1');
+        assert.equal(userId, 'user-9');
+        return {
+          created: true,
+          code: 'a1b2c3d4',
+          shareUrl: 'http://localhost:5173/c/camp-1?ref=a1b2c3d4',
+        };
+      },
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/campaigns/camp-1/referrals/links')
+    .set('Authorization', 'Bearer token')
+    .send({});
+
+  assert.equal(response.status, 201);
+  assert.equal(response.body.code, 'a1b2c3d4');
+  assert.equal(response.body.shareUrl, 'http://localhost:5173/c/camp-1?ref=a1b2c3d4');
+});
+
+test('POST /api/campaigns/:id/referrals/links returns 409 once maxReferrers is reached', async () => {
+  const app = buildApp({
+    authUser: { userId: 'user-11', role: 'contributor' },
+    referralStub: {
+      createReferralLink: async () => {
+        const err = new Error('This campaign has reached its limit of 10 referrers');
+        err.statusCode = 409;
+        err.code = 'REFERRER_LIMIT_REACHED';
+        throw err;
+      },
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/campaigns/camp-1/referrals/links')
+    .set('Authorization', 'Bearer token')
+    .send({});
+
+  assert.equal(response.status, 409);
+  assert.equal(response.body.code, 'REFERRER_LIMIT_REACHED');
+});
+
+test('GET /api/campaigns/:id/referrals/commissions returns the referrer breakdown to the owner', async () => {
+  const app = buildApp({
+    queryImpl: ownerQuery,
+    referralStub: {
+      listCampaignReferrers: async () => ({
+        program: { commission_percentage: 10, max_referrers: 10, referrer_count: 1 },
+        referrers: [
+          {
+            code: 'a1b2c3d4',
+            referrer_name: 'Alice',
+            contribution_count: 2,
+            referred_amount: '600.0000000',
+            commission_owed: '60.0000000',
+          },
+        ],
+      }),
+    },
+  });
+
+  const response = await request(app)
+    .get('/api/campaigns/camp-1/referrals/commissions')
+    .set('Authorization', 'Bearer token');
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.referrers.length, 1);
+  assert.equal(response.body.referrers[0].commission_owed, '60.0000000');
+});
+
+test('GET /api/campaigns/:id/referrals/commissions 404s when referrals are not enabled', async () => {
+  const app = buildApp({ queryImpl: ownerQuery });
+
+  const response = await request(app)
+    .get('/api/campaigns/camp-1/referrals/commissions')
+    .set('Authorization', 'Bearer token');
+
+  assert.equal(response.status, 404);
+});

--- a/backend/src/routes/contributions.js
+++ b/backend/src/routes/contributions.js
@@ -24,8 +24,8 @@ const {
 const { sendEmail } = require("../services/emailService");
 const { SLIPPAGE_BPS } = require("../config/constants");
 const {
+  buildAttributionMemo,
   buildContributionIntent,
-  buildContributionMemo,
   submitCustodialContribution,
 } = require('../services/contributionService');
 const {
@@ -39,6 +39,7 @@ const { emitWebhookEventForUser, emitWebhookEventForCampaign, WEBHOOK_EVENTS } =
 const { assertUserKycVerified } = require('../services/kycService');
 const asyncHandler = require('../utils/asyncHandler');
 const { getReferralCodeFromRequest } = require('../services/referralService');
+const { resolveReferralLink } = require('../services/referral');
 const { reserveTierSlot } = require('../services/rewardTierService');
 const { hashDeviceFingerprint } = require('../utils/deviceFingerprint');
 
@@ -66,6 +67,22 @@ function withReferralMetadata(flowMetadata, campaignId, req) {
   const referralCode = getReferralCodeFromRequest(campaignId, req);
   if (!referralCode) return flowMetadata;
   return { ...flowMetadata, referral_code: referralCode };
+}
+
+/**
+ * Resolve the `?ref=<code>` affiliate link for a campaign (#675).
+ * Throws a 404 INVALID_REFERRAL_CODE error when the code is unknown or belongs
+ * to a different campaign; returns null when no code was supplied.
+ */
+async function resolveAffiliateLink(campaignId, req) {
+  const code = typeof req.query?.ref === 'string' ? req.query.ref.trim() : '';
+  if (!code) return null;
+  return resolveReferralLink({ campaignId, code });
+}
+
+function respondInvalidReferralCode(res, err) {
+  if (err.code !== 'INVALID_REFERRAL_CODE') return null;
+  return res.status(404).json({ error: err.message, code: 'INVALID_REFERRAL_CODE' });
 }
 
 function validateFreighterPublicKey(publicKey) {
@@ -405,6 +422,15 @@ router.post('/prepare', requireAuth, contributionValidation, validateRequest, as
     }
   }
 
+  let affiliateLink;
+  try {
+    affiliateLink = await resolveAffiliateLink(campaign_id, req);
+  } catch (err) {
+    const handled = respondInvalidReferralCode(res, err);
+    if (handled) return handled;
+    throw err;
+  }
+
   try {
     const intent = await buildContributionIntent({
       campaign,
@@ -414,6 +440,7 @@ router.post('/prepare', requireAuth, contributionValidation, validateRequest, as
       displayName: display_name,
     });
 
+    const memo = buildAttributionMemo(campaign_id, affiliateLink?.code || null);
     const unsignedXdr =
       intent.kind === 'payment'
         ? await buildUnsignedContributionPayment({
@@ -421,7 +448,7 @@ router.post('/prepare', requireAuth, contributionValidation, validateRequest, as
             destinationPublicKey: campaign.wallet_public_key,
             asset: send_asset,
             amount,
-            memo: buildContributionMemo(campaign_id),
+            memo,
           })
         : await buildUnsignedContributionPathPayment({
             senderPublicKey: sender_public_key,
@@ -430,7 +457,7 @@ router.post('/prepare', requireAuth, contributionValidation, validateRequest, as
             sendMax: intent.sendMax,
             destAmount: amount,
             destAssetCode: campaign.asset_type,
-            memo: buildContributionMemo(campaign_id),
+            memo,
           });
 
     const prepareToken = createPreparedContributionToken({
@@ -438,7 +465,14 @@ router.post('/prepare', requireAuth, contributionValidation, validateRequest, as
       campaign_id,
       sender_public_key,
       unsigned_xdr: unsignedXdr,
-      flow_metadata: { ...withReferralMetadata(intent.flowMetadata, campaign_id, req), ip_address: req.ip, device_fingerprint: hashDeviceFingerprint(req.body.device_fingerprint) },
+      flow_metadata: {
+        ...withReferralMetadata(intent.flowMetadata, campaign_id, req),
+        ip_address: req.ip,
+        device_fingerprint: hashDeviceFingerprint(req.body.device_fingerprint),
+        ...(affiliateLink
+          ? { referral_link_id: affiliateLink.id, referral_link_code: affiliateLink.code }
+          : {}),
+      },
       conversion_quote: intent.conversionQuote,
     });
 
@@ -601,6 +635,15 @@ router.post('/', contributionPostLimiter, requireAuth, contributionValidation, v
     });
   }
 
+  let affiliateLink;
+  try {
+    affiliateLink = await resolveAffiliateLink(campaign_id, req);
+  } catch (err) {
+    const handled = respondInvalidReferralCode(res, err);
+    if (handled) return handled;
+    throw err;
+  }
+
   // If a specific reward tier was chosen, validate it exists and belongs to this campaign
   if (tier_id) {
     const { rows: tierRows } = await db.query(
@@ -661,6 +704,8 @@ router.post('/', contributionPostLimiter, requireAuth, contributionValidation, v
       sendAsset: send_asset,
       displayName: display_name,
       referralCode: getReferralCodeFromRequest(campaign_id, req),
+      referralLinkId: affiliateLink?.id || null,
+      referralLinkCode: affiliateLink?.code || null,
       ipAddress: req.ip,
       deviceFingerprint: hashDeviceFingerprint(req.body.device_fingerprint),
       client,

--- a/backend/src/routes/contributions.referral.test.js
+++ b/backend/src/routes/contributions.referral.test.js
@@ -1,0 +1,146 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const proxyquire = require('proxyquire').noCallThru();
+const { Networks } = require('@stellar/stellar-sdk');
+
+process.env.USDC_ISSUER = process.env.USDC_ISSUER || 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'unit-test-jwt-secret-for-contributions-32';
+
+const CAMPAIGN = {
+  id: 'camp-1',
+  status: 'active',
+  asset_type: 'XLM',
+  wallet_public_key: 'GCAMPAIGN',
+  creator_email: 'creator@example.com',
+  raised_amount: '0',
+  target_amount: '1000',
+};
+
+function buildApp({ resolveReferralLink, onSubmit }) {
+  const queryImpl = async (text) => {
+    if (text.includes('FROM campaigns c')) return { rows: [CAMPAIGN] };
+    if (text.includes('wallet_secret_encrypted')) {
+      return { rows: [{ wallet_secret_encrypted: 'enc', wallet_public_key: 'GCONTRIB' }] };
+    }
+    if (text.includes('wallet_type')) {
+      return { rows: [{ wallet_type: 'custodial', wallet_public_key: 'GCONTRIB', wallet_funded_at: new Date() }] };
+    }
+    return { rows: [] };
+  };
+
+  const router = proxyquire('./contributions', {
+    '../config/stellar': { networkPassphrase: Networks.TESTNET, isTestnet: true },
+    '../config/database': {
+      query: queryImpl,
+      connect: async () => ({ query: queryImpl, release: async () => {} }),
+    },
+    '../services/stellarService': {
+      buildUnsignedContributionPayment: async () => 'unsigned-xdr',
+      buildUnsignedContributionPathPayment: async () => 'unsigned-xdr',
+      submitPreparedTransaction: async () => 'tx-hash',
+      getPathPaymentQuote: async () => [],
+      getSupportedAssetCodes: () => ['XLM', 'USDC'],
+      isBadSequenceError: () => false,
+      accountExistsOnLedger: async () => true,
+    },
+    '../services/stellarTransactionService': { insertContributionSubmitted: async () => 'stellar-row' },
+    '../services/contributionService': {
+      buildAttributionMemo: (campaignId, code) => (code ? `ref:${code}` : `cp-${campaignId}`),
+      buildContributionIntent: async () => ({ kind: 'payment', conversionQuote: null, flowMetadata: {} }),
+      submitCustodialContribution: async (params) => {
+        onSubmit?.(params);
+        return { txHash: 'tx-hash', stellarTransactionId: 'stellar-row', conversionQuote: null };
+      },
+    },
+    '../services/referral': { resolveReferralLink },
+    '../services/referralService': { getReferralCodeFromRequest: () => null },
+    '../services/rewardTierService': { reserveTierSlot: async () => null },
+    '../services/sorobanService': { triggerRefund: async () => null },
+    '../services/kycService': { assertUserKycVerified: async () => {} },
+    '../services/emailService': { sendEmail: async () => {} },
+    '../middleware/auth': {
+      requireAuth: (req, _res, next) => {
+        req.user = { userId: 'user-1' };
+        next();
+      },
+    },
+    '../middleware/validation': {
+      contributionValidation: [],
+      contributionQuoteValidation: [],
+      validateRequest: (_req, _res, next) => next(),
+    },
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/contributions', router);
+  return app;
+}
+
+test('POST /api/contributions?ref=CODE attributes the contribution to the referral link', async () => {
+  let submitted;
+  const app = buildApp({
+    resolveReferralLink: async ({ campaignId, code }) => {
+      assert.equal(campaignId, 'camp-1');
+      assert.equal(code, 'a1b2c3d4');
+      return { id: 'link-1', campaign_id: 'camp-1', user_id: 'user-2', code: 'a1b2c3d4' };
+    },
+    onSubmit: (params) => {
+      submitted = params;
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/contributions?ref=a1b2c3d4')
+    .set('Authorization', 'Bearer token')
+    .send({ campaign_id: 'camp-1', amount: '100', send_asset: 'XLM' });
+
+  assert.equal(response.status, 202);
+  assert.equal(submitted.referralLinkId, 'link-1');
+  assert.equal(submitted.referralLinkCode, 'a1b2c3d4');
+});
+
+test('POST /api/contributions?ref=CODE returns 404 INVALID_REFERRAL_CODE for another campaign\'s code', async () => {
+  const app = buildApp({
+    resolveReferralLink: async () => {
+      const err = new Error('Referral code is not valid for this campaign');
+      err.statusCode = 404;
+      err.code = 'INVALID_REFERRAL_CODE';
+      throw err;
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/contributions?ref=notmine1')
+    .set('Authorization', 'Bearer token')
+    .send({ campaign_id: 'camp-1', amount: '100', send_asset: 'XLM' });
+
+  assert.equal(response.status, 404);
+  assert.equal(response.body.code, 'INVALID_REFERRAL_CODE');
+});
+
+test('POST /api/contributions without ?ref stays unattributed', async () => {
+  let submitted;
+  let resolveCalled = false;
+  const app = buildApp({
+    resolveReferralLink: async () => {
+      resolveCalled = true;
+      return null;
+    },
+    onSubmit: (params) => {
+      submitted = params;
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/contributions')
+    .set('Authorization', 'Bearer token')
+    .send({ campaign_id: 'camp-1', amount: '100', send_asset: 'XLM' });
+
+  assert.equal(response.status, 202);
+  assert.equal(resolveCalled, false);
+  assert.equal(submitted.referralLinkId, null);
+  assert.equal(submitted.referralLinkCode, null);
+});

--- a/backend/src/routes/contributions.test.js
+++ b/backend/src/routes/contributions.test.js
@@ -73,6 +73,7 @@ function buildApp({ queryImpl, stellarImpl, stellarTxImpl, connectImpl }) {
   const contributionServiceStub = {
     SLIPPAGE_BPS: 500,
     buildContributionMemo: () => 'cp-c-1',
+    buildAttributionMemo: (_campaignId, referralCode) => (referralCode ? `ref:${referralCode}` : 'cp-c-1'),
     buildContributionIntent: async ({ campaign, amount, sendAsset, contributorPublicKey }) => {
       if (sendAsset === campaign.asset_type) {
         return {

--- a/backend/src/routes/referrals.js
+++ b/backend/src/routes/referrals.js
@@ -8,6 +8,7 @@ const {
   getUserFraudChecks,
   resolveFraudCheck,
 } = require('../services/referralService');
+const { listUserReferralLinks } = require('../services/referral');
 const asyncHandler = require('../utils/asyncHandler');
 
 /**
@@ -46,6 +47,38 @@ router.get('/leaderboard', asyncHandler(async (req, res) => {
   const { limit = 20, offset = 0 } = req.query;
   const leaderboard = await getLeaderboard({ limit: Math.min(Number(limit), 100), offset: Math.max(Number(offset), 0) });
   res.json({ leaderboard });
+}));
+
+/**
+ * @openapi
+ * /api/referrals/links:
+ *   get:
+ *     tags: [Referrals]
+ *     summary: Affiliate links held by the authenticated user, with commission earned
+ *     security: [{ bearerAuth: [] }]
+ *     responses:
+ *       200:
+ *         description: List of referral links
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 links:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       code: { type: string }
+ *                       campaign_title: { type: string }
+ *                       share_url: { type: string }
+ *                       referred_amount: { type: string }
+ *                       commission_earned: { type: string }
+ *                       status: { type: string, enum: [no_referrals, pending, paid] }
+ */
+router.get('/links', requireAuth, asyncHandler(async (req, res) => {
+  const links = await listUserReferralLinks(req.user.userId);
+  res.json({ links });
 }));
 
 /**

--- a/backend/src/routes/withdrawals.js
+++ b/backend/src/routes/withdrawals.js
@@ -23,6 +23,7 @@ const { emitWebhookEventForUser, WEBHOOK_EVENTS } = require('../services/webhook
 const { withDecryptedWalletSecret } = require('../services/walletSecrets');
 const { createNotification } = require('../services/notifications');
 const { notifyContributorFundRelease } = require('../services/fundReleaseNotifications');
+const { calculateCommissions, settleCommissions } = require('../services/referral');
 const { parsePagination } = require('../utils/pagination');
 const asyncHandler = require('../utils/asyncHandler');
 
@@ -209,11 +210,35 @@ router.post('/request', requireAuth, withdrawalValidation, validateRequest, asyn
     });
   }
 
+  // Referral commissions are settled out of the campaign balance in the same
+  // transaction as the creator payout (#675).
+  const { commissions, totalCommission } = await calculateCommissions(campaign_id);
+  const payableCommissions = commissions.filter(
+    (commission) => commission.destination_public_key && parseFloat(commission.commission_owed) > 0
+  );
+  const commissionTotal = payableCommissions.reduce(
+    (sum, commission) => sum + parseFloat(commission.commission_owed),
+    0
+  );
+  const creatorAmount = (parseFloat(amount) - commissionTotal).toFixed(7);
+
+  if (parseFloat(creatorAmount) <= 0) {
+    return res.status(422).json({
+      error: `Referral commissions of ${totalCommission} ${campaign.asset_type} exceed the requested withdrawal amount. Withdraw a larger amount.`,
+      code: 'COMMISSIONS_EXCEED_WITHDRAWAL',
+      total_commission: totalCommission,
+    });
+  }
+
   const xdr = await buildWithdrawalTransaction({
     campaignWalletPublicKey: campaign.wallet_public_key,
     destinationPublicKey: destination_key,
-    amount,
+    amount: creatorAmount,
     asset: campaign.asset_type,
+    commissions: payableCommissions.map((commission) => ({
+      destinationPublicKey: commission.destination_public_key,
+      amount: commission.commission_owed,
+    })),
   });
 
   const client = await db.connect();
@@ -242,10 +267,21 @@ router.post('/request', requireAuth, withdrawalValidation, validateRequest, asyn
         amount,
         destination_key,
         asset_type: campaign.asset_type,
+        creator_amount: creatorAmount,
+        referral_commissions: payableCommissions.map((commission) => ({
+          referral_link_id: commission.referral_link_id,
+          code: commission.code,
+          destination_public_key: commission.destination_public_key,
+          commission_owed: commission.commission_owed,
+        })),
       },
     });
     await client.query('COMMIT');
-    res.status(201).json(rows[0]);
+    res.status(201).json({
+      ...rows[0],
+      creator_amount: creatorAmount,
+      referral_commissions: payableCommissions,
+    });
   } catch (err) {
     await client.query('ROLLBACK');
     logger.error('Withdrawal request creation failed', { error: err.message, campaign_id });
@@ -516,6 +552,19 @@ const platformApproveHandler = async (req, res) => {
       [txHash, req.params.id]
     );
     updatedWithdrawalRow = updated[0];
+
+    // Record the commissions now settled on-chain so a later withdrawal for the
+    // same campaign does not pay the same referrers twice (#675).
+    const { rows: withdrawalTxRows } = await finalizeClient.query(
+      `SELECT metadata FROM stellar_transactions
+       WHERE withdrawal_request_id = $1 AND kind = 'withdrawal'
+       LIMIT 1`,
+      [req.params.id]
+    );
+    await settleCommissions(
+      finalizeClient,
+      withdrawalTxRows[0]?.metadata?.referral_commissions || []
+    );
 
     await finalizeWithdrawalSubmitted(finalizeClient, {
       withdrawalRequestId: req.params.id,

--- a/backend/src/routes/withdrawals.test.js
+++ b/backend/src/routes/withdrawals.test.js
@@ -4,7 +4,7 @@ const express = require('express');
 const request = require('supertest');
 const proxyquire = require('proxyquire').noCallThru();
 
-function buildApp({ queryImpl, stellarImpl, userId = 'creator-1', role = 'creator', platformApproverUserId } = {}) {
+function buildApp({ queryImpl, stellarImpl, referralImpl, userId = 'creator-1', role = 'creator', platformApproverUserId } = {}) {
   const prevApprover = process.env.PLATFORM_APPROVER_USER_ID;
   if (platformApproverUserId !== false) {
     process.env.PLATFORM_APPROVER_USER_ID = platformApproverUserId ?? userId;
@@ -25,7 +25,14 @@ function buildApp({ queryImpl, stellarImpl, userId = 'creator-1', role = 'creato
     ...stellarImpl,
   };
 
+  const referralStub = {
+    calculateCommissions: async () => ({ program: null, commissions: [], totalCommission: '0.0000000' }),
+    settleCommissions: async () => {},
+    ...referralImpl,
+  };
+
   const router = proxyquire('./withdrawals', {
+    '../services/referral': referralStub,
     '../config/database': {
       connect: async () => ({
         query: queryImpl,
@@ -626,4 +633,167 @@ test('POST /api/withdrawals/:id/approve/platform returns 410 when XDR time bound
   cleanup();
   assert.equal(response.status, 410);
   assert.match(response.body.error, /expired/i);
+});
+
+test('POST /api/withdrawals/request splits the payout between the creator and referrers', async () => {
+  let builtWith;
+  let insertedMetadata;
+  const { app, cleanup } = buildApp({
+    referralImpl: {
+      calculateCommissions: async () => ({
+        program: { commission_percentage: 10, max_referrers: 10 },
+        commissions: [
+          {
+            referral_link_id: 'link-1',
+            code: 'aaaa1111',
+            destination_public_key: 'GALICE',
+            commission_owed: '60.0000000',
+          },
+          {
+            referral_link_id: 'link-2',
+            code: 'bbbb2222',
+            destination_public_key: 'GBOB',
+            commission_owed: '30.0000000',
+          },
+        ],
+        totalCommission: '90.0000000',
+      }),
+    },
+    stellarImpl: {
+      buildWithdrawalTransaction: async (params) => {
+        builtWith = params;
+        return 'xdr-base';
+      },
+    },
+    queryImpl: async (text, params) => {
+      if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
+      if (text.includes('FROM campaigns WHERE id')) return { rows: [campaignRow()] };
+      if (text.includes('FROM withdrawal_requests') && text.includes("status = 'pending'")) return { rows: [] };
+      if (text.includes('wallet_public_key FROM users')) return { rows: [{ wallet_public_key: 'GCREATOR' }] };
+      if (text.includes('INSERT INTO withdrawal_requests')) {
+        return { rows: [{ id: 'w-1', status: 'pending', creator_signed: false, platform_signed: false }] };
+      }
+      if (text.includes('INSERT INTO stellar_transactions')) {
+        insertedMetadata = JSON.parse(params[4]);
+        return { rows: [{ id: 'stellar-1' }] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/request')
+    .set('Authorization', 'Bearer token')
+    .send({
+      campaign_id: '11111111-1111-1111-1111-111111111111',
+      destination_key: VALID_DESTINATION,
+      amount: '1000.0000000',
+    });
+
+  cleanup();
+  assert.equal(response.status, 201);
+  // Creator receives the requested amount less the 90 owed to referrers
+  assert.equal(builtWith.amount, '910.0000000');
+  assert.equal(builtWith.commissions.length, 2);
+  assert.deepEqual(builtWith.commissions[0], { destinationPublicKey: 'GALICE', amount: '60.0000000' });
+  assert.deepEqual(builtWith.commissions[1], { destinationPublicKey: 'GBOB', amount: '30.0000000' });
+  assert.equal(insertedMetadata.referral_commissions.length, 2);
+  assert.equal(response.body.creator_amount, '910.0000000');
+});
+
+test('POST /api/withdrawals/request rejects a withdrawal smaller than the commissions owed', async () => {
+  const { app, cleanup } = buildApp({
+    referralImpl: {
+      calculateCommissions: async () => ({
+        program: { commission_percentage: 20, max_referrers: 10 },
+        commissions: [
+          {
+            referral_link_id: 'link-1',
+            code: 'aaaa1111',
+            destination_public_key: 'GALICE',
+            commission_owed: '60.0000000',
+          },
+        ],
+        totalCommission: '60.0000000',
+      }),
+    },
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns WHERE id')) return { rows: [campaignRow()] };
+      if (text.includes('FROM withdrawal_requests') && text.includes("status = 'pending'")) return { rows: [] };
+      if (text.includes('wallet_public_key FROM users')) return { rows: [{ wallet_public_key: 'GCREATOR' }] };
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/request')
+    .set('Authorization', 'Bearer token')
+    .send({
+      campaign_id: '11111111-1111-1111-1111-111111111111',
+      destination_key: VALID_DESTINATION,
+      amount: '50.0000000',
+    });
+
+  cleanup();
+  assert.equal(response.status, 422);
+  assert.equal(response.body.code, 'COMMISSIONS_EXCEED_WITHDRAWAL');
+});
+
+test('POST /api/withdrawals/:id/approve/platform settles the commissions it submitted', async () => {
+  let settled;
+  const { app, cleanup } = buildApp({
+    referralImpl: {
+      settleCommissions: async (_client, commissions) => {
+        settled = commissions;
+      },
+    },
+    queryImpl: async (text) => {
+      if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
+      if (text.includes('FROM withdrawal_requests wr')) {
+        return {
+          rows: [{
+            id: 'w-1',
+            campaign_id: '11111111-1111-1111-1111-111111111111',
+            status: 'pending',
+            creator_signed: true,
+            platform_signed: false,
+            unsigned_xdr: 'xdr-creator-signed',
+            amount: '910.0000000',
+            destination_key: VALID_DESTINATION,
+            campaign_status: 'active',
+            creator_id: 'creator-1',
+          }],
+        };
+      }
+      if (text.includes('UPDATE withdrawal_requests') && text.includes("status = 'approved'")) {
+        return { rows: [{ id: 'w-1', status: 'approved' }] };
+      }
+      if (text.includes('UPDATE withdrawal_requests') && text.includes("status = 'submitted'")) {
+        return { rows: [{ id: 'w-1', status: 'submitted', campaign_id: '11111111-1111-1111-1111-111111111111', amount: '910.0000000' }] };
+      }
+      if (text.includes('SELECT metadata FROM stellar_transactions')) {
+        return {
+          rows: [{
+            metadata: {
+              referral_commissions: [
+                { referral_link_id: 'link-1', code: 'aaaa1111', commission_owed: '60.0000000' },
+              ],
+            },
+          }],
+        };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/w-1/approve/platform')
+    .set('Authorization', 'Bearer token')
+    .send({});
+
+  cleanup();
+  assert.equal(response.status, 200);
+  assert.equal(settled.length, 1);
+  assert.equal(settled[0].referral_link_id, 'link-1');
+  assert.equal(settled[0].commission_owed, '60.0000000');
 });

--- a/backend/src/services/contributionService.js
+++ b/backend/src/services/contributionService.js
@@ -8,9 +8,18 @@ const {
   ensureCustodialAccountFundedAndTrusted,
 } = require('./stellarService');
 const { SLIPPAGE_BPS } = require('../config/constants');
+const { buildReferralMemo } = require('./referral');
 
 function buildContributionMemo(campaignId) {
   return `cp-${String(campaignId).replace(/-/g, '').slice(0, 25)}`.slice(0, 28);
+}
+
+/**
+ * A referred contribution carries `ref:<code>` instead of the campaign memo, so
+ * attribution is recorded on-chain and stays verifiable from Horizon (#675).
+ */
+function buildAttributionMemo(campaignId, referralCode) {
+  return referralCode ? buildReferralMemo(referralCode) : buildContributionMemo(campaignId);
 }
 
 async function buildContributionIntent({
@@ -86,6 +95,8 @@ async function submitCustodialContribution({
   anchorMetadata,
   displayName,
   referralCode,
+  referralLinkCode,
+  referralLinkId,
   ipAddress,
   deviceFingerprint,
   client,
@@ -119,7 +130,7 @@ async function submitCustodialContribution({
           destinationPublicKey: campaign.wallet_public_key,
           asset: sendAsset,
           amount,
-          memo: buildContributionMemo(campaignId),
+          memo: buildAttributionMemo(campaignId, referralLinkCode),
         });
       }
 
@@ -130,7 +141,7 @@ async function submitCustodialContribution({
         sendMax: intent.sendMax,
         destAmount: amount,
         destAssetCode: campaign.asset_type,
-        memo: buildContributionMemo(campaignId),
+        memo: buildAttributionMemo(campaignId, referralLinkCode),
       });
     }
   );
@@ -151,6 +162,7 @@ async function submitCustodialContribution({
     tier_id: tierId || null,
     nft_reward: Boolean(tierId),
     ...(referralCode ? { referral_code: referralCode } : {}),
+    ...(referralLinkId ? { referral_link_id: referralLinkId, referral_link_code: referralLinkCode } : {}),
     ...(anchorMetadata
       ? {
           anchor: {
@@ -184,6 +196,7 @@ async function submitCustodialContribution({
 }
 
 module.exports = {
+  buildAttributionMemo,
   buildContributionIntent,
   buildContributionMemo,
   submitCustodialContribution,

--- a/backend/src/services/ledgerMonitor.js
+++ b/backend/src/services/ledgerMonitor.js
@@ -262,14 +262,16 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
     const ipAddress = submittedRows[0]?.metadata?.ip_address || null;
     const deviceFingerprint = submittedRows[0]?.metadata?.device_fingerprint || null;
     const reservedTierId = submittedRows[0]?.metadata?.tier_id || null;
+    const referralLinkId = submittedRows[0]?.metadata?.referral_link_id || null;
     const nftRewardRequested = submittedRows[0]?.metadata?.nft_reward === true;
 
     const { rows: inserted } = await client.query(
       `INSERT INTO contributions
          (campaign_id, sender_public_key, amount, asset, anchor_id, anchor_transaction_id,
           anchor_asset, anchor_amount, payment_type, source_amount, source_asset,
-          conversion_rate, path, tx_hash, platform_fee_amount, display_name, ip_address, device_fingerprint)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14, $15, $16, $17, $18)
+          conversion_rate, path, tx_hash, platform_fee_amount, display_name, ip_address, device_fingerprint,
+          referral_link_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14, $15, $16, $17, $18, $19)
        RETURNING id`,
       [
         campaignId,
@@ -290,6 +292,7 @@ async function handlePayment(campaignId, walletPublicKey, payment) {
         displayName,
         ipAddress,
         deviceFingerprint,
+        referralLinkId,
       ],
     );
 

--- a/backend/src/services/referral.js
+++ b/backend/src/services/referral.js
@@ -1,0 +1,372 @@
+const crypto = require('crypto');
+const db = require('../config/database');
+
+// Stellar memo text is capped at 28 bytes; `ref:` + an 8-char code fits comfortably.
+const MEMO_PREFIX = 'ref:';
+const REFERRAL_CODE_LENGTH = 8;
+const CODE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+const STELLAR_DECIMALS = 7;
+
+const MIN_COMMISSION_PERCENTAGE = 1;
+const MAX_COMMISSION_PERCENTAGE = 20;
+const MIN_MAX_REFERRERS = 1;
+const MAX_MAX_REFERRERS = 100;
+
+function httpError(statusCode, code, message) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  err.code = code;
+  return err;
+}
+
+function frontendBaseUrl() {
+  return (process.env.FRONTEND_URL || 'http://localhost:5173').replace(/\/$/, '');
+}
+
+function buildShareUrl(campaignId, code) {
+  return `${frontendBaseUrl()}/c/${campaignId}?ref=${code}`;
+}
+
+function buildReferralMemo(code) {
+  return `${MEMO_PREFIX}${code}`;
+}
+
+/** Round to Stellar's 7-decimal precision without ever paying out more than is owed. */
+function toStellarAmount(value) {
+  const scale = 10 ** STELLAR_DECIMALS;
+  return (Math.floor(Number(value) * scale) / scale).toFixed(STELLAR_DECIMALS);
+}
+
+function randomCode() {
+  const bytes = crypto.randomBytes(REFERRAL_CODE_LENGTH);
+  let code = '';
+  for (let i = 0; i < REFERRAL_CODE_LENGTH; i++) {
+    code += CODE_ALPHABET[bytes[i] % CODE_ALPHABET.length];
+  }
+  return code;
+}
+
+async function generateUniqueLinkCode(runner = db) {
+  for (let i = 0; i < 10; i++) {
+    const code = randomCode();
+    const { rows } = await runner.query('SELECT 1 FROM referral_links WHERE code = $1', [code]);
+    if (!rows.length) return code;
+  }
+  throw new Error('Could not generate unique referral code');
+}
+
+/**
+ * Enable referrals on a campaign. Re-running updates the existing program so a
+ * creator can adjust the commission without orphaning issued links.
+ */
+async function createReferralProgram(campaignId, { commissionPercentage, maxReferrers }, runner = db) {
+  const percentage = Number(commissionPercentage);
+  const referrers = Number(maxReferrers);
+
+  if (
+    !Number.isFinite(percentage) ||
+    percentage < MIN_COMMISSION_PERCENTAGE ||
+    percentage > MAX_COMMISSION_PERCENTAGE
+  ) {
+    throw httpError(
+      400,
+      'INVALID_COMMISSION_PERCENTAGE',
+      `commissionPercentage must be between ${MIN_COMMISSION_PERCENTAGE} and ${MAX_COMMISSION_PERCENTAGE}`
+    );
+  }
+  if (
+    !Number.isInteger(referrers) ||
+    referrers < MIN_MAX_REFERRERS ||
+    referrers > MAX_MAX_REFERRERS
+  ) {
+    throw httpError(
+      400,
+      'INVALID_MAX_REFERRERS',
+      `maxReferrers must be an integer between ${MIN_MAX_REFERRERS} and ${MAX_MAX_REFERRERS}`
+    );
+  }
+
+  const { rows } = await runner.query(
+    `INSERT INTO referral_programs (campaign_id, commission_percentage, max_referrers)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (campaign_id) DO UPDATE
+       SET commission_percentage = EXCLUDED.commission_percentage,
+           max_referrers = EXCLUDED.max_referrers
+     RETURNING id, campaign_id, commission_percentage, max_referrers, created_at`,
+    [campaignId, percentage, referrers]
+  );
+  return rows[0];
+}
+
+async function getReferralProgram(campaignId, runner = db) {
+  const { rows } = await runner.query(
+    `SELECT id, campaign_id, commission_percentage, max_referrers, created_at
+     FROM referral_programs WHERE campaign_id = $1`,
+    [campaignId]
+  );
+  return rows[0] || null;
+}
+
+/**
+ * Issue (or return the existing) referral link for a user on a campaign.
+ * Rejects with REFERRER_LIMIT_REACHED once max_referrers links exist.
+ */
+async function createReferralLink({ campaignId, userId }, runner = db) {
+  const program = await getReferralProgram(campaignId, runner);
+  if (!program) {
+    throw httpError(404, 'REFERRAL_PROGRAM_NOT_FOUND', 'This campaign does not have a referral program');
+  }
+
+  const { rows: existing } = await runner.query(
+    'SELECT id, code, created_at FROM referral_links WHERE campaign_id = $1 AND user_id = $2',
+    [campaignId, userId]
+  );
+  if (existing.length) {
+    return {
+      link: existing[0],
+      created: false,
+      code: existing[0].code,
+      shareUrl: buildShareUrl(campaignId, existing[0].code),
+    };
+  }
+
+  const { rows: countRows } = await runner.query(
+    'SELECT COUNT(*)::int AS total FROM referral_links WHERE campaign_id = $1',
+    [campaignId]
+  );
+  if ((countRows[0]?.total || 0) >= program.max_referrers) {
+    throw httpError(
+      409,
+      'REFERRER_LIMIT_REACHED',
+      `This campaign has reached its limit of ${program.max_referrers} referrers`
+    );
+  }
+
+  const code = await generateUniqueLinkCode(runner);
+  const { rows } = await runner.query(
+    `INSERT INTO referral_links (campaign_id, user_id, code)
+     VALUES ($1, $2, $3)
+     RETURNING id, code, created_at`,
+    [campaignId, userId, code]
+  );
+  return {
+    link: rows[0],
+    created: true,
+    code: rows[0].code,
+    shareUrl: buildShareUrl(campaignId, rows[0].code),
+  };
+}
+
+/**
+ * Resolve a referral code for a campaign. A code that exists but belongs to a
+ * different campaign is treated exactly like a missing one.
+ */
+async function resolveReferralLink({ campaignId, code }, runner = db) {
+  if (!code) return null;
+  const { rows } = await runner.query(
+    'SELECT id, campaign_id, user_id, code FROM referral_links WHERE code = $1 AND campaign_id = $2',
+    [code, campaignId]
+  );
+  if (!rows.length) {
+    throw httpError(404, 'INVALID_REFERRAL_CODE', 'Referral code is not valid for this campaign');
+  }
+  return rows[0];
+}
+
+/**
+ * Commission owed to every referrer of a campaign, net of commission already
+ * paid out by earlier withdrawals. Referrers with nothing owed are excluded so
+ * a zero-amount payment can never reach the withdrawal transaction.
+ */
+async function calculateCommissions(campaignId, runner = db) {
+  const program = await getReferralProgram(campaignId, runner);
+  if (!program) {
+    return { program: null, commissions: [], totalCommission: '0.0000000' };
+  }
+
+  const { rows } = await runner.query(
+    `SELECT rl.id AS referral_link_id,
+            rl.code,
+            rl.user_id,
+            rl.commission_paid,
+            u.name AS referrer_name,
+            u.wallet_public_key,
+            COUNT(c.id)::int AS contribution_count,
+            COALESCE(SUM(c.amount), 0)::numeric AS referred_amount
+     FROM referral_links rl
+     JOIN users u ON u.id = rl.user_id
+     LEFT JOIN contributions c
+       ON c.referral_link_id = rl.id AND c.refunded = FALSE
+     WHERE rl.campaign_id = $1
+     GROUP BY rl.id, rl.code, rl.user_id, rl.commission_paid, u.name, u.wallet_public_key
+     ORDER BY referred_amount DESC`,
+    [campaignId]
+  );
+
+  const rate = Number(program.commission_percentage) / 100;
+  const commissions = [];
+  let total = 0;
+
+  for (const row of rows) {
+    const referredAmount = Number(row.referred_amount);
+    const earned = Number(toStellarAmount(referredAmount * rate));
+    const owed = Number(toStellarAmount(earned - Number(row.commission_paid)));
+    if (owed <= 0) continue;
+
+    commissions.push({
+      referral_link_id: row.referral_link_id,
+      code: row.code,
+      user_id: row.user_id,
+      referrer_name: row.referrer_name,
+      destination_public_key: row.wallet_public_key,
+      contribution_count: row.contribution_count,
+      referred_amount: toStellarAmount(referredAmount),
+      commission_earned: toStellarAmount(earned),
+      commission_paid: toStellarAmount(row.commission_paid),
+      commission_owed: toStellarAmount(owed),
+    });
+    total += owed;
+  }
+
+  return {
+    program: {
+      commission_percentage: Number(program.commission_percentage),
+      max_referrers: program.max_referrers,
+    },
+    commissions,
+    totalCommission: toStellarAmount(total),
+  };
+}
+
+/**
+ * Full referrer breakdown for the campaign analytics tab — unlike
+ * calculateCommissions this keeps referrers who have not converted yet.
+ */
+async function listCampaignReferrers(campaignId, runner = db) {
+  const program = await getReferralProgram(campaignId, runner);
+  if (!program) return { program: null, referrers: [] };
+
+  const { rows } = await runner.query(
+    `SELECT rl.id AS referral_link_id,
+            rl.code,
+            rl.user_id,
+            rl.commission_paid,
+            rl.created_at,
+            u.name AS referrer_name,
+            COUNT(c.id)::int AS contribution_count,
+            COALESCE(SUM(c.amount), 0)::numeric AS referred_amount
+     FROM referral_links rl
+     JOIN users u ON u.id = rl.user_id
+     LEFT JOIN contributions c
+       ON c.referral_link_id = rl.id AND c.refunded = FALSE
+     WHERE rl.campaign_id = $1
+     GROUP BY rl.id, rl.code, rl.user_id, rl.commission_paid, rl.created_at, u.name
+     ORDER BY referred_amount DESC, rl.created_at ASC`,
+    [campaignId]
+  );
+
+  const rate = Number(program.commission_percentage) / 100;
+  return {
+    program: {
+      commission_percentage: Number(program.commission_percentage),
+      max_referrers: program.max_referrers,
+      referrer_count: rows.length,
+    },
+    referrers: rows.map((row) => {
+      const earned = Number(toStellarAmount(Number(row.referred_amount) * rate));
+      return {
+        referral_link_id: row.referral_link_id,
+        code: row.code,
+        user_id: row.user_id,
+        referrer_name: row.referrer_name,
+        contribution_count: row.contribution_count,
+        referred_amount: toStellarAmount(row.referred_amount),
+        commission_earned: toStellarAmount(earned),
+        commission_paid: toStellarAmount(row.commission_paid),
+        commission_owed: toStellarAmount(Math.max(earned - Number(row.commission_paid), 0)),
+        created_at: row.created_at,
+      };
+    }),
+  };
+}
+
+/** Every referral link a user holds, with the commission each has earned. */
+async function listUserReferralLinks(userId, runner = db) {
+  const { rows } = await runner.query(
+    `SELECT rl.id AS referral_link_id,
+            rl.code,
+            rl.campaign_id,
+            rl.commission_paid,
+            rl.created_at,
+            c.title AS campaign_title,
+            c.status AS campaign_status,
+            c.asset_type,
+            rp.commission_percentage,
+            COUNT(ctr.id)::int AS contribution_count,
+            COALESCE(SUM(ctr.amount), 0)::numeric AS referred_amount
+     FROM referral_links rl
+     JOIN campaigns c ON c.id = rl.campaign_id
+     LEFT JOIN referral_programs rp ON rp.campaign_id = rl.campaign_id
+     LEFT JOIN contributions ctr
+       ON ctr.referral_link_id = rl.id AND ctr.refunded = FALSE
+     WHERE rl.user_id = $1
+     GROUP BY rl.id, rl.code, rl.campaign_id, rl.commission_paid, rl.created_at,
+              c.title, c.status, c.asset_type, rp.commission_percentage
+     ORDER BY rl.created_at DESC`,
+    [userId]
+  );
+
+  return rows.map((row) => {
+    const rate = Number(row.commission_percentage || 0) / 100;
+    const earned = Number(toStellarAmount(Number(row.referred_amount) * rate));
+    const paid = Number(row.commission_paid);
+    return {
+      referral_link_id: row.referral_link_id,
+      code: row.code,
+      campaign_id: row.campaign_id,
+      campaign_title: row.campaign_title,
+      campaign_status: row.campaign_status,
+      asset_type: row.asset_type,
+      commission_percentage: Number(row.commission_percentage || 0),
+      share_url: buildShareUrl(row.campaign_id, row.code),
+      contribution_count: row.contribution_count,
+      referred_amount: toStellarAmount(row.referred_amount),
+      commission_earned: toStellarAmount(earned),
+      commission_paid: toStellarAmount(paid),
+      commission_owed: toStellarAmount(Math.max(earned - paid, 0)),
+      status: earned <= 0 ? 'no_referrals' : paid >= earned ? 'paid' : 'pending',
+      created_at: row.created_at,
+    };
+  });
+}
+
+/**
+ * Record commissions that have just been submitted on-chain so the next
+ * withdrawal for the campaign does not pay them again.
+ */
+async function settleCommissions(client, commissions = []) {
+  const runner = client || db;
+  for (const commission of commissions) {
+    await runner.query(
+      'UPDATE referral_links SET commission_paid = commission_paid + $1 WHERE id = $2',
+      [commission.commission_owed ?? commission.amount, commission.referral_link_id]
+    );
+  }
+}
+
+module.exports = {
+  buildReferralMemo,
+  buildShareUrl,
+  calculateCommissions,
+  createReferralLink,
+  createReferralProgram,
+  generateUniqueLinkCode,
+  getReferralProgram,
+  listCampaignReferrers,
+  listUserReferralLinks,
+  resolveReferralLink,
+  settleCommissions,
+  toStellarAmount,
+  MEMO_PREFIX,
+  REFERRAL_CODE_LENGTH,
+};

--- a/backend/src/services/referral.test.js
+++ b/backend/src/services/referral.test.js
@@ -1,0 +1,294 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const proxyquire = require('proxyquire').noCallThru();
+
+function buildReferral(queryImpl) {
+  return proxyquire('./referral', {
+    '../config/database': { query: queryImpl },
+  });
+}
+
+test('buildReferralMemo produces a ref:<code> memo that fits Stellar memo text', () => {
+  const { buildReferralMemo } = buildReferral(async () => ({ rows: [] }));
+  const memo = buildReferralMemo('a1b2c3d4');
+  assert.equal(memo, 'ref:a1b2c3d4');
+  assert.ok(Buffer.byteLength(memo, 'utf8') <= 28);
+});
+
+test('generateUniqueLinkCode returns an 8-character alphanumeric code and retries on collision', async () => {
+  let selectCount = 0;
+  const { generateUniqueLinkCode } = buildReferral(async (text) => {
+    if (text.includes('FROM referral_links WHERE code')) {
+      selectCount++;
+      return selectCount === 1 ? { rows: [{ 1: 1 }] } : { rows: [] };
+    }
+    return { rows: [] };
+  });
+
+  const code = await generateUniqueLinkCode();
+  assert.equal(selectCount, 2);
+  assert.match(code, /^[A-Za-z0-9]{8}$/);
+});
+
+test('createReferralProgram rejects a commission percentage outside 1-20', async () => {
+  const { createReferralProgram } = buildReferral(async () => ({ rows: [] }));
+  await assert.rejects(
+    () => createReferralProgram('camp-1', { commissionPercentage: 25, maxReferrers: 10 }),
+    (err) => err.statusCode === 400 && err.code === 'INVALID_COMMISSION_PERCENTAGE'
+  );
+  await assert.rejects(
+    () => createReferralProgram('camp-1', { commissionPercentage: 0, maxReferrers: 10 }),
+    (err) => err.code === 'INVALID_COMMISSION_PERCENTAGE'
+  );
+});
+
+test('createReferralProgram rejects maxReferrers outside 1-100', async () => {
+  const { createReferralProgram } = buildReferral(async () => ({ rows: [] }));
+  await assert.rejects(
+    () => createReferralProgram('camp-1', { commissionPercentage: 10, maxReferrers: 101 }),
+    (err) => err.statusCode === 400 && err.code === 'INVALID_MAX_REFERRERS'
+  );
+});
+
+test('createReferralProgram persists a valid program', async () => {
+  const calls = [];
+  const { createReferralProgram } = buildReferral(async (text, params) => {
+    calls.push({ text, params });
+    return { rows: [{ id: 'prog-1', campaign_id: 'camp-1', commission_percentage: '5.00', max_referrers: 10 }] };
+  });
+
+  const program = await createReferralProgram('camp-1', { commissionPercentage: 5, maxReferrers: 10 });
+  assert.equal(program.id, 'prog-1');
+  assert.match(calls[0].text, /INSERT INTO referral_programs/);
+  assert.deepEqual(calls[0].params, ['camp-1', 5, 10]);
+});
+
+test('createReferralLink issues a code and share url', async () => {
+  const { createReferralLink } = buildReferral(async (text) => {
+    if (text.includes('FROM referral_programs')) {
+      return { rows: [{ id: 'prog-1', commission_percentage: '5.00', max_referrers: 3 }] };
+    }
+    if (text.includes('FROM referral_links WHERE campaign_id = $1 AND user_id')) return { rows: [] };
+    if (text.includes('COUNT(*)::int AS total FROM referral_links')) return { rows: [{ total: 1 }] };
+    if (text.includes('FROM referral_links WHERE code')) return { rows: [] };
+    if (text.includes('INSERT INTO referral_links')) {
+      return { rows: [{ id: 'link-1', code: 'abcd1234', created_at: 'now' }] };
+    }
+    return { rows: [] };
+  });
+
+  const result = await createReferralLink({ campaignId: 'camp-1', userId: 'user-2' });
+  assert.equal(result.created, true);
+  assert.equal(result.code, 'abcd1234');
+  assert.match(result.shareUrl, /\/c\/camp-1\?ref=abcd1234$/);
+});
+
+test('createReferralLink returns the existing link instead of issuing a second one', async () => {
+  const calls = [];
+  const { createReferralLink } = buildReferral(async (text) => {
+    calls.push(text);
+    if (text.includes('FROM referral_programs')) {
+      return { rows: [{ id: 'prog-1', commission_percentage: '5.00', max_referrers: 3 }] };
+    }
+    if (text.includes('FROM referral_links WHERE campaign_id = $1 AND user_id')) {
+      return { rows: [{ id: 'link-1', code: 'existing1', created_at: 'now' }] };
+    }
+    return { rows: [] };
+  });
+
+  const result = await createReferralLink({ campaignId: 'camp-1', userId: 'user-2' });
+  assert.equal(result.created, false);
+  assert.equal(result.code, 'existing1');
+  assert.ok(!calls.some((text) => text.includes('INSERT INTO referral_links')));
+});
+
+test('createReferralLink rejects the (n+1)th referrer with REFERRER_LIMIT_REACHED', async () => {
+  const { createReferralLink } = buildReferral(async (text) => {
+    if (text.includes('FROM referral_programs')) {
+      return { rows: [{ id: 'prog-1', commission_percentage: '5.00', max_referrers: 3 }] };
+    }
+    if (text.includes('FROM referral_links WHERE campaign_id = $1 AND user_id')) return { rows: [] };
+    if (text.includes('COUNT(*)::int AS total FROM referral_links')) return { rows: [{ total: 3 }] };
+    return { rows: [] };
+  });
+
+  await assert.rejects(
+    () => createReferralLink({ campaignId: 'camp-1', userId: 'user-4' }),
+    (err) => err.statusCode === 409 && err.code === 'REFERRER_LIMIT_REACHED'
+  );
+});
+
+test('createReferralLink 404s when the campaign has no referral program', async () => {
+  const { createReferralLink } = buildReferral(async () => ({ rows: [] }));
+  await assert.rejects(
+    () => createReferralLink({ campaignId: 'camp-1', userId: 'user-2' }),
+    (err) => err.statusCode === 404 && err.code === 'REFERRAL_PROGRAM_NOT_FOUND'
+  );
+});
+
+test('resolveReferralLink rejects a code that belongs to another campaign', async () => {
+  const { resolveReferralLink } = buildReferral(async () => ({ rows: [] }));
+  await assert.rejects(
+    () => resolveReferralLink({ campaignId: 'camp-1', code: 'other123' }),
+    (err) => err.statusCode === 404 && err.code === 'INVALID_REFERRAL_CODE'
+  );
+});
+
+test('resolveReferralLink returns the link when the code belongs to the campaign', async () => {
+  const { resolveReferralLink } = buildReferral(async (text, params) => {
+    assert.deepEqual(params, ['abcd1234', 'camp-1']);
+    assert.match(text, /FROM referral_links WHERE code = \$1 AND campaign_id = \$2/);
+    return { rows: [{ id: 'link-1', campaign_id: 'camp-1', user_id: 'user-2', code: 'abcd1234' }] };
+  });
+
+  const link = await resolveReferralLink({ campaignId: 'camp-1', code: 'abcd1234' });
+  assert.equal(link.id, 'link-1');
+});
+
+test('resolveReferralLink is a no-op when no code is supplied', async () => {
+  let called = false;
+  const { resolveReferralLink } = buildReferral(async () => {
+    called = true;
+    return { rows: [] };
+  });
+  assert.equal(await resolveReferralLink({ campaignId: 'camp-1', code: null }), null);
+  assert.equal(called, false);
+});
+
+test('calculateCommissions distributes commission proportional to attributed contributions', async () => {
+  const { calculateCommissions } = buildReferral(async (text) => {
+    if (text.includes('FROM referral_programs')) {
+      return { rows: [{ id: 'prog-1', commission_percentage: '10.00', max_referrers: 10 }] };
+    }
+    return {
+      rows: [
+        {
+          referral_link_id: 'link-1', code: 'aaaa1111', user_id: 'u1', commission_paid: '0',
+          referrer_name: 'Alice', wallet_public_key: 'GALICE', contribution_count: 2, referred_amount: '600',
+        },
+        {
+          referral_link_id: 'link-2', code: 'bbbb2222', user_id: 'u2', commission_paid: '0',
+          referrer_name: 'Bob', wallet_public_key: 'GBOB', contribution_count: 1, referred_amount: '300',
+        },
+        {
+          referral_link_id: 'link-3', code: 'cccc3333', user_id: 'u3', commission_paid: '0',
+          referrer_name: 'Cara', wallet_public_key: 'GCARA', contribution_count: 1, referred_amount: '100',
+        },
+      ],
+    };
+  });
+
+  const { commissions, totalCommission } = await calculateCommissions('camp-1');
+
+  assert.equal(commissions.length, 3);
+  // 10% of 600 / 300 / 100 — checked against manual arithmetic
+  assert.equal(commissions[0].commission_owed, '60.0000000');
+  assert.equal(commissions[1].commission_owed, '30.0000000');
+  assert.equal(commissions[2].commission_owed, '10.0000000');
+  assert.equal(totalCommission, '100.0000000');
+});
+
+test('calculateCommissions excludes a referrer whose referred contributions total zero', async () => {
+  const { calculateCommissions } = buildReferral(async (text) => {
+    if (text.includes('FROM referral_programs')) {
+      return { rows: [{ id: 'prog-1', commission_percentage: '5.00', max_referrers: 10 }] };
+    }
+    return {
+      rows: [
+        {
+          referral_link_id: 'link-1', code: 'aaaa1111', user_id: 'u1', commission_paid: '0',
+          referrer_name: 'Alice', wallet_public_key: 'GALICE', contribution_count: 1, referred_amount: '200',
+        },
+        {
+          referral_link_id: 'link-2', code: 'bbbb2222', user_id: 'u2', commission_paid: '0',
+          referrer_name: 'Bob', wallet_public_key: 'GBOB', contribution_count: 0, referred_amount: '0',
+        },
+      ],
+    };
+  });
+
+  const { commissions, totalCommission } = await calculateCommissions('camp-1');
+  assert.equal(commissions.length, 1);
+  assert.equal(commissions[0].code, 'aaaa1111');
+  assert.equal(totalCommission, '10.0000000');
+});
+
+test('calculateCommissions nets off commission already paid by an earlier withdrawal', async () => {
+  const { calculateCommissions } = buildReferral(async (text) => {
+    if (text.includes('FROM referral_programs')) {
+      return { rows: [{ id: 'prog-1', commission_percentage: '10.00', max_referrers: 10 }] };
+    }
+    return {
+      rows: [
+        {
+          referral_link_id: 'link-1', code: 'aaaa1111', user_id: 'u1', commission_paid: '40',
+          referrer_name: 'Alice', wallet_public_key: 'GALICE', contribution_count: 2, referred_amount: '600',
+        },
+        {
+          referral_link_id: 'link-2', code: 'bbbb2222', user_id: 'u2', commission_paid: '30',
+          referrer_name: 'Bob', wallet_public_key: 'GBOB', contribution_count: 1, referred_amount: '300',
+        },
+      ],
+    };
+  });
+
+  const { commissions, totalCommission } = await calculateCommissions('camp-1');
+  assert.equal(commissions.length, 1);
+  assert.equal(commissions[0].commission_owed, '20.0000000');
+  assert.equal(totalCommission, '20.0000000');
+});
+
+test('calculateCommissions returns nothing when the campaign has no referral program', async () => {
+  const { calculateCommissions } = buildReferral(async () => ({ rows: [] }));
+  const result = await calculateCommissions('camp-1');
+  assert.equal(result.program, null);
+  assert.deepEqual(result.commissions, []);
+  assert.equal(result.totalCommission, '0.0000000');
+});
+
+test('settleCommissions credits each referral link with the amount just paid', async () => {
+  const calls = [];
+  const { settleCommissions } = buildReferral(async (text, params) => {
+    calls.push({ text, params });
+    return { rows: [] };
+  });
+
+  await settleCommissions(null, [
+    { referral_link_id: 'link-1', commission_owed: '60.0000000' },
+    { referral_link_id: 'link-2', commission_owed: '30.0000000' },
+  ]);
+
+  assert.equal(calls.length, 2);
+  assert.match(calls[0].text, /commission_paid = commission_paid \+ \$1/);
+  assert.deepEqual(calls[0].params, ['60.0000000', 'link-1']);
+  assert.deepEqual(calls[1].params, ['30.0000000', 'link-2']);
+});
+
+test('listUserReferralLinks reports commission earned and payout status per campaign', async () => {
+  const { listUserReferralLinks } = buildReferral(async () => ({
+    rows: [
+      {
+        referral_link_id: 'link-1', code: 'aaaa1111', campaign_id: 'camp-1', commission_paid: '0',
+        created_at: 'now', campaign_title: 'Solar', campaign_status: 'active', asset_type: 'USDC',
+        commission_percentage: '10.00', contribution_count: 2, referred_amount: '500',
+      },
+      {
+        referral_link_id: 'link-2', code: 'bbbb2222', campaign_id: 'camp-2', commission_paid: '25',
+        created_at: 'now', campaign_title: 'Wells', campaign_status: 'funded', asset_type: 'USDC',
+        commission_percentage: '5.00', contribution_count: 1, referred_amount: '500',
+      },
+      {
+        referral_link_id: 'link-3', code: 'cccc3333', campaign_id: 'camp-3', commission_paid: '0',
+        created_at: 'now', campaign_title: 'Books', campaign_status: 'active', asset_type: 'XLM',
+        commission_percentage: '5.00', contribution_count: 0, referred_amount: '0',
+      },
+    ],
+  }));
+
+  const links = await listUserReferralLinks('user-2');
+  assert.equal(links[0].commission_earned, '50.0000000');
+  assert.equal(links[0].status, 'pending');
+  assert.equal(links[1].status, 'paid');
+  assert.equal(links[2].status, 'no_referrals');
+  assert.match(links[0].share_url, /\/c\/camp-1\?ref=aaaa1111$/);
+});

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -269,7 +269,11 @@ async function buildUnsignedContributionPayment({
     );
   }
 
-  const tx = builder.build();
+  if (memo) {
+    builder.addMemo(Memo.text(memo));
+  }
+
+  const tx = builder.setTimeout(TX_TIMEOUT_CONTRIBUTION_S).build();
   return tx.toXDR();
 }
 
@@ -357,7 +361,11 @@ async function buildUnsignedContributionPathPayment({
     );
   }
 
-  const tx = builder.build();
+  if (memo) {
+    builder.addMemo(Memo.text(memo));
+  }
+
+  const tx = builder.setTimeout(TX_TIMEOUT_CONTRIBUTION_S).build();
   return tx.toXDR();
 }
 
@@ -433,27 +441,48 @@ async function getPathPaymentQuote({ sendAsset, destAsset, destAmount }) {
 /**
  * Build a withdrawal transaction for a campaign wallet.
  * Returns the unsigned XDR — both the creator and platform must sign it.
+ *
+ * `commissions` (issue #675) adds one extra Payment operation per referrer, so
+ * the creator's net payout and every affiliate commission settle atomically in
+ * a single transaction. Zero-amount commissions are dropped rather than turned
+ * into an operation Stellar would reject.
  */
 async function buildWithdrawalTransaction({
   campaignWalletPublicKey,
   destinationPublicKey,
   amount,
   asset,
+  commissions = [],
 }) {
   const campaignAccount = await server.loadAccount(campaignWalletPublicKey);
   const stellarAsset = toStellarAsset(asset);
 
-  const tx = new TransactionBuilder(campaignAccount, {
+  const payableCommissions = commissions.filter(
+    (commission) => commission.destinationPublicKey && parseFloat(commission.amount) > 0
+  );
+
+  const builder = new TransactionBuilder(campaignAccount, {
     fee: BASE_FEE,
     networkPassphrase,
-  })
-    .addOperation(
+  }).addOperation(
+    Operation.payment({
+      destination: destinationPublicKey,
+      asset: stellarAsset,
+      amount: String(amount),
+    })
+  );
+
+  for (const commission of payableCommissions) {
+    builder.addOperation(
       Operation.payment({
-        destination: destinationPublicKey,
+        destination: commission.destinationPublicKey,
         asset: stellarAsset,
-        amount: String(amount),
+        amount: String(commission.amount),
       })
-    )
+    );
+  }
+
+  const tx = builder
     .setTimeout(TX_TIMEOUT_WITHDRAWAL_S) // platform approver may not be available immediately (see issue #128)
     .build();
 

--- a/backend/src/services/stellarService.referral.test.js
+++ b/backend/src/services/stellarService.referral.test.js
@@ -1,0 +1,127 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const proxyquire = require('proxyquire');
+const { Asset, Keypair, Networks, TransactionBuilder } = require('@stellar/stellar-sdk');
+
+const NETWORK_PASSPHRASE = Networks.TESTNET;
+const USDC_ISSUER = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+
+function mockedStellarService() {
+  return proxyquire('./stellarService', {
+    '../config/stellar': {
+      server: {
+        loadAccount: async (key) => ({
+          accountId: () => key,
+          sequenceNumber: () => '100',
+          incrementSequenceNumber: () => {},
+          balances: [],
+          thresholds: { low_threshold: 1, med_threshold: 2, high_threshold: 2 },
+          signers: [{ key, weight: 1 }],
+        }),
+        submitTransaction: async () => ({ hash: 'hash' }),
+      },
+      networkPassphrase: NETWORK_PASSPHRASE,
+      USDC: new Asset('USDC', USDC_ISSUER),
+      isTestnet: true,
+      configuredAssets: { USDC: { issuer: USDC_ISSUER } },
+    },
+    '../config/database': { query: async () => ({ rows: [] }) },
+  });
+}
+
+test('contribution payment carries the referral code in the Stellar memo', async () => {
+  const { buildUnsignedContributionPayment } = mockedStellarService();
+
+  const xdr = await buildUnsignedContributionPayment({
+    senderPublicKey: Keypair.random().publicKey(),
+    destinationPublicKey: Keypair.random().publicKey(),
+    asset: 'XLM',
+    amount: '100',
+    memo: 'ref:a1b2c3d4',
+  });
+
+  const tx = TransactionBuilder.fromXDR(xdr, NETWORK_PASSPHRASE);
+  assert.equal(tx.memo.type, 'text');
+  assert.equal(tx.memo.value.toString('utf8'), 'ref:a1b2c3d4');
+});
+
+test('contribution path payment carries the referral code in the Stellar memo', async () => {
+  const { buildUnsignedContributionPathPayment } = mockedStellarService();
+
+  const xdr = await buildUnsignedContributionPathPayment({
+    senderPublicKey: Keypair.random().publicKey(),
+    destinationPublicKey: Keypair.random().publicKey(),
+    sendAsset: 'XLM',
+    sendMax: '120',
+    destAmount: '100',
+    destAssetCode: 'USDC',
+    memo: 'ref:a1b2c3d4',
+  });
+
+  const tx = TransactionBuilder.fromXDR(xdr, NETWORK_PASSPHRASE);
+  assert.equal(tx.memo.value.toString('utf8'), 'ref:a1b2c3d4');
+});
+
+test('withdrawal transaction has one Payment per referrer plus one for the creator', async () => {
+  const { buildWithdrawalTransaction } = mockedStellarService();
+
+  const creator = Keypair.random().publicKey();
+  const referrers = [
+    { destinationPublicKey: Keypair.random().publicKey(), amount: '60.0000000' },
+    { destinationPublicKey: Keypair.random().publicKey(), amount: '30.0000000' },
+    { destinationPublicKey: Keypair.random().publicKey(), amount: '10.0000000' },
+  ];
+
+  const xdr = await buildWithdrawalTransaction({
+    campaignWalletPublicKey: Keypair.random().publicKey(),
+    destinationPublicKey: creator,
+    amount: '900.0000000',
+    asset: 'XLM',
+    commissions: referrers,
+  });
+
+  const tx = TransactionBuilder.fromXDR(xdr, NETWORK_PASSPHRASE);
+  assert.equal(tx.operations.length, 4);
+  assert.equal(tx.operations[0].destination, creator);
+  assert.equal(tx.operations[0].amount, '900.0000000');
+  referrers.forEach((referrer, index) => {
+    assert.equal(tx.operations[index + 1].type, 'payment');
+    assert.equal(tx.operations[index + 1].destination, referrer.destinationPublicKey);
+    assert.equal(tx.operations[index + 1].amount, referrer.amount);
+  });
+});
+
+test('withdrawal transaction never includes a zero-amount commission payment', async () => {
+  const { buildWithdrawalTransaction } = mockedStellarService();
+
+  const paidReferrer = Keypair.random().publicKey();
+  const xdr = await buildWithdrawalTransaction({
+    campaignWalletPublicKey: Keypair.random().publicKey(),
+    destinationPublicKey: Keypair.random().publicKey(),
+    amount: '950.0000000',
+    asset: 'XLM',
+    commissions: [
+      { destinationPublicKey: paidReferrer, amount: '50.0000000' },
+      { destinationPublicKey: Keypair.random().publicKey(), amount: '0.0000000' },
+      { destinationPublicKey: null, amount: '25.0000000' },
+    ],
+  });
+
+  const tx = TransactionBuilder.fromXDR(xdr, NETWORK_PASSPHRASE);
+  assert.equal(tx.operations.length, 2);
+  assert.equal(tx.operations[1].destination, paidReferrer);
+});
+
+test('withdrawal transaction with no referrals stays a single creator payment', async () => {
+  const { buildWithdrawalTransaction } = mockedStellarService();
+
+  const xdr = await buildWithdrawalTransaction({
+    campaignWalletPublicKey: Keypair.random().publicKey(),
+    destinationPublicKey: Keypair.random().publicKey(),
+    amount: '1000.0000000',
+    asset: 'XLM',
+  });
+
+  const tx = TransactionBuilder.fromXDR(xdr, NETWORK_PASSPHRASE);
+  assert.equal(tx.operations.length, 1);
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,6 +37,8 @@ const NotFound = lazy(() => import('./pages/NotFound'));
 const CreatorProfile = lazy(() => import('./pages/CreatorProfile'));
 const CreatorAnalytics = lazy(() => import('./pages/CreatorAnalytics'));
 const CreatorCampaignAnalytics = lazy(() => import('./pages/CreatorCampaignAnalytics'));
+const CampaignShare = lazy(() => import('./pages/CampaignShare'));
+const ReferralDashboard = lazy(() => import('./pages/ReferralDashboard'));
 
 function PrivateRoute({ children }) {
   const { user, ready } = useAuth();
@@ -78,6 +80,9 @@ export default function App() {
                   }
                 />
                 <Route path="/campaigns/:id" element={<Campaign />} />
+                <Route path="/campaigns/:id/share" element={<CampaignShare />} />
+                {/* Short share link handed out by the referral system (#675) */}
+                <Route path="/c/:id" element={<Campaign />} />
                 <Route path="/campaigns/:id/invite/:token" element={<AcceptInvite />} />
                 <Route path="/embed/campaigns/:id" element={<CampaignEmbed />} />
                 <Route path="/widget/campaigns/:id" element={<Widget />} />
@@ -106,6 +111,14 @@ export default function App() {
                   element={
                     <PrivateRoute>
                       <Dashboard />
+                    </PrivateRoute>
+                  }
+                />
+                <Route
+                  path="/dashboard/referrals"
+                  element={
+                    <PrivateRoute>
+                      <ReferralDashboard />
                     </PrivateRoute>
                   }
                 />

--- a/frontend/src/components/CampaignReferralsTab.jsx
+++ b/frontend/src/components/CampaignReferralsTab.jsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { api } from '../services/api';
+
+export default function CampaignReferralsTab({ campaignId, assetType }) {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!campaignId) return;
+    api
+      .getCampaignReferralCommissions(campaignId)
+      .then(setData)
+      .catch((err) => setError(err.status === 404 ? 'not_enabled' : err.message || 'Failed to load referrals'));
+  }, [campaignId]);
+
+  if (error === 'not_enabled') {
+    return (
+      <p style={{ color: 'var(--color-text-muted)' }}>
+        Referrals are not enabled for this campaign. Turn them on in campaign settings to let
+        supporters earn commission on the contributions they bring in.
+      </p>
+    );
+  }
+  if (error) return <p style={{ color: 'var(--color-danger)' }}>{error}</p>;
+  if (!data) return <p style={{ color: 'var(--color-text-muted)' }}>Loading referrals…</p>;
+
+  const { program, referrers } = data;
+
+  return (
+    <div style={{ display: 'grid', gap: '1rem' }}>
+      <p style={{ margin: 0, fontSize: '0.85rem', color: 'var(--color-text-muted)' }}>
+        {referrers.length} of {program.max_referrers} referrer slots claimed —{' '}
+        {program.commission_percentage}% commission per referred contribution.
+      </p>
+
+      {referrers.length === 0 ? (
+        <p style={{ color: 'var(--color-text-muted)' }}>No one has claimed a referral link yet.</p>
+      ) : (
+        <div className="campaign-card" style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
+            <thead>
+              <tr style={{ borderBottom: '2px solid var(--color-border)', textAlign: 'left' }}>
+                <th style={{ padding: '0.5rem 0.75rem' }}>Referrer</th>
+                <th style={{ padding: '0.5rem 0.75rem' }}>Code</th>
+                <th style={{ padding: '0.5rem 0.75rem', textAlign: 'center' }}>Contributions</th>
+                <th style={{ padding: '0.5rem 0.75rem', textAlign: 'right' }}>Total referred</th>
+                <th style={{ padding: '0.5rem 0.75rem', textAlign: 'right' }}>Commission owed</th>
+              </tr>
+            </thead>
+            <tbody>
+              {referrers.map((referrer) => (
+                <tr
+                  key={referrer.referral_link_id}
+                  style={{ borderBottom: '1px solid var(--color-border-lighter)' }}
+                >
+                  <td style={{ padding: '0.5rem 0.75rem', fontWeight: 600 }}>{referrer.referrer_name}</td>
+                  <td style={{ padding: '0.5rem 0.75rem', fontFamily: 'monospace' }}>{referrer.code}</td>
+                  <td style={{ padding: '0.5rem 0.75rem', textAlign: 'center' }}>
+                    {referrer.contribution_count}
+                  </td>
+                  <td style={{ padding: '0.5rem 0.75rem', textAlign: 'right' }}>
+                    {referrer.referred_amount} {assetType}
+                  </td>
+                  <td style={{ padding: '0.5rem 0.75rem', textAlign: 'right', fontWeight: 600 }}>
+                    {referrer.commission_owed} {assetType}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ContributeModal.jsx
+++ b/frontend/src/components/ContributeModal.jsx
@@ -100,6 +100,7 @@ export default function ContributeModal({
   onSuccess,
   guestFreighterMode = false,
   tiers = [],
+  referralCode = null,
 }) {
   const { user, token, updateUser } = useAuth();
   const [amount, setAmount] = useState('');
@@ -377,6 +378,9 @@ export default function ContributeModal({
     return () => modal.removeEventListener('keydown', trapTab);
   }, [phase]);
 
+  // Attribution travels as a query parameter so it lands in the Stellar memo (#675)
+  const referralQuery = referralCode ? { query: { ref: referralCode } } : {};
+
   async function submitWithCustodial() {
     setLoadingLabel('Submitting with CrowdPay wallet…');
     const device_fingerprint = await getDeviceFingerprint();
@@ -389,7 +393,7 @@ export default function ContributeModal({
         device_fingerprint: device_fingerprint || undefined,
         idempotency_key: activeSubmissionKeyRef.current,
       },
-      token
+      referralQuery
     );
   }
 
@@ -432,7 +436,7 @@ export default function ContributeModal({
         device_fingerprint: device_fingerprint || undefined,
         idempotency_key: activeSubmissionKeyRef.current,
       },
-      token
+      referralQuery
     );
 
     setLoadingLabel('Checking Freighter network…');
@@ -509,13 +513,16 @@ export default function ContributeModal({
 
     setAnchorSession(session);
     setPhase('anchor');
-    return api.contribute({
-      campaign_id: campaign.id,
-      amount: destAmount,
-      send_asset: effectiveSendAsset,
-      display_name: displayName || undefined,
-      idempotency_key: activeSubmissionKeyRef.current,
-    });
+    return api.contribute(
+      {
+        campaign_id: campaign.id,
+        amount: destAmount,
+        send_asset: effectiveSendAsset,
+        display_name: displayName || undefined,
+        idempotency_key: activeSubmissionKeyRef.current,
+      },
+      referralQuery
+    );
   }
 
   async function handleSubmit(e) {

--- a/frontend/src/components/ContributeModal.test.jsx
+++ b/frontend/src/components/ContributeModal.test.jsx
@@ -134,7 +134,28 @@ describe('ContributeModal', () => {
           send_asset: 'USDC',
           idempotency_key: 'idem-key-123',
         }),
-        'test-token'
+        {}
+      );
+    });
+  });
+
+  it('forwards the referral code as a ?ref query parameter', async () => {
+    const user = userEvent.setup();
+    render(
+      <ContributeModal
+        campaign={campaign}
+        onClose={mockOnClose}
+        onSuccess={mockOnSuccess}
+        referralCode="a1b2c3d4"
+      />
+    );
+    await user.clear(screen.getByLabelText(/amount campaign receives/i));
+    await user.type(screen.getByLabelText(/amount campaign receives/i), '15');
+    await user.click(screen.getByRole('button', { name: /confirm payment/i }));
+    await waitFor(() => {
+      expect(mockContribute).toHaveBeenCalledWith(
+        expect.objectContaining({ campaign_id: campaign.id }),
+        { query: { ref: 'a1b2c3d4' } }
       );
     });
   });

--- a/frontend/src/components/ReferralProgramSettings.jsx
+++ b/frontend/src/components/ReferralProgramSettings.jsx
@@ -1,0 +1,115 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { api } from '../services/api';
+
+const DEFAULT_COMMISSION = 5;
+const DEFAULT_MAX_REFERRERS = 20;
+
+export default function ReferralProgramSettings({ campaignId }) {
+  const [program, setProgram] = useState(null);
+  const [enabled, setEnabled] = useState(false);
+  const [commissionPercentage, setCommissionPercentage] = useState(DEFAULT_COMMISSION);
+  const [maxReferrers, setMaxReferrers] = useState(DEFAULT_MAX_REFERRERS);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [status, setStatus] = useState('');
+
+  useEffect(() => {
+    if (!campaignId) return;
+    api
+      .getReferralProgram(campaignId)
+      .then((data) => {
+        setProgram(data);
+        setEnabled(true);
+        setCommissionPercentage(Number(data.commission_percentage));
+        setMaxReferrers(Number(data.max_referrers));
+      })
+      .catch(() => {
+        setProgram(null);
+        setEnabled(false);
+      });
+  }, [campaignId]);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setError('');
+    setStatus('');
+    try {
+      const saved = await api.enableReferralProgram(campaignId, {
+        commissionPercentage: Number(commissionPercentage),
+        maxReferrers: Number(maxReferrers),
+      });
+      setProgram(saved);
+      setStatus('Referral program saved.');
+    } catch (err) {
+      setError(err.message || 'Could not save the referral program');
+    } finally {
+      setSaving(false);
+    }
+  }, [campaignId, commissionPercentage, maxReferrers]);
+
+  return (
+    <div className="campaign-card" style={{ display: 'grid', gap: '0.85rem' }}>
+      <label style={{ display: 'flex', alignItems: 'center', gap: '0.6rem', fontWeight: 600 }}>
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => setEnabled(e.target.checked)}
+          aria-label="Enable referrals"
+        />
+        Enable Referrals
+      </label>
+
+      <p style={{ margin: 0, fontSize: '0.82rem', color: 'var(--color-text-muted)' }}>
+        Supporters get a trackable share link. Their commission is paid out of the campaign balance
+        in the same transaction as your withdrawal.
+      </p>
+
+      {enabled && (
+        <>
+          <div style={{ display: 'grid', gap: '0.35rem' }}>
+            <label htmlFor="referral-commission" style={{ fontSize: '0.85rem', fontWeight: 600 }}>
+              Commission: {commissionPercentage}%
+            </label>
+            <input
+              id="referral-commission"
+              type="range"
+              min="1"
+              max="20"
+              step="1"
+              value={commissionPercentage}
+              onChange={(e) => setCommissionPercentage(Number(e.target.value))}
+            />
+          </div>
+
+          <div style={{ display: 'grid', gap: '0.35rem' }}>
+            <label htmlFor="referral-max" style={{ fontSize: '0.85rem', fontWeight: 600 }}>
+              Maximum referrers
+            </label>
+            <input
+              id="referral-max"
+              type="number"
+              min="1"
+              max="100"
+              value={maxReferrers}
+              onChange={(e) => setMaxReferrers(e.target.value)}
+              style={{ maxWidth: '8rem', padding: '0.4rem 0.5rem' }}
+            />
+          </div>
+
+          <button
+            type="button"
+            className="btn-primary"
+            onClick={handleSave}
+            disabled={saving}
+            style={{ justifySelf: 'start' }}
+          >
+            {saving ? 'Saving…' : program ? 'Update referral program' : 'Enable referrals'}
+          </button>
+        </>
+      )}
+
+      {error && <p style={{ margin: 0, color: 'var(--color-danger)', fontSize: '0.85rem' }}>{error}</p>}
+      {status && <p style={{ margin: 0, color: 'var(--color-success)', fontSize: '0.85rem' }}>{status}</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -6,6 +6,8 @@ import { api } from '../services/api';
 import { useAuth } from '../context/AuthContext';
 import { useToast } from '../context/ToastContext';
 import ContributeModal from '../components/ContributeModal';
+import ReferralProgramSettings from '../components/ReferralProgramSettings';
+import CampaignReferralsTab from '../components/CampaignReferralsTab';
 import RelativeTime from '../components/RelativeTime';
 import DisputeModal from '../components/DisputeModal';
 import TransactionHistory from '../components/TransactionHistory';
@@ -1576,11 +1578,34 @@ export default function Campaign() {
           >
             {linkCopied ? 'Copied!' : 'Copy link'}
           </button>
+
+          <Link
+            to={`/campaigns/${campaign.id}/share`}
+            className="btn-secondary"
+            style={{
+              fontSize: '0.85rem',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: '0.5rem',
+              width: '100%',
+              textDecoration: 'none',
+            }}
+          >
+            Share page &amp; referral link
+          </Link>
         </div>
       </div>
 
       {user && campaign && isOwner && (
         <CampaignPublishControls campaign={campaign} isOwner={isOwner} navigate={navigate} />
+      )}
+
+      {user && campaign && isOwner && (
+        <div data-no-print style={{ marginBottom: '1.75rem' }}>
+          <h2 style={styles.sectionTitle}>Referrals</h2>
+          <ReferralProgramSettings campaignId={campaign.id} />
+        </div>
       )}
 
       {/* Edit campaign — owner or editor */}
@@ -2458,6 +2483,25 @@ export default function Campaign() {
             >
               Backers
             </button>
+
+            <button
+              type="button"
+              role="tab"
+              aria-selected={analyticsTab === 'referrals'}
+              onClick={() => setAnalyticsTab('referrals')}
+              style={{
+                background: analyticsTab === 'referrals' ? 'var(--color-accent)' : 'transparent',
+                color: analyticsTab === 'referrals' ? 'var(--color-bg)' : 'var(--color-text-primary)',
+                border: '1px solid var(--color-border-light)',
+                borderRadius: '6px',
+                padding: '0.4rem 0.9rem',
+                fontWeight: 600,
+                fontSize: '0.85rem',
+                cursor: 'pointer',
+              }}
+            >
+              Referrals
+            </button>
           </div>
 
           {analyticsTab === 'overview' && (
@@ -2545,6 +2589,10 @@ export default function Campaign() {
 
           {analyticsTab === 'backers' && (
             <p style={{ color: 'var(--color-text-muted)' }}>Backer insights coming soon.</p>
+          )}
+
+          {analyticsTab === 'referrals' && (
+            <CampaignReferralsTab campaignId={campaign.id} assetType={campaign.asset_type} />
           )}
         </div>
       )}
@@ -2655,6 +2703,7 @@ export default function Campaign() {
         <ContributeModal
           campaign={campaign}
           tiers={tiers}
+          referralCode={refParam}
           guestFreighterMode={freighterGuestMode}
           onClose={() => {
             setShowModal(false);

--- a/frontend/src/pages/CampaignShare.jsx
+++ b/frontend/src/pages/CampaignShare.jsx
@@ -1,0 +1,159 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { api } from '../services/api';
+import CampaignQRCode from '../components/CampaignQRCode';
+
+function shareTexts(campaignTitle, shareUrl) {
+  return {
+    twitter: `Backing ${campaignTitle} on CrowdPay — funded transparently on Stellar. Join me: ${shareUrl}`,
+    whatsapp: `Hey! I'm supporting ${campaignTitle} on CrowdPay. Every contribution settles on Stellar in seconds — take a look: ${shareUrl}`,
+    telegram: `${campaignTitle} is raising funds on CrowdPay, built on Stellar. Here's the link: ${shareUrl}`,
+  };
+}
+
+export default function CampaignShare() {
+  const { id } = useParams();
+  const { user, ready } = useAuth();
+  const [campaign, setCampaign] = useState(null);
+  const [program, setProgram] = useState(null);
+  const [link, setLink] = useState(null);
+  const [error, setError] = useState('');
+  const [claiming, setClaiming] = useState(false);
+  const [copied, setCopied] = useState('');
+
+  useEffect(() => {
+    if (!id) return;
+    api.getCampaign(id).then(setCampaign).catch(() => setCampaign(null));
+    api.getReferralProgram(id).then(setProgram).catch(() => setProgram(null));
+  }, [id]);
+
+  const claimLink = useCallback(async () => {
+    setClaiming(true);
+    setError('');
+    try {
+      setLink(await api.createReferralLink(id));
+    } catch (err) {
+      setError(
+        err.message === 'REFERRER_LIMIT_REACHED'
+          ? 'This campaign has reached its referrer limit.'
+          : err.message || 'Could not create your referral link'
+      );
+    } finally {
+      setClaiming(false);
+    }
+  }, [id]);
+
+  const copy = useCallback(async (value, label) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(label);
+      setTimeout(() => setCopied(''), 2000);
+    } catch {
+      setError('Could not copy to clipboard');
+    }
+  }, []);
+
+  if (!ready) return null;
+
+  const campaignUrl = `${window.location.origin}/campaigns/${id}`;
+  const shareUrl = link?.shareUrl || campaignUrl;
+  const texts = shareTexts(campaign?.title || 'this campaign', shareUrl);
+
+  return (
+    <div style={{ maxWidth: '720px', margin: '0 auto', padding: '1.5rem 1rem' }}>
+      <h1 style={{ marginBottom: '0.25rem' }}>Share {campaign?.title || 'campaign'}</h1>
+      <p style={{ color: 'var(--color-text-muted)', marginTop: 0 }}>
+        {program
+          ? `Referrers earn ${Number(program.commission_percentage)}% of every contribution made through their link.`
+          : 'Share this campaign with your network.'}
+      </p>
+
+      {program && !link && (
+        <div className="campaign-card" style={{ marginBottom: '1.25rem' }}>
+          {user ? (
+            <>
+              <p style={{ marginTop: 0 }}>
+                Claim your personal referral link to earn commission on the contributions you bring in.
+              </p>
+              <button type="button" className="btn-primary" onClick={claimLink} disabled={claiming}>
+                {claiming ? 'Creating…' : 'Get my referral link'}
+              </button>
+            </>
+          ) : (
+            <p style={{ margin: 0 }}>
+              <Link to="/login">Log in</Link> to claim a referral link for this campaign.
+            </p>
+          )}
+        </div>
+      )}
+
+      {error && <p style={{ color: 'var(--color-danger)' }}>{error}</p>}
+
+      <div className="campaign-card" style={{ display: 'grid', gap: '0.75rem', marginBottom: '1.25rem' }}>
+        <strong>{link ? 'Your referral link' : 'Campaign link'}</strong>
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <input
+            readOnly
+            value={shareUrl}
+            aria-label="Share URL"
+            style={{ flex: '1 1 20rem', padding: '0.45rem 0.6rem', fontFamily: 'monospace', fontSize: '0.82rem' }}
+          />
+          <button type="button" className="btn-secondary" onClick={() => copy(shareUrl, 'url')}>
+            {copied === 'url' ? 'Copied!' : 'Copy link'}
+          </button>
+        </div>
+        {link && (
+          <span style={{ fontSize: '0.8rem', color: 'var(--color-text-hint)' }}>
+            Referral code <code>{link.code}</code> — recorded in the Stellar memo of every contribution
+            made through this link.
+          </span>
+        )}
+      </div>
+
+      <div className="campaign-card" style={{ marginBottom: '1.25rem' }}>
+        <strong style={{ display: 'block', marginBottom: '0.75rem' }}>QR code</strong>
+        <CampaignQRCode url={shareUrl} />
+      </div>
+
+      <div className="campaign-card" style={{ display: 'grid', gap: '1rem' }}>
+        <strong>Ready-to-post messages</strong>
+
+        {[
+          { key: 'twitter', label: 'X / Twitter', href: `https://twitter.com/intent/tweet?text=${encodeURIComponent(texts.twitter)}` },
+          { key: 'whatsapp', label: 'WhatsApp', href: `https://wa.me/?text=${encodeURIComponent(texts.whatsapp)}` },
+          { key: 'telegram', label: 'Telegram', href: `https://t.me/share/url?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(texts.telegram)}` },
+        ].map((channel) => (
+          <div key={channel.key} style={{ display: 'grid', gap: '0.4rem' }}>
+            <span style={{ fontSize: '0.85rem', fontWeight: 600 }}>{channel.label}</span>
+            <textarea
+              readOnly
+              rows={3}
+              value={texts[channel.key]}
+              aria-label={`${channel.label} share text`}
+              style={{ width: '100%', padding: '0.5rem', fontSize: '0.82rem' }}
+            />
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              <button
+                type="button"
+                className="btn-secondary"
+                onClick={() => copy(texts[channel.key], channel.key)}
+              >
+                {copied === channel.key ? 'Copied!' : 'Copy text'}
+              </button>
+              <a
+                className="btn-secondary"
+                href={channel.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => api.trackShare(id, channel.key).catch(() => {})}
+              >
+                Share on {channel.label}
+              </a>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ReferralDashboard.jsx
+++ b/frontend/src/pages/ReferralDashboard.jsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { api } from '../services/api';
+
+const STATUS_LABELS = {
+  no_referrals: 'No referrals yet',
+  pending: 'Pending payout',
+  paid: 'Paid out',
+};
+
+export default function ReferralDashboard() {
+  const { user, ready } = useAuth();
+  const [links, setLinks] = useState(null);
+  const [error, setError] = useState('');
+  const [copied, setCopied] = useState('');
+
+  useEffect(() => {
+    if (!user) return;
+    api
+      .getMyReferralLinks()
+      .then((data) => setLinks(data.links || []))
+      .catch((err) => setError(err.message || 'Could not load your referrals'));
+  }, [user]);
+
+  if (!ready) return null;
+  if (!user) return <Navigate to="/login" replace />;
+
+  const totalEarned = (links || []).reduce((sum, link) => sum + Number(link.commission_earned), 0);
+  const totalPending = (links || []).reduce((sum, link) => sum + Number(link.commission_owed), 0);
+
+  async function copyUrl(link) {
+    try {
+      await navigator.clipboard.writeText(link.share_url);
+      setCopied(link.code);
+      setTimeout(() => setCopied(''), 2000);
+    } catch {
+      setError('Could not copy to clipboard');
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: '960px', margin: '0 auto', padding: '1.5rem 1rem' }}>
+      <h1 style={{ marginBottom: '0.25rem' }}>My referrals</h1>
+      <p style={{ color: 'var(--color-text-muted)', marginTop: 0 }}>
+        Commission is paid to your wallet when the creator withdraws from the campaign.
+      </p>
+
+      {error && <p style={{ color: 'var(--color-danger)' }}>{error}</p>}
+
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', margin: '1rem 0 1.5rem' }}>
+        <div className="campaign-card" style={{ minHeight: 'auto', padding: '0.6rem 0.9rem' }}>
+          <strong style={{ fontSize: '1.1rem' }}>{totalEarned.toFixed(7)}</strong>
+          <div style={{ fontSize: '0.78rem', color: 'var(--color-text-hint)' }}>Commission earned</div>
+        </div>
+        <div className="campaign-card" style={{ minHeight: 'auto', padding: '0.6rem 0.9rem' }}>
+          <strong style={{ fontSize: '1.1rem' }}>{totalPending.toFixed(7)}</strong>
+          <div style={{ fontSize: '0.78rem', color: 'var(--color-text-hint)' }}>Awaiting payout</div>
+        </div>
+      </div>
+
+      {links === null ? (
+        <p>Loading…</p>
+      ) : links.length === 0 ? (
+        <p style={{ color: 'var(--color-text-muted)' }}>
+          You have no referral links yet. Open a campaign that offers referrals and claim your link
+          from its <strong>Share</strong> page.
+        </p>
+      ) : (
+        <div className="campaign-card" style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
+            <thead>
+              <tr style={{ borderBottom: '2px solid var(--color-border)', textAlign: 'left' }}>
+                <th style={{ padding: '0.5rem 0.75rem' }}>Campaign</th>
+                <th style={{ padding: '0.5rem 0.75rem', textAlign: 'center' }}>Rate</th>
+                <th style={{ padding: '0.5rem 0.75rem', textAlign: 'center' }}>Contributions</th>
+                <th style={{ padding: '0.5rem 0.75rem', textAlign: 'right' }}>Referred</th>
+                <th style={{ padding: '0.5rem 0.75rem', textAlign: 'right' }}>Commission</th>
+                <th style={{ padding: '0.5rem 0.75rem' }}>Status</th>
+                <th style={{ padding: '0.5rem 0.75rem' }}>Link</th>
+              </tr>
+            </thead>
+            <tbody>
+              {links.map((link) => (
+                <tr key={link.referral_link_id} style={{ borderBottom: '1px solid var(--color-border-lighter)' }}>
+                  <td style={{ padding: '0.5rem 0.75rem', fontWeight: 600 }}>
+                    <Link to={`/campaigns/${link.campaign_id}`}>{link.campaign_title}</Link>
+                  </td>
+                  <td style={{ padding: '0.5rem 0.75rem', textAlign: 'center' }}>
+                    {link.commission_percentage}%
+                  </td>
+                  <td style={{ padding: '0.5rem 0.75rem', textAlign: 'center' }}>
+                    {link.contribution_count}
+                  </td>
+                  <td style={{ padding: '0.5rem 0.75rem', textAlign: 'right' }}>
+                    {link.referred_amount} {link.asset_type}
+                  </td>
+                  <td style={{ padding: '0.5rem 0.75rem', textAlign: 'right', fontWeight: 600 }}>
+                    {link.commission_earned} {link.asset_type}
+                  </td>
+                  <td style={{ padding: '0.5rem 0.75rem' }}>{STATUS_LABELS[link.status]}</td>
+                  <td style={{ padding: '0.5rem 0.75rem' }}>
+                    <button type="button" className="btn-secondary" onClick={() => copyUrl(link)}>
+                      {copied === link.code ? 'Copied!' : 'Copy'}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -476,8 +476,9 @@ export const api = {
   voteMilestone: (id, body) => request('POST', `/milestones/${id}/votes`, body || {}),
   approveMilestone: (id, body) => request('POST', `/milestones/${id}/release`, body || {}),
   rejectMilestone: (id, body) => request('POST', `/milestones/${id}/reject`, body || {}),
-  contribute: (body) => request('POST', '/contributions', body),
-  prepareContribution: (body) => request('POST', '/contributions/prepare', body),
+  contribute: (body, options = {}) => request('POST', '/contributions', body, options),
+  prepareContribution: (body, options = {}) =>
+    request('POST', '/contributions/prepare', body, options),
   submitSignedContribution: (body) => request('POST', '/contributions/submit-signed', body),
   buildContributionXdr: (body) => request('POST', '/contributions/build-xdr', body),
   guestContribute: (body) => request('POST', '/contributions/guest', body),
@@ -610,6 +611,17 @@ export const api = {
 
   getReferralCode: (campaignId) => request('GET', `/campaigns/${campaignId}/referral`),
   getReferralLeaderboard: (campaignId) => request('GET', `/campaigns/${campaignId}/referrals`),
+
+  // ── Referral & affiliate program ─────────────────────────────────────
+  enableReferralProgram: (campaignId, body) =>
+    request('POST', `/campaigns/${encodeURIComponent(campaignId)}/referrals`, body),
+  getReferralProgram: (campaignId) =>
+    request('GET', `/campaigns/${encodeURIComponent(campaignId)}/referrals/program`),
+  createReferralLink: (campaignId) =>
+    request('POST', `/campaigns/${encodeURIComponent(campaignId)}/referrals/links`, {}),
+  getCampaignReferralCommissions: (campaignId) =>
+    request('GET', `/campaigns/${encodeURIComponent(campaignId)}/referrals/commissions`),
+  getMyReferralLinks: () => request('GET', '/referrals/links'),
 
   sendBulkThankYou: (campaignId, message) =>
     request('POST', `/campaigns/${campaignId}/thank-you`, { message }),

--- a/frontend/src/test/components/CampaignReferralsTab.test.jsx
+++ b/frontend/src/test/components/CampaignReferralsTab.test.jsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import CampaignReferralsTab from '../../components/CampaignReferralsTab';
+import { renderWithProviders } from '../renderWithProviders';
+
+const apiMocks = vi.hoisted(() => ({
+  getCampaignReferralCommissions: vi.fn(),
+}));
+
+vi.mock('../../services/api', () => ({ api: apiMocks }));
+
+describe('CampaignReferralsTab', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders every referrer with referred totals and commission owed', async () => {
+    apiMocks.getCampaignReferralCommissions.mockResolvedValue({
+      program: { commission_percentage: 10, max_referrers: 20, referrer_count: 2 },
+      referrers: [
+        {
+          referral_link_id: 'link-1',
+          code: 'a1b2c3d4',
+          referrer_name: 'Alice',
+          contribution_count: 2,
+          referred_amount: '600.0000000',
+          commission_owed: '60.0000000',
+        },
+        {
+          referral_link_id: 'link-2',
+          code: 'e5f6g7h8',
+          referrer_name: 'Bob',
+          contribution_count: 1,
+          referred_amount: '300.0000000',
+          commission_owed: '30.0000000',
+        },
+      ],
+    });
+
+    renderWithProviders(<CampaignReferralsTab campaignId="camp-1" assetType="USDC" />);
+
+    expect(await screen.findByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('60.0000000 USDC')).toBeInTheDocument();
+    expect(screen.getByText(/2 of 20 referrer slots claimed/)).toBeInTheDocument();
+  });
+
+  it('prompts the creator to enable referrals when no program exists', async () => {
+    const err = new Error('Not found');
+    err.status = 404;
+    apiMocks.getCampaignReferralCommissions.mockRejectedValue(err);
+
+    renderWithProviders(<CampaignReferralsTab campaignId="camp-1" assetType="USDC" />);
+
+    expect(await screen.findByText(/Referrals are not enabled/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/pages/ReferralDashboard.test.jsx
+++ b/frontend/src/test/pages/ReferralDashboard.test.jsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import ReferralDashboard from '../../pages/ReferralDashboard';
+import { renderWithProviders } from '../renderWithProviders';
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user-2', role: 'contributor' }, ready: true, updateUser: vi.fn() }),
+}));
+
+const apiMocks = vi.hoisted(() => ({
+  getMyReferralLinks: vi.fn(),
+}));
+
+vi.mock('../../services/api', () => ({ api: apiMocks }));
+
+describe('ReferralDashboard page', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists referred campaigns with commission earned and status', async () => {
+    apiMocks.getMyReferralLinks.mockResolvedValue({
+      links: [
+        {
+          referral_link_id: 'link-1',
+          code: 'a1b2c3d4',
+          campaign_id: 'camp-1',
+          campaign_title: 'Solar Wells',
+          asset_type: 'USDC',
+          commission_percentage: 10,
+          contribution_count: 3,
+          referred_amount: '600.0000000',
+          commission_earned: '60.0000000',
+          commission_owed: '60.0000000',
+          status: 'pending',
+          share_url: 'http://localhost:5173/c/camp-1?ref=a1b2c3d4',
+        },
+      ],
+    });
+
+    renderWithProviders(<ReferralDashboard />);
+
+    expect(await screen.findByText('Solar Wells')).toBeInTheDocument();
+    expect(screen.getByText('60.0000000 USDC')).toBeInTheDocument();
+    expect(screen.getByText('Pending payout')).toBeInTheDocument();
+    expect(screen.getByText('10%')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when the user holds no referral links', async () => {
+    apiMocks.getMyReferralLinks.mockResolvedValue({ links: [] });
+
+    renderWithProviders(<ReferralDashboard />);
+
+    expect(await screen.findByText(/no referral links yet/i)).toBeInTheDocument();
+  });
+
+  it('surfaces an error when the referrals request fails', async () => {
+    apiMocks.getMyReferralLinks.mockRejectedValue(new Error('Referrals unavailable'));
+
+    renderWithProviders(<ReferralDashboard />);
+
+    expect(await screen.findByText('Referrals unavailable')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Closes #397  — Reward tier `claimed_count` is now atomically decremented when a tier-backed contribution is made, preventing overselling of limited-edition reward tiers.

**The Problem**
The `claimed_count` (and hence computed `remaining`) on `reward_tiers` was only incremented asynchronously in the ledger monitor when Horizon detected the on-chain payment. The contribution route itself never decremented the count, so:
- Sold-out tiers continued showing availability in the UI
- Multiple backers could claim the last slot of a limited tier
- Creators could end up owing more physical rewards than they could fulfil

**The Fix**
A new `reserveTierSlot()` function in `rewardTierService.js` atomically increments `claimed_count` **inside the contribution route's database transaction** — before the Stellar transaction is even submitted. If the tier is already at capacity, the contribution is rejected with **HTTP 409 Sold out** and the entire transaction is rolled back.

## Changes

### `backend/src/services/rewardTierService.js`
- **`reserveTierSlot(client, { tierId, campaignId })`** — Atomically increments `claimed_count` via `UPDATE ... WHERE (tier_limit IS NULL OR claimed_count < tier_limit) RETURNING`. Returns the tier row on success, or `null` if sold out.
- **`assignTierToContribution(client, { ..., tierId })`** — Extended to accept an optional `tierId`. When provided, only creates the `contribution_rewards` join row (idempotent via `ON CONFLICT DO NOTHING`) without double-incrementing `claimed_count`, since the route already reserved the slot.

### `backend/src/routes/contributions.js`
- Custodial `POST /` route now extracts optional `tier_id` from `req.body`
- Validates the tier belongs to the campaign (pre-flight `SELECT`)
- Calls `reserveTierSlot()` inside the existing transaction, **before** submitting to Stellar
- Returns **HTTP 409** with `{ error: "This reward tier is sold out", tier_id }` if the tier is at capacity
- Passes `tierId` through to `submitCustodialContribution` so it flows into metadata

### `backend/src/services/contributionService.js`
- Accepts new `tierId` parameter and includes it in `stellar_transactions.metadata` as `tier_id`

### `backend/src/services/ledgerMonitor.js`
- Reads `tier_id` from `stellar_transactions.metadata` and passes it to `assignTierToContribution`, ensuring pre-reserved tiers are honoured without double-counting `claimed_count`

### `backend/src/middleware/validation.js`
- Added optional `tier_id` validation (UUID format) to `contributionValidation`

## How It Works End-to-End

```
User contributes (with tier_id)
  │
  ├─ 1. Route validates tier exists & belongs to campaign (pre-flight)
  │
  ├─ 2. BEGIN transaction
  │     ├─ Advisory lock (campaign + user)
  │     ├─ Check per-user cap
  │     ├─ reserveTierSlot() → UPDATE reward_tiers SET claimed_count++ 
  │     │                        WHERE id = tier_id AND claimed_count < tier_limit
  │     │                        RETURNING id
  │     │     └─ If 0 rows → ROLLBACK, respond 409 Sold out 🚫
  │     ├─ Submit Stellar transaction
  │     ├─ Insert stellar_transactions record (metadata.tier_id set)
  │     └─ COMMIT ✅
  │
  └─ 3. (async) Ledger monitor indexes on-chain payment
        ├─ Insert contributions row
        ├─ assignTierToContribution(tierId) → creates contribution_rewards
        │   (idempotent via ON CONFLICT DO NOTHING, no double-increment)
        └─ Update campaign raised_amount
```

## Acceptance Criteria

| Criteria | Status |
|----------|--------|
| Tier `claimed_count` decrements atomically with each contribution | ✅ `UPDATE ... SET claimed_count = claimed_count + 1` inside route transaction |
| Contribution rejected with 409 when tier is sold out | ✅ `reserveTierSlot()` returns null → `res.status(409)` |
| Concurrent contributions for the last slot handled correctly (only one succeeds) | ✅ Atomic `UPDATE ... WHERE claimed_count < tier_limit` with PostgreSQL row-level locking inside transaction |
| Tier sold-out state reflected in UI immediately | ✅ `claimed_count` is updated atomically in the route, so the next `listTiersWithAvailability()` query reflects the correct `remaining` |

## Testing

- [ ] Unit test `reserveTierSlot()` — success path
- [ ] Unit test `reserveTierSlot()` — sold-out path returns null
- [ ] Unit test `assignTierToContribution()` with explicit `tierId` — no double-increment
- [ ] Integration: contribute with valid `tier_id`, verify `claimed_count` incremented
- [ ] Integration: contribute with sold-out `tier_id`, verify 409 response
- [ ] Integration: concurrent contributions for last slot, verify exactly one 202 and one 409
