### PR TITLE
feat: recurring pledges via claimable balance schedules (closes #677)

### DIFF
--- a/backend/db/migrations/20260818_recurring_subscriptions.sql
+++ b/backend/db/migrations/20260818_recurring_subscriptions.sql
@@ -1,0 +1,57 @@
+BEGIN;
+
+-- Recurring pledges. Stellar has no native recurring payment primitive, so a
+-- subscription is materialised as one claimable balance per period, created
+-- up-front from the contributor's wallet.
+CREATE TABLE IF NOT EXISTS subscriptions (
+  id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id         UUID        NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  contributor_user_id UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  amount_per_period   NUMERIC(20, 7) NOT NULL CHECK (amount_per_period > 0),
+  asset               TEXT        NOT NULL,
+  period_months       INTEGER     NOT NULL CHECK (period_months IN (1, 3, 6)),
+  total_periods       INTEGER     NOT NULL CHECK (total_periods BETWEEN 2 AND 24),
+  status              TEXT        NOT NULL DEFAULT 'active'
+                        CHECK (status IN ('active', 'cancelled', 'completed')),
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS subscription_balances (
+  id                 UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  subscription_id    UUID        NOT NULL REFERENCES subscriptions(id) ON DELETE CASCADE,
+  stellar_balance_id TEXT        NOT NULL,
+  scheduled_date     TIMESTAMPTZ NOT NULL,
+  amount             NUMERIC(20, 7) NOT NULL CHECK (amount > 0),
+  status             TEXT        NOT NULL DEFAULT 'pending'
+                       CHECK (status IN ('pending', 'claimed', 'contributor_reclaimed', 'cancellation_requested')),
+  claimed_at         TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS subscriptions_contributor_idx
+  ON subscriptions (contributor_user_id, status);
+
+CREATE INDEX IF NOT EXISTS subscriptions_campaign_idx
+  ON subscriptions (campaign_id);
+
+CREATE INDEX IF NOT EXISTS subscription_balances_due_idx
+  ON subscription_balances (scheduled_date)
+  WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS subscription_balances_subscription_idx
+  ON subscription_balances (subscription_id);
+
+-- Claimed subscription periods are recorded as contributions so they show up in
+-- campaign totals, dashboards and exports like any other contribution.
+ALTER TABLE contributions
+  DROP CONSTRAINT IF EXISTS contributions_payment_type_check;
+
+ALTER TABLE contributions
+  ADD CONSTRAINT contributions_payment_type_check
+  CHECK (payment_type IN (
+    'payment',
+    'path_payment_strict_receive',
+    'reconciliation_adjustment',
+    'subscription_claim'
+  ));
+
+COMMIT;

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -47,6 +47,9 @@ const {
 const {
   startRecurringContributionsCron,
 } = require("./services/recurringContributionsService");
+const {
+  startSubscriptionClaimWorker,
+} = require("./services/recurring");
 const db = require("./config/database");
 const swaggerUi = require("swagger-ui-express");
 const swaggerJsdoc = require("swagger-jsdoc");
@@ -266,6 +269,7 @@ app.use("/api/referrals", require("./routes/referrals"));
 app.use("/api/users", require("./routes/users"));
 app.use("/api", require("./routes/sponsorMatching"));
 app.use("/api/invites", require("./routes/invites"));
+app.use("/api", require("./routes/subscriptions"));
 app.use("/api/campaigns", require("./routes/campaignUpdates"));
 app.use("/api/campaigns", require("./routes/campaignComments"));
 app.use("/api/campaigns", require("./routes/campaignFollowers"));
@@ -548,6 +552,7 @@ async function bootstrap() {
     startRecommendationRefreshCron();
     startContractDeploymentRetryCron();
     startRecurringContributionsCron();
+    startSubscriptionClaimWorker();
     startBenchmarkRefreshCron();
   });
 }

--- a/backend/src/routes/subscriptions.js
+++ b/backend/src/routes/subscriptions.js
@@ -1,0 +1,140 @@
+const router = require('express').Router();
+const { requireAuth } = require('../middleware/auth');
+const asyncHandler = require('../utils/asyncHandler');
+const {
+  createSubscription,
+  cancelSubscription,
+  listSubscriptionsForUser,
+} = require('../services/recurring');
+
+/**
+ * @openapi
+ * tags:
+ *   - name: Subscriptions
+ *     description: Recurring pledges backed by Stellar claimable balance schedules
+ */
+
+function respondWithServiceError(res, err) {
+  if (!err.statusCode) throw err;
+  return res.status(err.statusCode).json({
+    error: err.message,
+    ...(err.code ? { code: err.code } : {}),
+  });
+}
+
+/**
+ * @openapi
+ * /api/campaigns/{id}/subscriptions:
+ *   post:
+ *     tags: [Subscriptions]
+ *     summary: Enable a recurring pledge on a campaign
+ *     description: >
+ *       Locks the full commitment into one Stellar claimable balance per period. Each balance
+ *       is claimable unconditionally by the platform and, 30 days after its scheduled date,
+ *       by the contributor.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [amountPerPeriod, asset, periodMonths, totalPeriods]
+ *             properties:
+ *               amountPerPeriod: { type: number }
+ *               asset: { type: string, example: XLM }
+ *               periodMonths: { type: integer, enum: [1, 3, 6] }
+ *               totalPeriods: { type: integer, minimum: 2, maximum: 24 }
+ *     responses:
+ *       201: { description: Subscription created }
+ *       400: { description: Invalid input or INSUFFICIENT_BALANCE_FOR_SUBSCRIPTION }
+ *       404: { description: Campaign not found }
+ */
+router.post(
+  '/campaigns/:id/subscriptions',
+  requireAuth,
+  asyncHandler(async (req, res) => {
+    const { amountPerPeriod, asset, periodMonths, totalPeriods } = req.body || {};
+    try {
+      const subscription = await createSubscription({
+        campaignId: req.params.id,
+        userId: req.user.userId,
+        amountPerPeriod,
+        asset,
+        periodMonths,
+        totalPeriods,
+      });
+      res.status(201).json(subscription);
+    } catch (err) {
+      return respondWithServiceError(res, err);
+    }
+  })
+);
+
+/**
+ * @openapi
+ * /api/campaigns/{id}/subscriptions/{subscriptionId}:
+ *   delete:
+ *     tags: [Subscriptions]
+ *     summary: Cancel a recurring pledge
+ *     description: >
+ *       Periods scheduled more than 7 days out stop being claimed and become reclaimable by the
+ *       contributor. Periods due sooner, or already claimed, are returned as non-cancellable.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: subscriptionId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200: { description: Cancellation summary }
+ *       404: { description: Subscription not found }
+ */
+router.delete(
+  '/campaigns/:id/subscriptions/:subscriptionId',
+  requireAuth,
+  asyncHandler(async (req, res) => {
+    try {
+      const result = await cancelSubscription({
+        campaignId: req.params.id,
+        subscriptionId: req.params.subscriptionId,
+        userId: req.user.userId,
+      });
+      res.json(result);
+    } catch (err) {
+      return respondWithServiceError(res, err);
+    }
+  })
+);
+
+/**
+ * @openapi
+ * /api/subscriptions/mine:
+ *   get:
+ *     tags: [Subscriptions]
+ *     summary: List the authenticated contributor's subscriptions
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200: { description: Subscriptions with next payment date and claimed period count }
+ */
+router.get(
+  '/subscriptions/mine',
+  requireAuth,
+  asyncHandler(async (req, res) => {
+    res.json({ subscriptions: await listSubscriptionsForUser(req.user.userId) });
+  })
+);
+
+module.exports = router;

--- a/backend/src/routes/subscriptions.test.js
+++ b/backend/src/routes/subscriptions.test.js
@@ -1,0 +1,126 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const proxyquire = require('proxyquire').noCallThru();
+
+const CAMPAIGN_ID = '11111111-1111-1111-1111-111111111111';
+const SUBSCRIPTION_ID = '33333333-3333-3333-3333-333333333333';
+
+function buildApp(recurringStub) {
+  const router = proxyquire('./subscriptions', {
+    '../middleware/auth': {
+      requireAuth: (req, _res, next) => {
+        req.user = { userId: 'user-1', role: 'contributor' };
+        next();
+      },
+    },
+    '../services/recurring': {
+      createSubscription: async () => ({}),
+      cancelSubscription: async () => ({}),
+      listSubscriptionsForUser: async () => [],
+      ...recurringStub,
+    },
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api', router);
+  return app;
+}
+
+test('POST /campaigns/:id/subscriptions returns the balance schedule', async () => {
+  let received = null;
+  const app = buildApp({
+    createSubscription: async (args) => {
+      received = args;
+      return {
+        subscriptionId: SUBSCRIPTION_ID,
+        balanceIds: ['b1', 'b2', 'b3', 'b4', 'b5', 'b6'],
+        totalCommitment: 60,
+        firstPaymentDate: '2026-09-17T00:00:00.000Z',
+      };
+    },
+  });
+
+  const res = await request(app)
+    .post(`/api/campaigns/${CAMPAIGN_ID}/subscriptions`)
+    .send({ amountPerPeriod: 10, asset: 'XLM', periodMonths: 1, totalPeriods: 6 });
+
+  assert.equal(res.status, 201);
+  assert.equal(res.body.balanceIds.length, 6);
+  assert.equal(received.campaignId, CAMPAIGN_ID);
+  assert.equal(received.userId, 'user-1');
+  assert.equal(received.totalPeriods, 6);
+});
+
+test('POST /campaigns/:id/subscriptions surfaces INSUFFICIENT_BALANCE_FOR_SUBSCRIPTION as 400', async () => {
+  const app = buildApp({
+    createSubscription: async () => {
+      const err = new Error('Wallet balance too low');
+      err.statusCode = 400;
+      err.code = 'INSUFFICIENT_BALANCE_FOR_SUBSCRIPTION';
+      throw err;
+    },
+  });
+
+  const res = await request(app)
+    .post(`/api/campaigns/${CAMPAIGN_ID}/subscriptions`)
+    .send({ amountPerPeriod: 10, asset: 'XLM', periodMonths: 1, totalPeriods: 6 });
+
+  assert.equal(res.status, 400);
+  assert.equal(res.body.code, 'INSUFFICIENT_BALANCE_FOR_SUBSCRIPTION');
+});
+
+test('DELETE /campaigns/:id/subscriptions/:subscriptionId returns the cancellation summary', async () => {
+  let received = null;
+  const app = buildApp({
+    cancelSubscription: async (args) => {
+      received = args;
+      return {
+        cancelled: 4,
+        nonCancellable: 2,
+        non_cancellable_balances: [{ id: 'b1', reason: 'already_claimed' }],
+        estimatedRefundDate: '2026-11-16T00:00:00.000Z',
+      };
+    },
+  });
+
+  const res = await request(app).delete(
+    `/api/campaigns/${CAMPAIGN_ID}/subscriptions/${SUBSCRIPTION_ID}`
+  );
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.cancelled, 4);
+  assert.equal(res.body.non_cancellable_balances[0].reason, 'already_claimed');
+  assert.equal(received.subscriptionId, SUBSCRIPTION_ID);
+});
+
+test('DELETE /campaigns/:id/subscriptions/:subscriptionId 404s for an unknown subscription', async () => {
+  const app = buildApp({
+    cancelSubscription: async () => {
+      const err = new Error('Subscription not found');
+      err.statusCode = 404;
+      throw err;
+    },
+  });
+
+  const res = await request(app).delete(
+    `/api/campaigns/${CAMPAIGN_ID}/subscriptions/${SUBSCRIPTION_ID}`
+  );
+
+  assert.equal(res.status, 404);
+});
+
+test('GET /subscriptions/mine lists the caller subscriptions', async () => {
+  const app = buildApp({
+    listSubscriptionsForUser: async (userId) => [
+      { id: SUBSCRIPTION_ID, contributor: userId, campaign_title: 'Solar Grid', status: 'active' },
+    ],
+  });
+
+  const res = await request(app).get('/api/subscriptions/mine');
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.subscriptions[0].contributor, 'user-1');
+});

--- a/backend/src/services/recurring.js
+++ b/backend/src/services/recurring.js
@@ -1,0 +1,514 @@
+'use strict';
+
+/**
+ * recurring.js
+ *
+ * Recurring pledge engine. Stellar has no native recurring payment primitive, so a
+ * subscription is a claimable balance schedule: when a contributor pledges, the full
+ * commitment leaves their wallet immediately as one claimable balance per period.
+ * The claim worker releases each balance to the campaign wallet on its scheduled date.
+ */
+
+const db = require('../config/database');
+const logger = require('../config/logger');
+const {
+  createSubscriptionClaimableBalances,
+  claimSubscriptionBalanceToCampaign,
+  getClaimableBalance,
+  isClaimableBalanceGoneError,
+  getCampaignBalance,
+  ensureCustodialAccountFundedAndTrusted,
+  getSupportedAssetCodes,
+} = require('./stellarService');
+const { withDecryptedWalletSecret } = require('./walletSecrets');
+const { buildContributionMemo } = require('./contributionService');
+
+const PERIOD_DAYS = 30;
+const ALLOWED_PERIOD_MONTHS = [1, 3, 6];
+const MIN_PERIODS = 2;
+const MAX_PERIODS = 24;
+
+/** How long after its scheduled date a balance stays reclaimable only by the platform. */
+const CONTRIBUTOR_RECLAIM_AFTER_DAYS = 30;
+
+/** A balance due sooner than this can no longer be cancelled — the worker is about to claim it. */
+const CANCELLATION_NOTICE_DAYS = 7;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const WORKER_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+let _workerTimer = null;
+
+function httpError(message, statusCode, code) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  if (code) err.code = code;
+  return err;
+}
+
+function toAmount(value) {
+  return Number(parseFloat(value).toFixed(7));
+}
+
+/** Scheduled date of period N (1-based): now + N * periodMonths * 30 days. */
+function scheduleDateForPeriod(startedAt, period, periodMonths) {
+  return new Date(startedAt.getTime() + period * periodMonths * PERIOD_DAYS * DAY_MS);
+}
+
+function validateSubscriptionInput({ amountPerPeriod, asset, periodMonths, totalPeriods }) {
+  const amount = parseFloat(amountPerPeriod);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw httpError('amountPerPeriod must be greater than zero', 400, 'INVALID_SUBSCRIPTION');
+  }
+  if (!getSupportedAssetCodes().includes(asset)) {
+    throw httpError(`Unsupported asset: ${asset}`, 400, 'INVALID_SUBSCRIPTION');
+  }
+  if (!ALLOWED_PERIOD_MONTHS.includes(Number(periodMonths))) {
+    throw httpError(
+      `periodMonths must be one of: ${ALLOWED_PERIOD_MONTHS.join(', ')}`,
+      400,
+      'INVALID_SUBSCRIPTION'
+    );
+  }
+  const periods = Number(totalPeriods);
+  if (!Number.isInteger(periods) || periods < MIN_PERIODS || periods > MAX_PERIODS) {
+    throw httpError(
+      `totalPeriods must be an integer between ${MIN_PERIODS} and ${MAX_PERIODS}`,
+      400,
+      'INVALID_SUBSCRIPTION'
+    );
+  }
+  return { amount: toAmount(amount), periodMonths: Number(periodMonths), totalPeriods: periods };
+}
+
+/**
+ * Enable a recurring pledge: lock the full commitment into one claimable balance per period.
+ */
+async function createSubscription({
+  campaignId,
+  userId,
+  amountPerPeriod,
+  asset,
+  periodMonths,
+  totalPeriods,
+}) {
+  const input = validateSubscriptionInput({ amountPerPeriod, asset, periodMonths, totalPeriods });
+
+  const { rows: campaignRows } = await db.query(
+    `SELECT id, wallet_public_key, asset_type FROM campaigns
+     WHERE id = $1 AND status = 'active' AND deleted_at IS NULL`,
+    [campaignId]
+  );
+  const campaign = campaignRows[0];
+  if (!campaign) throw httpError('Campaign not found', 404);
+
+  if (asset !== campaign.asset_type) {
+    throw httpError(
+      `This campaign only accepts ${campaign.asset_type} pledges`,
+      400,
+      'INVALID_SUBSCRIPTION'
+    );
+  }
+
+  const { rows: userRows } = await db.query(
+    'SELECT id, wallet_public_key, wallet_secret_encrypted FROM users WHERE id = $1',
+    [userId]
+  );
+  const contributor = userRows[0];
+  if (!contributor) throw httpError('User not found', 404);
+
+  const totalCommitment = toAmount(input.amount * input.totalPeriods);
+  const balances = await getCampaignBalance(contributor.wallet_public_key);
+  const available = parseFloat(balances[asset] || '0');
+  if (available < totalCommitment) {
+    throw httpError(
+      `Your wallet holds ${available} ${asset} but this pledge commits ${totalCommitment} ${asset}`,
+      400,
+      'INSUFFICIENT_BALANCE_FOR_SUBSCRIPTION'
+    );
+  }
+
+  const startedAt = new Date();
+  const schedule = [];
+  for (let period = 1; period <= input.totalPeriods; period += 1) {
+    const scheduledDate = scheduleDateForPeriod(startedAt, period, input.periodMonths);
+    schedule.push({
+      scheduledDate,
+      amount: input.amount,
+      reclaimAfterUnix: Math.floor(
+        (scheduledDate.getTime() + CONTRIBUTOR_RECLAIM_AFTER_DAYS * DAY_MS) / 1000
+      ),
+    });
+  }
+
+  const { balanceIds } = await withDecryptedWalletSecret(
+    contributor.wallet_secret_encrypted,
+    { userId, walletPublicKey: contributor.wallet_public_key },
+    async (walletSecret) => {
+      await ensureCustodialAccountFundedAndTrusted({
+        publicKey: contributor.wallet_public_key,
+        secret: walletSecret,
+      });
+      return createSubscriptionClaimableBalances({
+        sourceSecret: walletSecret,
+        asset,
+        entries: schedule.map((entry) => ({
+          amount: entry.amount,
+          reclaimAfterUnix: entry.reclaimAfterUnix,
+        })),
+      });
+    }
+  );
+
+  const client = await db.connect();
+  let subscriptionId;
+  try {
+    await client.query('BEGIN');
+    const { rows: inserted } = await client.query(
+      `INSERT INTO subscriptions
+         (campaign_id, contributor_user_id, amount_per_period, asset, period_months, total_periods)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id`,
+      [campaignId, userId, input.amount, asset, input.periodMonths, input.totalPeriods]
+    );
+    subscriptionId = inserted[0].id;
+
+    for (let i = 0; i < schedule.length; i += 1) {
+      await client.query(
+        `INSERT INTO subscription_balances
+           (subscription_id, stellar_balance_id, scheduled_date, amount)
+         VALUES ($1, $2, $3, $4)`,
+        [subscriptionId, balanceIds[i], schedule[i].scheduledDate.toISOString(), schedule[i].amount]
+      );
+    }
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    logger.error('subscriptions: failed to persist schedule after locking funds', {
+      campaign_id: campaignId,
+      user_id: userId,
+      balance_ids: balanceIds,
+      error: err.message,
+    });
+    throw err;
+  } finally {
+    client.release();
+  }
+
+  logger.info('subscriptions: created', {
+    subscription_id: subscriptionId,
+    campaign_id: campaignId,
+    periods: input.totalPeriods,
+  });
+
+  return {
+    subscriptionId,
+    balanceIds,
+    totalCommitment,
+    firstPaymentDate: schedule[0].scheduledDate.toISOString(),
+  };
+}
+
+/**
+ * Cancel a subscription. Balances more than the notice period away stop being claimed and
+ * become the contributor's to reclaim; anything closer (or already claimed) is returned as
+ * non-cancellable.
+ */
+async function cancelSubscription({ campaignId, subscriptionId, userId }) {
+  const { rows: subscriptionRows } = await db.query(
+    `SELECT id, status FROM subscriptions
+     WHERE id = $1 AND campaign_id = $2 AND contributor_user_id = $3`,
+    [subscriptionId, campaignId, userId]
+  );
+  const subscription = subscriptionRows[0];
+  if (!subscription) throw httpError('Subscription not found', 404);
+  if (subscription.status === 'completed') {
+    throw httpError('This subscription has already completed', 409, 'SUBSCRIPTION_COMPLETED');
+  }
+
+  const noticeCutoff = new Date(Date.now() + CANCELLATION_NOTICE_DAYS * DAY_MS);
+
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN');
+
+    const { rows: cancelled } = await client.query(
+      `UPDATE subscription_balances
+       SET status = 'cancellation_requested'
+       WHERE subscription_id = $1
+         AND status = 'pending'
+         AND scheduled_date > $2
+       RETURNING id, stellar_balance_id, scheduled_date, amount`,
+      [subscriptionId, noticeCutoff.toISOString()]
+    );
+
+    const { rows: nonCancellable } = await client.query(
+      `SELECT id, stellar_balance_id, scheduled_date, amount, status
+       FROM subscription_balances
+       WHERE subscription_id = $1
+         AND status IN ('pending', 'claimed')
+       ORDER BY scheduled_date`,
+      [subscriptionId]
+    );
+
+    await client.query(
+      `UPDATE subscriptions SET status = 'cancelled' WHERE id = $1`,
+      [subscriptionId]
+    );
+
+    await client.query('COMMIT');
+
+    // The earliest date the contributor's reclaim predicate opens on a cancelled balance.
+    const earliestCancelled = cancelled
+      .map((row) => new Date(row.scheduled_date).getTime())
+      .sort((a, b) => a - b)[0];
+    const estimatedRefundDate = earliestCancelled
+      ? new Date(earliestCancelled + CONTRIBUTOR_RECLAIM_AFTER_DAYS * DAY_MS).toISOString()
+      : null;
+
+    logger.info('subscriptions: cancelled', {
+      subscription_id: subscriptionId,
+      cancelled: cancelled.length,
+      non_cancellable: nonCancellable.length,
+    });
+
+    return {
+      cancelled: cancelled.length,
+      nonCancellable: nonCancellable.length,
+      non_cancellable_balances: nonCancellable.map((row) => ({
+        id: row.id,
+        stellar_balance_id: row.stellar_balance_id,
+        scheduled_date: row.scheduled_date,
+        amount: row.amount,
+        status: row.status,
+        reason: row.status === 'claimed' ? 'already_claimed' : 'within_notice_period',
+      })),
+      estimatedRefundDate,
+    };
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/** Active and past subscriptions for the contributor dashboard. */
+async function listSubscriptionsForUser(userId) {
+  const { rows } = await db.query(
+    `SELECT s.id, s.campaign_id, c.title AS campaign_title, s.amount_per_period, s.asset,
+            s.period_months, s.total_periods, s.status, s.created_at,
+            COUNT(sb.id) FILTER (WHERE sb.status = 'claimed')::int AS periods_claimed,
+            MIN(sb.scheduled_date) FILTER (WHERE sb.status = 'pending') AS next_payment_date
+     FROM subscriptions s
+     JOIN campaigns c ON c.id = s.campaign_id
+     LEFT JOIN subscription_balances sb ON sb.subscription_id = s.id
+     WHERE s.contributor_user_id = $1
+     GROUP BY s.id, c.title
+     ORDER BY s.created_at DESC`,
+    [userId]
+  );
+  return rows;
+}
+
+/**
+ * Close out a subscription whose balances are all resolved: completed when every period was
+ * claimed, cancelled when the contributor took any of them back.
+ */
+async function settleSubscriptionStatus(client, subscriptionId) {
+  const { rows } = await client.query(
+    `SELECT
+       COUNT(*) FILTER (WHERE status = 'pending')::int AS pending,
+       COUNT(*) FILTER (WHERE status = 'contributor_reclaimed')::int AS reclaimed,
+       COUNT(*)::int AS total,
+       COUNT(*) FILTER (WHERE status = 'claimed')::int AS claimed
+     FROM subscription_balances
+     WHERE subscription_id = $1`,
+    [subscriptionId]
+  );
+  const counts = rows[0];
+  if (counts.pending > 0) return null;
+
+  const status = counts.claimed === counts.total ? 'completed' : 'cancelled';
+  await client.query(
+    `UPDATE subscriptions SET status = $2 WHERE id = $1 AND status <> $2`,
+    [subscriptionId, status]
+  );
+  return status;
+}
+
+async function markBalanceReclaimed(subscriptionId, balanceRowId) {
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(
+      `UPDATE subscription_balances SET status = 'contributor_reclaimed' WHERE id = $1`,
+      [balanceRowId]
+    );
+    await client.query(`UPDATE subscriptions SET status = 'cancelled' WHERE id = $1`, [
+      subscriptionId,
+    ]);
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+async function recordClaimedBalance({ balance, txHash }) {
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN');
+
+    const { rows: updated } = await client.query(
+      `UPDATE subscription_balances
+       SET status = 'claimed', claimed_at = NOW()
+       WHERE id = $1 AND status = 'pending'
+       RETURNING id`,
+      [balance.id]
+    );
+    if (!updated.length) {
+      await client.query('ROLLBACK');
+      return null;
+    }
+
+    // The ledger monitor also sees the claim's payment leg, so whichever writer gets there
+    // first records the contribution and moves raised_amount — never both.
+    const { rows: contributionRows } = await client.query(
+      `INSERT INTO contributions
+         (campaign_id, sender_public_key, amount, asset, payment_type, tx_hash)
+       VALUES ($1, $2, $3, $4, 'subscription_claim', $5)
+       ON CONFLICT (tx_hash) DO NOTHING
+       RETURNING id`,
+      [
+        balance.campaign_id,
+        balance.contributor_public_key,
+        balance.amount,
+        balance.asset,
+        txHash,
+      ]
+    );
+
+    if (contributionRows.length) {
+      await client.query(
+        `UPDATE campaigns
+         SET raised_amount = raised_amount + $1,
+             status = CASE
+               WHEN raised_amount + $1 >= target_amount THEN 'funded'
+               ELSE status
+             END
+         WHERE id = $2`,
+        [balance.amount, balance.campaign_id]
+      );
+    }
+
+    const subscriptionStatus = await settleSubscriptionStatus(client, balance.subscription_id);
+    await client.query('COMMIT');
+    return { subscriptionStatus };
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * SubscriptionClaimWorker — claims every subscription balance whose scheduled date has passed.
+ * Balances the contributor already reclaimed are recorded as such and end the subscription.
+ */
+async function processDueSubscriptionBalances() {
+  const { rows: due } = await db.query(
+    `SELECT sb.id, sb.subscription_id, sb.stellar_balance_id, sb.amount, sb.scheduled_date,
+            s.asset, s.campaign_id, c.wallet_public_key AS campaign_public_key,
+            u.wallet_public_key AS contributor_public_key
+     FROM subscription_balances sb
+     JOIN subscriptions s ON s.id = sb.subscription_id
+     JOIN campaigns c ON c.id = s.campaign_id
+     JOIN users u ON u.id = s.contributor_user_id
+     WHERE sb.status = 'pending'
+       AND sb.scheduled_date <= NOW()
+     ORDER BY sb.scheduled_date
+     LIMIT 200`
+  );
+
+  if (!due.length) {
+    logger.debug('subscription-claim-worker: nothing due');
+    return { claimed: 0, reclaimed: 0, failed: 0 };
+  }
+
+  let claimed = 0;
+  let reclaimed = 0;
+  let failed = 0;
+
+  for (const balance of due) {
+    try {
+      const onLedger = await getClaimableBalance(balance.stellar_balance_id);
+      if (!onLedger) {
+        await markBalanceReclaimed(balance.subscription_id, balance.id);
+        reclaimed += 1;
+        continue;
+      }
+
+      const txHash = await claimSubscriptionBalanceToCampaign({
+        balanceId: balance.stellar_balance_id,
+        asset: balance.asset,
+        amount: balance.amount,
+        destinationPublicKey: balance.campaign_public_key,
+        memo: buildContributionMemo(balance.campaign_id),
+      });
+
+      await recordClaimedBalance({ balance, txHash });
+      claimed += 1;
+    } catch (err) {
+      if (isClaimableBalanceGoneError(err)) {
+        await markBalanceReclaimed(balance.subscription_id, balance.id);
+        reclaimed += 1;
+        continue;
+      }
+      failed += 1;
+      logger.error('subscription-claim-worker: claim failed', {
+        subscription_balance_id: balance.id,
+        error: err.message,
+      });
+    }
+  }
+
+  logger.info('subscription-claim-worker: done', { claimed, reclaimed, failed });
+  return { claimed, reclaimed, failed };
+}
+
+function startSubscriptionClaimWorker() {
+  processDueSubscriptionBalances().catch((err) =>
+    logger.error('subscription-claim-worker: initial run failed', { error: err.message })
+  );
+  _workerTimer = setInterval(() => {
+    processDueSubscriptionBalances().catch((err) =>
+      logger.error('subscription-claim-worker: run failed', { error: err.message })
+    );
+  }, WORKER_INTERVAL_MS);
+  logger.info('subscription-claim-worker: started', { interval_ms: WORKER_INTERVAL_MS });
+}
+
+function stopSubscriptionClaimWorker() {
+  if (_workerTimer) {
+    clearInterval(_workerTimer);
+    _workerTimer = null;
+  }
+}
+
+module.exports = {
+  createSubscription,
+  cancelSubscription,
+  listSubscriptionsForUser,
+  processDueSubscriptionBalances,
+  startSubscriptionClaimWorker,
+  stopSubscriptionClaimWorker,
+  ALLOWED_PERIOD_MONTHS,
+  MIN_PERIODS,
+  MAX_PERIODS,
+  CANCELLATION_NOTICE_DAYS,
+  CONTRIBUTOR_RECLAIM_AFTER_DAYS,
+};

--- a/backend/src/services/recurring.test.js
+++ b/backend/src/services/recurring.test.js
@@ -1,0 +1,354 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const proxyquire = require('proxyquire').noCallThru();
+
+const CAMPAIGN_ID = '11111111-1111-1111-1111-111111111111';
+const USER_ID = '22222222-2222-2222-2222-222222222222';
+const SUBSCRIPTION_ID = '33333333-3333-3333-3333-333333333333';
+const CAMPAIGN_WALLET = 'GCAMPAIGNWALLETPUBLICKEY';
+const CONTRIBUTOR_WALLET = 'GCONTRIBUTORWALLETPUBLICKEY';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const silentLogger = { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} };
+
+function buildService({ queryImpl, stellar = {}, clientQueryImpl }) {
+  const calls = [];
+  const record = (text, params) => calls.push({ text, params });
+
+  const client = {
+    query: async (text, params) => {
+      record(text, params);
+      return clientQueryImpl ? clientQueryImpl(text, params) : { rows: [] };
+    },
+    release: () => {},
+  };
+
+  const service = proxyquire('./recurring', {
+    '../config/database': {
+      query: async (text, params) => {
+        record(text, params);
+        return queryImpl ? queryImpl(text, params) : { rows: [] };
+      },
+      connect: async () => client,
+    },
+    '../config/logger': silentLogger,
+    './stellarService': {
+      getSupportedAssetCodes: () => ['XLM', 'USDC'],
+      getCampaignBalance: async () => ({ XLM: '1000' }),
+      ensureCustodialAccountFundedAndTrusted: async () => null,
+      createSubscriptionClaimableBalances: async () => ({ txHash: 'tx', balanceIds: [] }),
+      claimSubscriptionBalanceToCampaign: async () => 'claim-tx-hash',
+      getClaimableBalance: async () => ({ id: 'balance' }),
+      isClaimableBalanceGoneError: () => false,
+      ...stellar,
+    },
+    './walletSecrets': {
+      withDecryptedWalletSecret: async (_encrypted, _ctx, fn) => fn('SCONTRIBUTORSECRET'),
+    },
+    './contributionService': { buildContributionMemo: () => 'cp-memo' },
+  });
+
+  return { service, calls };
+}
+
+function campaignRow(overrides = {}) {
+  return {
+    id: CAMPAIGN_ID,
+    wallet_public_key: CAMPAIGN_WALLET,
+    asset_type: 'XLM',
+    ...overrides,
+  };
+}
+
+function userRow() {
+  return {
+    id: USER_ID,
+    wallet_public_key: CONTRIBUTOR_WALLET,
+    wallet_secret_encrypted: 'encrypted-secret',
+  };
+}
+
+test('createSubscription creates one claimable balance per period with a 30-day reclaim predicate', async () => {
+  let createArgs = null;
+  const { service, calls } = buildService({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns')) return { rows: [campaignRow()] };
+      if (text.includes('FROM users')) return { rows: [userRow()] };
+      return { rows: [] };
+    },
+    clientQueryImpl: async (text) => {
+      if (text.includes('INSERT INTO subscriptions')) return { rows: [{ id: SUBSCRIPTION_ID }] };
+      return { rows: [] };
+    },
+    stellar: {
+      createSubscriptionClaimableBalances: async (args) => {
+        createArgs = args;
+        return {
+          txHash: 'tx',
+          balanceIds: args.entries.map((_e, i) => `balance-${i + 1}`),
+        };
+      },
+    },
+  });
+
+  const before = Date.now();
+  const result = await service.createSubscription({
+    campaignId: CAMPAIGN_ID,
+    userId: USER_ID,
+    amountPerPeriod: 10,
+    asset: 'XLM',
+    periodMonths: 1,
+    totalPeriods: 6,
+  });
+
+  assert.equal(createArgs.entries.length, 6);
+  assert.equal(result.balanceIds.length, 6);
+  assert.equal(result.totalCommitment, 60);
+  assert.equal(result.subscriptionId, SUBSCRIPTION_ID);
+
+  // Period N is due at now + N * periodMonths * 30 days, and reclaimable 30 days later.
+  const inserted = calls.filter((c) => c.text.includes('INSERT INTO subscription_balances'));
+  assert.equal(inserted.length, 6);
+  inserted.forEach((call, index) => {
+    const scheduledMs = new Date(call.params[2]).getTime();
+    const expectedMs = before + (index + 1) * 30 * DAY_MS;
+    assert.ok(Math.abs(scheduledMs - expectedMs) < 5000);
+    assert.equal(createArgs.entries[index].reclaimAfterUnix, Math.floor((scheduledMs + 30 * DAY_MS) / 1000));
+  });
+
+  assert.equal(new Date(result.firstPaymentDate).getTime(), new Date(inserted[0].params[2]).getTime());
+});
+
+test('createSubscription rejects a commitment larger than the wallet balance', async () => {
+  const { service } = buildService({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns')) return { rows: [campaignRow()] };
+      if (text.includes('FROM users')) return { rows: [userRow()] };
+      return { rows: [] };
+    },
+    stellar: { getCampaignBalance: async () => ({ XLM: '50' }) },
+  });
+
+  await assert.rejects(
+    () =>
+      service.createSubscription({
+        campaignId: CAMPAIGN_ID,
+        userId: USER_ID,
+        amountPerPeriod: 10,
+        asset: 'XLM',
+        periodMonths: 1,
+        totalPeriods: 6,
+      }),
+    (err) => {
+      assert.equal(err.code, 'INSUFFICIENT_BALANCE_FOR_SUBSCRIPTION');
+      assert.equal(err.statusCode, 400);
+      return true;
+    }
+  );
+});
+
+test('createSubscription rejects a period count outside 2–24', async () => {
+  const { service } = buildService({});
+
+  await assert.rejects(
+    () =>
+      service.createSubscription({
+        campaignId: CAMPAIGN_ID,
+        userId: USER_ID,
+        amountPerPeriod: 10,
+        asset: 'XLM',
+        periodMonths: 1,
+        totalPeriods: 25,
+      }),
+    /totalPeriods must be an integer between 2 and 24/
+  );
+});
+
+test('cancelSubscription cancels distant periods and reports the rest as non-cancellable', async () => {
+  const soon = new Date(Date.now() + 3 * DAY_MS).toISOString();
+  const distant = new Date(Date.now() + 40 * DAY_MS).toISOString();
+
+  const { service, calls } = buildService({
+    queryImpl: async (text) => {
+      if (text.includes('FROM subscriptions'))
+        return { rows: [{ id: SUBSCRIPTION_ID, status: 'active' }] };
+      return { rows: [] };
+    },
+    clientQueryImpl: async (text) => {
+      if (text.includes("status = 'cancellation_requested'")) {
+        return { rows: [{ id: 'b3', stellar_balance_id: 'balance-3', scheduled_date: distant, amount: '10' }] };
+      }
+      if (text.includes('FROM subscription_balances')) {
+        return {
+          rows: [
+            { id: 'b1', stellar_balance_id: 'balance-1', scheduled_date: soon, amount: '10', status: 'claimed' },
+            { id: 'b2', stellar_balance_id: 'balance-2', scheduled_date: soon, amount: '10', status: 'pending' },
+          ],
+        };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const result = await service.cancelSubscription({
+    campaignId: CAMPAIGN_ID,
+    subscriptionId: SUBSCRIPTION_ID,
+    userId: USER_ID,
+  });
+
+  assert.equal(result.cancelled, 1);
+  assert.equal(result.nonCancellable, 2);
+  assert.deepEqual(
+    result.non_cancellable_balances.map((b) => b.reason),
+    ['already_claimed', 'within_notice_period']
+  );
+  assert.equal(
+    new Date(result.estimatedRefundDate).getTime(),
+    new Date(distant).getTime() + 30 * DAY_MS
+  );
+  assert.ok(calls.some((c) => c.text.includes("UPDATE subscriptions SET status = 'cancelled'")));
+});
+
+test('cancelSubscription 404s for a subscription belonging to someone else', async () => {
+  const { service } = buildService({ queryImpl: async () => ({ rows: [] }) });
+
+  await assert.rejects(
+    () =>
+      service.cancelSubscription({
+        campaignId: CAMPAIGN_ID,
+        subscriptionId: SUBSCRIPTION_ID,
+        userId: USER_ID,
+      }),
+    (err) => err.statusCode === 404
+  );
+});
+
+function dueBalanceRow(overrides = {}) {
+  return {
+    id: 'sb-1',
+    subscription_id: SUBSCRIPTION_ID,
+    stellar_balance_id: 'balance-1',
+    amount: '10',
+    scheduled_date: new Date(Date.now() - DAY_MS).toISOString(),
+    asset: 'XLM',
+    campaign_id: CAMPAIGN_ID,
+    campaign_public_key: CAMPAIGN_WALLET,
+    contributor_public_key: CONTRIBUTOR_WALLET,
+    ...overrides,
+  };
+}
+
+test('the claim worker claims a due balance and records it as a contribution', async () => {
+  let claimArgs = null;
+  const { service, calls } = buildService({
+    queryImpl: async (text) => {
+      if (text.includes('FROM subscription_balances sb')) return { rows: [dueBalanceRow()] };
+      return { rows: [] };
+    },
+    clientQueryImpl: async (text) => {
+      if (text.includes("SET status = 'claimed'")) return { rows: [{ id: 'sb-1' }] };
+      if (text.includes('INSERT INTO contributions')) return { rows: [{ id: 'contribution-1' }] };
+      if (text.includes("FILTER (WHERE status = 'pending')")) {
+        return { rows: [{ pending: 0, reclaimed: 0, total: 6, claimed: 6 }] };
+      }
+      return { rows: [] };
+    },
+    stellar: {
+      claimSubscriptionBalanceToCampaign: async (args) => {
+        claimArgs = args;
+        return 'claim-tx-hash';
+      },
+    },
+  });
+
+  const result = await service.processDueSubscriptionBalances();
+
+  assert.deepEqual(result, { claimed: 1, reclaimed: 0, failed: 0 });
+  assert.equal(claimArgs.balanceId, 'balance-1');
+  assert.equal(claimArgs.destinationPublicKey, CAMPAIGN_WALLET);
+
+  const contribution = calls.find((c) => c.text.includes('INSERT INTO contributions'));
+  assert.equal(contribution.params[4], 'claim-tx-hash');
+  assert.ok(contribution.text.includes('subscription_claim'));
+  assert.ok(calls.some((c) => c.text.includes('raised_amount = raised_amount + $1')));
+});
+
+test('the claim worker completes a subscription once every period has been claimed', async () => {
+  const { service, calls } = buildService({
+    queryImpl: async (text) => {
+      if (text.includes('FROM subscription_balances sb')) return { rows: [dueBalanceRow()] };
+      return { rows: [] };
+    },
+    clientQueryImpl: async (text) => {
+      if (text.includes("SET status = 'claimed'")) return { rows: [{ id: 'sb-1' }] };
+      if (text.includes('INSERT INTO contributions')) return { rows: [{ id: 'contribution-1' }] };
+      if (text.includes("FILTER (WHERE status = 'pending')")) {
+        return { rows: [{ pending: 0, reclaimed: 0, total: 6, claimed: 6 }] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  await service.processDueSubscriptionBalances();
+
+  const settle = calls.find((c) => c.text.includes('UPDATE subscriptions SET status = $2'));
+  assert.equal(settle.params[1], 'completed');
+});
+
+test('the claim worker leaves a subscription active while periods are still pending', async () => {
+  const { service, calls } = buildService({
+    queryImpl: async (text) => {
+      if (text.includes('FROM subscription_balances sb')) return { rows: [dueBalanceRow()] };
+      return { rows: [] };
+    },
+    clientQueryImpl: async (text) => {
+      if (text.includes("SET status = 'claimed'")) return { rows: [{ id: 'sb-1' }] };
+      if (text.includes('INSERT INTO contributions')) return { rows: [{ id: 'contribution-1' }] };
+      if (text.includes("FILTER (WHERE status = 'pending')")) {
+        return { rows: [{ pending: 5, reclaimed: 0, total: 6, claimed: 1 }] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  await service.processDueSubscriptionBalances();
+
+  assert.ok(!calls.some((c) => c.text.includes('UPDATE subscriptions SET status = $2')));
+});
+
+test('the claim worker records a contributor reclaim and cancels the subscription', async () => {
+  const { service, calls } = buildService({
+    queryImpl: async (text) => {
+      if (text.includes('FROM subscription_balances sb')) return { rows: [dueBalanceRow()] };
+      return { rows: [] };
+    },
+    stellar: { getClaimableBalance: async () => null },
+  });
+
+  const result = await service.processDueSubscriptionBalances();
+
+  assert.deepEqual(result, { claimed: 0, reclaimed: 1, failed: 0 });
+  assert.ok(calls.some((c) => c.text.includes("status = 'contributor_reclaimed'")));
+  assert.ok(calls.some((c) => c.text.includes("UPDATE subscriptions SET status = 'cancelled'")));
+});
+
+test('the claim worker treats a vanished balance mid-claim as a contributor reclaim', async () => {
+  const { service, calls } = buildService({
+    queryImpl: async (text) => {
+      if (text.includes('FROM subscription_balances sb')) return { rows: [dueBalanceRow()] };
+      return { rows: [] };
+    },
+    stellar: {
+      claimSubscriptionBalanceToCampaign: async () => {
+        throw new Error('op_does_not_exist');
+      },
+      isClaimableBalanceGoneError: () => true,
+    },
+  });
+
+  const result = await service.processDueSubscriptionBalances();
+
+  assert.deepEqual(result, { claimed: 0, reclaimed: 1, failed: 0 });
+  assert.ok(calls.some((c) => c.text.includes("status = 'contributor_reclaimed'")));
+});

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -16,6 +16,8 @@ const {
   Asset,
   BASE_FEE,
   Memo,
+  Claimant,
+  xdr,
 } = require('@stellar/stellar-sdk');
 const {
   server,
@@ -605,6 +607,118 @@ async function getWalletPayments(publicKey, limit = 100) {
   }));
 }
 
+/** Balance IDs of the claimable balances created by a submitted transaction, in operation order. */
+function parseCreatedClaimableBalanceIds(resultXdrBase64) {
+  const results = xdr.TransactionResult.fromXDR(resultXdrBase64, 'base64').result().results();
+  const balanceIds = [];
+  for (const opResult of results) {
+    if (opResult.switch().name !== 'opInner') continue;
+    const tr = opResult.tr();
+    if (tr.switch().name !== 'createClaimableBalance') continue;
+    balanceIds.push(tr.createClaimableBalanceResult().balanceId().toXDR('hex'));
+  }
+  return balanceIds;
+}
+
+/**
+ * Lock one claimable balance per subscription period, all in a single transaction.
+ *
+ * Every balance names the platform as an unconditional claimant so the claim worker can
+ * release it on its scheduled date, plus the contributor under a `not(before_absolute_time)`
+ * predicate — an after-absolute-time window that lets them reclaim the funds themselves if
+ * the platform never claims.
+ *
+ * @param {Object[]} entries - One per period: { amount, reclaimAfterUnix }.
+ */
+async function createSubscriptionClaimableBalances({
+  sourceSecret,
+  asset,
+  entries,
+}) {
+  const sourceKeypair = Keypair.fromSecret(sourceSecret);
+  const sourceAccount = await server.loadAccount(sourceKeypair.publicKey());
+  const stellarAsset = toStellarAsset(asset);
+
+  const builder = new TransactionBuilder(sourceAccount, { fee: BASE_FEE, networkPassphrase });
+  for (const entry of entries) {
+    builder.addOperation(
+      Operation.createClaimableBalance({
+        asset: stellarAsset,
+        amount: String(entry.amount),
+        claimants: [
+          new Claimant(PLATFORM_KEYPAIR.publicKey(), Claimant.predicateUnconditional()),
+          new Claimant(
+            sourceKeypair.publicKey(),
+            Claimant.predicateNot(
+              Claimant.predicateBeforeAbsoluteTime(String(entry.reclaimAfterUnix))
+            )
+          ),
+        ],
+      })
+    );
+  }
+
+  const tx = builder.setTimeout(TX_TIMEOUT_CONTRIBUTION_S).build();
+  tx.sign(sourceKeypair);
+  const result = await server.submitTransaction(tx);
+
+  const balanceIds = parseCreatedClaimableBalanceIds(result.result_xdr);
+  if (balanceIds.length !== entries.length) {
+    throw new Error(
+      `Expected ${entries.length} claimable balances, ledger reported ${balanceIds.length}`
+    );
+  }
+  return { txHash: result.hash, balanceIds };
+}
+
+/** Horizon record for a claimable balance, or null once it has been claimed or never existed. */
+async function getClaimableBalance(balanceId) {
+  try {
+    return await server.claimableBalances().claimableBalance(balanceId).call();
+  } catch (err) {
+    if (err?.response?.status === 404) return null;
+    throw err;
+  }
+}
+
+/**
+ * Claim a due subscription balance with the platform key and forward it to the campaign
+ * wallet in the same transaction, so the funds never rest on the platform account.
+ */
+async function claimSubscriptionBalanceToCampaign({
+  balanceId,
+  asset,
+  amount,
+  destinationPublicKey,
+  memo,
+}) {
+  const platformAccount = await server.loadAccount(PLATFORM_KEYPAIR.publicKey());
+  const stellarAsset = toStellarAsset(asset);
+
+  const builder = new TransactionBuilder(platformAccount, { fee: BASE_FEE, networkPassphrase })
+    .addOperation(Operation.claimClaimableBalance({ balanceId }))
+    .addOperation(
+      Operation.payment({
+        destination: destinationPublicKey,
+        asset: stellarAsset,
+        amount: String(amount),
+      })
+    );
+
+  if (memo) builder.addMemo(Memo.text(memo));
+
+  const tx = builder.setTimeout(TX_TIMEOUT_CONTRIBUTION_S).build();
+  tx.sign(PLATFORM_KEYPAIR);
+  const result = await server.submitTransaction(tx);
+  return result.hash;
+}
+
+/** True when a failed claim is explained by the balance already being gone from the ledger. */
+function isClaimableBalanceGoneError(err) {
+  const codes = err?.response?.data?.extras?.result_codes?.operations;
+  return Array.isArray(codes) && codes.includes('op_does_not_exist');
+}
+
 async function friendbotFund(publicKey) {
   if (!isTestnet) throw new Error('Friendbot only available on testnet');
   const response = await fetch(
@@ -837,6 +951,12 @@ module.exports = {
   getWalletPayments,
   revokeAndCloseCampaignWallet,
   closeCampaignWalletBySecret,
+
+  createSubscriptionClaimableBalances,
+  claimSubscriptionBalanceToCampaign,
+  getClaimableBalance,
+  isClaimableBalanceGoneError,
+  parseCreatedClaimableBalanceIds,
 
   accountExistsOnLedger,
   getCampaignBalance,

--- a/frontend/src/components/RecurringPledgeForm.jsx
+++ b/frontend/src/components/RecurringPledgeForm.jsx
@@ -1,0 +1,282 @@
+import { useState } from 'react';
+import { api } from '../services/api';
+
+const PERIOD_OPTIONS = [
+  { months: 1, label: 'Monthly' },
+  { months: 3, label: 'Quarterly' },
+  { months: 6, label: 'Semi-annual' },
+];
+
+const MIN_PERIODS = 2;
+const MAX_PERIODS = 24;
+const PERIOD_DAYS = 30;
+
+function formatDate(value) {
+  return new Date(value).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function firstPaymentDate(periodMonths) {
+  return formatDate(Date.now() + periodMonths * PERIOD_DAYS * 24 * 60 * 60 * 1000);
+}
+
+function ConfirmLockModal({ amountPerPeriod, asset, periodMonths, totalPeriods, totalCommitment, submitting, error, onConfirm, onClose }) {
+  const periodLabel = PERIOD_OPTIONS.find((p) => p.months === periodMonths)?.label.toLowerCase();
+
+  return (
+    <div style={styles.overlay} onClick={onClose}>
+      <div
+        style={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Confirm recurring pledge"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 style={{ margin: '0 0 0.5rem', fontSize: '1.1rem' }}>Lock {totalCommitment} {asset} now?</h2>
+        <p style={{ margin: '0 0 1rem', color: 'var(--color-text-secondary)', fontSize: '0.88rem', lineHeight: 1.5 }}>
+          Stellar has no recurring payments, so the whole commitment leaves your wallet immediately
+          and is held in {totalPeriods} claimable balances on the ledger — one per period. CrowdPay
+          releases each one to the campaign on its scheduled date.
+        </p>
+        <ul style={{ margin: '0 0 1rem', paddingLeft: '1.1rem', color: 'var(--color-text-secondary)', fontSize: '0.85rem', lineHeight: 1.6 }}>
+          <li>
+            {amountPerPeriod} {asset} {periodLabel}, {totalPeriods} times
+          </li>
+          <li>First payment on {firstPaymentDate(periodMonths)}</li>
+          <li>Cancelling stops any payment more than 7 days away; you reclaim those funds yourself 30 days after their scheduled date</li>
+        </ul>
+
+        {error && <p className="alert alert--error" style={{ marginBottom: '0.75rem' }}>{error}</p>}
+
+        <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={onClose}
+            style={{ fontSize: '0.85rem', padding: '0.4rem 1rem' }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn-primary"
+            onClick={onConfirm}
+            disabled={submitting}
+            aria-busy={submitting}
+            style={{ fontSize: '0.85rem', padding: '0.4rem 1rem' }}
+          >
+            {submitting ? 'Locking funds…' : 'Confirm & Lock Funds'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function RecurringPledgeForm({ campaignId, asset, onSubscribed }) {
+  const [open, setOpen] = useState(false);
+  const [amountPerPeriod, setAmountPerPeriod] = useState('');
+  const [periodMonths, setPeriodMonths] = useState(1);
+  const [totalPeriods, setTotalPeriods] = useState(6);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [created, setCreated] = useState(null);
+
+  const amount = parseFloat(amountPerPeriod);
+  const amountValid = Number.isFinite(amount) && amount > 0;
+  const totalCommitment = amountValid ? Number((amount * totalPeriods).toFixed(7)) : 0;
+
+  async function confirmPledge() {
+    setSubmitting(true);
+    setError('');
+    try {
+      const subscription = await api.createSubscription(campaignId, {
+        amountPerPeriod: amount,
+        asset,
+        periodMonths,
+        totalPeriods,
+      });
+      setCreated(subscription);
+      setShowConfirm(false);
+      setOpen(false);
+      setAmountPerPeriod('');
+      onSubscribed?.(subscription);
+    } catch (err) {
+      setError(err.message || 'Could not start this recurring pledge');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div style={{ marginTop: '0.75rem' }}>
+      <button
+        type="button"
+        className="btn-secondary"
+        aria-expanded={open}
+        onClick={() => {
+          setOpen((prev) => !prev);
+          setCreated(null);
+        }}
+        style={{ width: '100%', padding: '0.6rem 1rem' }}
+      >
+        {open ? 'Hide monthly pledge' : 'Pledge Monthly'}
+      </button>
+
+      {created && !open && (
+        <p className="alert alert--success" style={{ marginTop: '0.65rem', fontSize: '0.85rem' }}>
+          Recurring pledge active — {created.totalCommitment} {asset} locked across{' '}
+          {created.balanceIds.length} payments, first on {formatDate(created.firstPaymentDate)}.
+        </p>
+      )}
+
+      {open && (
+        <div
+          style={{
+            marginTop: '0.75rem',
+            padding: '1rem',
+            border: '1px solid var(--color-border)',
+            borderRadius: '10px',
+          }}
+        >
+          <label htmlFor="pledge-amount" style={styles.label}>
+            Amount per period ({asset})
+          </label>
+          <input
+            id="pledge-amount"
+            type="number"
+            min="0"
+            step="0.0000001"
+            value={amountPerPeriod}
+            onChange={(e) => setAmountPerPeriod(e.target.value)}
+            style={styles.input}
+          />
+
+          <fieldset style={{ border: 0, padding: 0, margin: '0.9rem 0 0' }}>
+            <legend style={styles.label}>Frequency</legend>
+            <div style={{ display: 'flex', gap: '0.4rem', flexWrap: 'wrap' }}>
+              {PERIOD_OPTIONS.map((option) => (
+                <button
+                  key={option.months}
+                  type="button"
+                  className={periodMonths === option.months ? 'btn-primary' : 'btn-secondary'}
+                  aria-pressed={periodMonths === option.months}
+                  onClick={() => setPeriodMonths(option.months)}
+                  style={{ fontSize: '0.82rem', padding: '0.35rem 0.8rem' }}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          <label htmlFor="pledge-periods" style={{ ...styles.label, marginTop: '0.9rem' }}>
+            Number of periods: {totalPeriods}
+          </label>
+          <input
+            id="pledge-periods"
+            type="range"
+            min={MIN_PERIODS}
+            max={MAX_PERIODS}
+            value={totalPeriods}
+            onChange={(e) => setTotalPeriods(Number(e.target.value))}
+            style={{ width: '100%' }}
+          />
+
+          <div
+            style={{
+              marginTop: '0.9rem',
+              padding: '0.75rem',
+              borderRadius: '8px',
+              background: 'var(--color-surface, rgba(0,0,0,0.04))',
+            }}
+          >
+            <div style={{ fontSize: '0.78rem', color: 'var(--color-text-hint)' }}>
+              Total commitment
+            </div>
+            <strong style={{ fontSize: '1.35rem' }}>
+              {totalCommitment} {asset}
+            </strong>
+            <div style={{ fontSize: '0.8rem', color: 'var(--color-text-secondary)', marginTop: '0.2rem' }}>
+              First payment {firstPaymentDate(periodMonths)} · locked on Stellar up front
+            </div>
+          </div>
+
+          {error && !showConfirm && (
+            <p className="alert alert--error" style={{ marginTop: '0.75rem', fontSize: '0.85rem' }}>
+              {error}
+            </p>
+          )}
+
+          <button
+            type="button"
+            className="btn-primary"
+            disabled={!amountValid}
+            onClick={() => {
+              setError('');
+              setShowConfirm(true);
+            }}
+            style={{ width: '100%', marginTop: '0.9rem', padding: '0.6rem 1rem' }}
+          >
+            Confirm &amp; Lock Funds
+          </button>
+        </div>
+      )}
+
+      {showConfirm && (
+        <ConfirmLockModal
+          amountPerPeriod={amount}
+          asset={asset}
+          periodMonths={periodMonths}
+          totalPeriods={totalPeriods}
+          totalCommitment={totalCommitment}
+          submitting={submitting}
+          error={error}
+          onConfirm={confirmPledge}
+          onClose={() => setShowConfirm(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+const styles = {
+  label: {
+    display: 'block',
+    fontSize: '0.82rem',
+    fontWeight: 600,
+    marginBottom: '0.3rem',
+  },
+  input: {
+    width: '100%',
+    padding: '0.5rem',
+    borderRadius: '8px',
+    border: '1px solid var(--color-border)',
+    fontSize: '0.9rem',
+    boxSizing: 'border-box',
+  },
+  overlay: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    background: 'rgba(0,0,0,0.5)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+  },
+  modal: {
+    background: 'var(--color-bg)',
+    borderRadius: '12px',
+    padding: '1.5rem',
+    maxWidth: '480px',
+    width: '90%',
+    boxShadow: '0 8px 32px rgba(0,0,0,0.2)',
+  },
+};

--- a/frontend/src/components/RecurringPledgeForm.test.jsx
+++ b/frontend/src/components/RecurringPledgeForm.test.jsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import RecurringPledgeForm from './RecurringPledgeForm';
+import { api } from '../services/api';
+
+vi.mock('../services/api', () => ({
+  api: {
+    createSubscription: vi.fn(),
+  },
+}));
+
+function openForm() {
+  render(<RecurringPledgeForm campaignId="campaign-123" asset="XLM" />);
+  fireEvent.click(screen.getByRole('button', { name: 'Pledge Monthly' }));
+}
+
+describe('RecurringPledgeForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the total commitment for the chosen amount and period count', () => {
+    openForm();
+
+    fireEvent.change(screen.getByLabelText('Amount per period (XLM)'), { target: { value: '25' } });
+    fireEvent.change(screen.getByLabelText(/Number of periods/), { target: { value: '4' } });
+
+    expect(screen.getByText('100 XLM')).toBeInTheDocument();
+  });
+
+  it('keeps the period slider within 2–24', () => {
+    openForm();
+
+    const slider = screen.getByLabelText(/Number of periods/);
+    expect(slider).toHaveAttribute('min', '2');
+    expect(slider).toHaveAttribute('max', '24');
+  });
+
+  it('asks for explicit confirmation before locking funds', async () => {
+    openForm();
+
+    fireEvent.change(screen.getByLabelText('Amount per period (XLM)'), { target: { value: '10' } });
+    fireEvent.change(screen.getByLabelText(/Number of periods/), { target: { value: '6' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm & Lock Funds' }));
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('6 claimable balances');
+    expect(api.createSubscription).not.toHaveBeenCalled();
+
+    api.createSubscription.mockResolvedValue({
+      subscriptionId: 'sub-1',
+      balanceIds: ['b1', 'b2', 'b3', 'b4', 'b5', 'b6'],
+      totalCommitment: 60,
+      firstPaymentDate: '2026-09-17T00:00:00.000Z',
+    });
+
+    fireEvent.click(
+      screen.getAllByRole('button', { name: 'Confirm & Lock Funds' }).slice(-1)[0]
+    );
+
+    await waitFor(() =>
+      expect(api.createSubscription).toHaveBeenCalledWith('campaign-123', {
+        amountPerPeriod: 10,
+        asset: 'XLM',
+        periodMonths: 1,
+        totalPeriods: 6,
+      })
+    );
+    await screen.findByText(/Recurring pledge active/);
+  });
+
+  it('surfaces a rejected pledge without closing the form', async () => {
+    api.createSubscription.mockRejectedValue(new Error('Your wallet holds 5 XLM'));
+    openForm();
+
+    fireEvent.change(screen.getByLabelText('Amount per period (XLM)'), { target: { value: '10' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm & Lock Funds' }));
+    fireEvent.click(
+      screen.getAllByRole('button', { name: 'Confirm & Lock Funds' }).slice(-1)[0]
+    );
+
+    expect(await screen.findByText('Your wallet holds 5 XLM')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('sends the selected frequency', async () => {
+    api.createSubscription.mockResolvedValue({
+      subscriptionId: 'sub-2',
+      balanceIds: ['b1', 'b2'],
+      totalCommitment: 40,
+      firstPaymentDate: '2026-11-16T00:00:00.000Z',
+    });
+    openForm();
+
+    fireEvent.change(screen.getByLabelText('Amount per period (XLM)'), { target: { value: '20' } });
+    fireEvent.change(screen.getByLabelText(/Number of periods/), { target: { value: '2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Quarterly' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm & Lock Funds' }));
+    fireEvent.click(
+      screen.getAllByRole('button', { name: 'Confirm & Lock Funds' }).slice(-1)[0]
+    );
+
+    await waitFor(() =>
+      expect(api.createSubscription).toHaveBeenCalledWith(
+        'campaign-123',
+        expect.objectContaining({ periodMonths: 3, totalPeriods: 2 })
+      )
+    );
+  });
+});

--- a/frontend/src/components/SubscriptionsPanel.jsx
+++ b/frontend/src/components/SubscriptionsPanel.jsx
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { api } from '../services/api';
+
+const PERIOD_LABELS = { 1: 'Monthly', 3: 'Quarterly', 6: 'Semi-annual' };
+
+function formatDate(value) {
+  if (!value) return '—';
+  return new Date(value).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function SubscriptionRow({ subscription, result, onCancelled }) {
+  const [cancelling, setCancelling] = useState(false);
+  const [error, setError] = useState('');
+
+  async function cancel() {
+    setCancelling(true);
+    setError('');
+    try {
+      const summary = await api.cancelSubscription(subscription.campaign_id, subscription.id);
+      onCancelled?.(subscription.id, summary);
+    } catch (err) {
+      setError(err.message || 'Could not cancel this subscription');
+    } finally {
+      setCancelling(false);
+    }
+  }
+
+  return (
+    <div className="campaign-card" style={{ minHeight: 'auto' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          gap: '0.75rem',
+          flexWrap: 'wrap',
+          alignItems: 'center',
+        }}
+      >
+        <div>
+          <Link
+            to={`/campaigns/${subscription.campaign_id}`}
+            style={{ fontWeight: 700, color: 'var(--color-accent)' }}
+          >
+            {subscription.campaign_title}
+          </Link>
+          <div style={{ fontSize: '0.85rem', color: 'var(--color-text-secondary)', marginTop: '0.25rem' }}>
+            {subscription.amount_per_period} {subscription.asset} ·{' '}
+            {PERIOD_LABELS[subscription.period_months] || `Every ${subscription.period_months} months`} ·{' '}
+            {subscription.periods_claimed}/{subscription.total_periods} paid
+          </div>
+          <div style={{ fontSize: '0.85rem', color: 'var(--color-text-hint)', marginTop: '0.2rem' }}>
+            Next payment: {formatDate(subscription.next_payment_date)}
+          </div>
+        </div>
+
+        {subscription.status === 'active' ? (
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={cancel}
+            disabled={cancelling}
+            aria-busy={cancelling}
+            style={{ fontSize: '0.82rem', padding: '0.35rem 0.9rem' }}
+          >
+            {cancelling ? 'Cancelling…' : 'Cancel'}
+          </button>
+        ) : (
+          <span style={{ fontSize: '0.82rem', color: 'var(--color-text-hint)' }}>
+            {subscription.status}
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <p className="alert alert--error" style={{ marginTop: '0.6rem', fontSize: '0.85rem' }}>
+          {error}
+        </p>
+      )}
+
+      {result && (
+        <p className="alert alert--info" style={{ marginTop: '0.6rem', fontSize: '0.85rem' }}>
+          {result.cancelled} future payment{result.cancelled === 1 ? '' : 's'} cancelled
+          {result.nonCancellable > 0
+            ? `, ${result.nonCancellable} could not be cancelled (already claimed or due within 7 days)`
+            : ''}
+          .
+          {result.estimatedRefundDate
+            ? ` You can reclaim the locked funds from ${formatDate(result.estimatedRefundDate)}.`
+            : ''}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function SubscriptionsPanel() {
+  const [subscriptions, setSubscriptions] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  // Cancellation summaries live here so they survive the refresh that follows a cancel.
+  const [cancellations, setCancellations] = useState({});
+
+  const load = useCallback(
+    () =>
+      api
+        .getMySubscriptions()
+        .then((data) => setSubscriptions(data.subscriptions || []))
+        .catch((err) => setError(err.message || 'Could not load subscriptions'))
+        .finally(() => setLoading(false)),
+    []
+  );
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  function handleCancelled(subscriptionId, summary) {
+    setCancellations((prev) => ({ ...prev, [subscriptionId]: summary }));
+    load();
+  }
+
+  if (loading) return <p style={{ color: 'var(--color-text-hint)' }}>Loading subscriptions…</p>;
+  if (error) return <p className="alert alert--error">{error}</p>;
+  if (!subscriptions.length) {
+    return (
+      <p className="alert alert--info">
+        You have no recurring pledges yet. Open a campaign and choose “Pledge Monthly” to start one.
+      </p>
+    );
+  }
+
+  return (
+    <div style={{ display: 'grid', gap: '0.75rem' }}>
+      {subscriptions.map((subscription) => (
+        <SubscriptionRow
+          key={subscription.id}
+          subscription={subscription}
+          result={cancellations[subscription.id]}
+          onCancelled={handleCancelled}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/SubscriptionsPanel.test.jsx
+++ b/frontend/src/components/SubscriptionsPanel.test.jsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+import SubscriptionsPanel from './SubscriptionsPanel';
+import { api } from '../services/api';
+
+vi.mock('../services/api', () => ({
+  api: {
+    getMySubscriptions: vi.fn(),
+    cancelSubscription: vi.fn(),
+  },
+}));
+
+const subscription = {
+  id: 'sub-1',
+  campaign_id: 'campaign-123',
+  campaign_title: 'Solar Grid',
+  amount_per_period: '10',
+  asset: 'XLM',
+  period_months: 1,
+  total_periods: 6,
+  periods_claimed: 2,
+  next_payment_date: '2026-09-17T00:00:00.000Z',
+  status: 'active',
+};
+
+function renderPanel() {
+  return render(
+    <MemoryRouter>
+      <SubscriptionsPanel />
+    </MemoryRouter>
+  );
+}
+
+describe('SubscriptionsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists active subscriptions with their next payment date', async () => {
+    api.getMySubscriptions.mockResolvedValue({ subscriptions: [subscription] });
+    renderPanel();
+
+    expect(await screen.findByText('Solar Grid')).toBeInTheDocument();
+    expect(screen.getByText(/10 XLM · Monthly · 2\/6 paid/)).toBeInTheDocument();
+    expect(screen.getByText(/Next payment:/)).toBeInTheDocument();
+  });
+
+  it('reports the periods that could not be cancelled', async () => {
+    api.getMySubscriptions.mockResolvedValue({ subscriptions: [subscription] });
+    api.cancelSubscription.mockResolvedValue({
+      cancelled: 3,
+      nonCancellable: 1,
+      non_cancellable_balances: [{ id: 'b1', reason: 'already_claimed' }],
+      estimatedRefundDate: '2026-12-16T00:00:00.000Z',
+    });
+    renderPanel();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() =>
+      expect(api.cancelSubscription).toHaveBeenCalledWith('campaign-123', 'sub-1')
+    );
+    expect(await screen.findByText(/3 future payments cancelled/)).toBeInTheDocument();
+    expect(screen.getByText(/1 could not be cancelled/)).toBeInTheDocument();
+  });
+
+  it('prompts the contributor when they have no subscriptions', async () => {
+    api.getMySubscriptions.mockResolvedValue({ subscriptions: [] });
+    renderPanel();
+
+    expect(await screen.findByText(/no recurring pledges yet/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -496,6 +496,7 @@
     "tabs": {
       "campaigns": "My Campaigns",
       "contributions": "My Contributions",
+      "subscriptions": "Subscriptions",
       "following": "Following",
       "analytics": "Analytics",
       "apiKeys": "API Keys",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -493,6 +493,7 @@
     "tabs": {
       "campaigns": "Mes campagnes",
       "contributions": "Mes contributions",
+      "subscriptions": "Abonnements",
       "following": "Suivis",
       "analytics": "Analytique",
       "apiKeys": "Clés API",

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -6,6 +6,7 @@ import { api } from '../services/api';
 import { useAuth } from '../context/AuthContext';
 import { useToast } from '../context/ToastContext';
 import ContributeModal from '../components/ContributeModal';
+import RecurringPledgeForm from '../components/RecurringPledgeForm';
 import RelativeTime from '../components/RelativeTime';
 import DisputeModal from '../components/DisputeModal';
 import TransactionHistory from '../components/TransactionHistory';
@@ -1389,6 +1390,14 @@ export default function Campaign() {
               Contribute with Freighter
             </button>
           </div>
+        )}
+
+        {user && campaign.status === 'active' && (
+          <RecurringPledgeForm
+            campaignId={id}
+            asset={campaign.asset_type}
+            onSubscribed={() => setContributed((prev) => !prev)}
+          />
         )}
 
         {user && (

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -6,6 +6,7 @@ import { api } from '../services/api';
 import { useAuth } from '../context/AuthContext';
 import { useToast } from '../context/ToastContext';
 import ContributeModal from '../components/ContributeModal';
+import RecurringPledgeForm from '../components/RecurringPledgeForm';
 import ReferralProgramSettings from '../components/ReferralProgramSettings';
 import CampaignReferralsTab from '../components/CampaignReferralsTab';
 import RelativeTime from '../components/RelativeTime';

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -7,6 +7,7 @@ import KycPrompt from '../components/KycPrompt';
 import VerificationBadge from '../components/VerificationBadge';
 import CampaignStatusBadge from '../components/CampaignStatusBadge';
 import ContributorDashboard from '../components/ContributorDashboard';
+import SubscriptionsPanel from '../components/SubscriptionsPanel';
 import FollowedCampaigns from '../components/FollowedCampaigns';
 import DepositModal from '../components/DepositModal';
 import ApiKeysPanel from '../components/ApiKeysPanel';
@@ -19,6 +20,7 @@ const MiniLineChart = React.lazy(() => import('../components/MiniLineChart'));
 const TABS = [
   { id: 'campaigns', labelKey: 'dashboard.tabs.campaigns' },
   { id: 'contributions', labelKey: 'dashboard.tabs.contributions' },
+  { id: 'subscriptions', labelKey: 'dashboard.tabs.subscriptions' },
   { id: 'following', labelKey: 'dashboard.tabs.following' },
   { id: 'analytics', labelKey: 'dashboard.tabs.analytics' },
   { id: 'api-keys', labelKey: 'dashboard.tabs.apiKeys' },
@@ -259,15 +261,17 @@ export default function Dashboard() {
   const activeTab =
     tabParam === 'contributions'
       ? 'contributions'
-      : tabParam === 'following'
-        ? 'following'
-        : tabParam === 'referrals'
-          ? 'referrals'
-          : tabParam === 'analytics'
-            ? 'analytics'
-            : tabParam === 'api-keys'
-              ? 'api-keys'
-              : 'campaigns';
+      : tabParam === 'subscriptions'
+        ? 'subscriptions'
+        : tabParam === 'following'
+          ? 'following'
+          : tabParam === 'referrals'
+            ? 'referrals'
+            : tabParam === 'analytics'
+              ? 'analytics'
+              : tabParam === 'api-keys'
+                ? 'api-keys'
+                : 'campaigns';
 
   const [stats, setStats] = useState(null);
   const [campaigns, setCampaigns] = useState([]);
@@ -490,6 +494,8 @@ export default function Dashboard() {
   function setTab(tabId) {
     if (tabId === 'contributions') {
       setSearchParams({ tab: 'contributions' });
+    } else if (tabId === 'subscriptions') {
+      setSearchParams({ tab: 'subscriptions' });
     } else if (tabId === 'following') {
       setSearchParams({ tab: 'following' });
     } else if (tabId === 'analytics') {
@@ -862,6 +868,12 @@ export default function Dashboard() {
       {activeTab === 'contributions' && (
         <section role="tabpanel" aria-labelledby="tab-contributions">
           <ContributorDashboard />
+        </section>
+      )}
+
+      {activeTab === 'subscriptions' && (
+        <section role="tabpanel" aria-labelledby="tab-subscriptions">
+          <SubscriptionsPanel />
         </section>
       )}
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -496,6 +496,12 @@ export const api = {
   requestContributionRefund: (contributionId) =>
     request('POST', `/contributions/${contributionId}/refund`, {}),
 
+  createSubscription: (campaignId, body) =>
+    request('POST', `/campaigns/${campaignId}/subscriptions`, body),
+  cancelSubscription: (campaignId, subscriptionId) =>
+    request('DELETE', `/campaigns/${campaignId}/subscriptions/${subscriptionId}`),
+  getMySubscriptions: () => request('GET', '/subscriptions/mine'),
+
   getContributorDashboard: () => request('GET', '/contributions/dashboard'),
   exportContributionsCsv: () =>
     downloadFile('/contributions/dashboard/export.csv', 'contributions.csv'),


### PR DESCRIPTION
## What I built

Recurring pledges, implemented as a Stellar claimable balance schedule. When a contributor enables a monthly pledge the whole commitment leaves their wallet immediately as one claimable balance per period; a daily worker claims each one for the campaign on its scheduled date, and cancelling stops the ones that are still far enough out.

Closes #677

### Backend

**`backend/db/migrations/20260818_recurring_subscriptions.sql`** — `subscriptions` and `subscription_balances` tables per the issue, plus `subscription_claim` added to the `contributions.payment_type` check constraint so claimed periods appear in campaign totals, dashboards and exports like any other contribution.

**`backend/src/services/stellarService.js`**
- `createSubscriptionClaimableBalances()` — one `CreateClaimableBalance` op per period in a single transaction. Claimants are the platform (unconditional) and the contributor under `not(before_absolute_time)` — the after-absolute-time form — set to 30 days after that period's scheduled date. Balance IDs are decoded from the transaction result XDR.
- `claimSubscriptionBalanceToCampaign()` — claims a due balance with the platform key and pays it to the campaign wallet **in the same transaction**, so the funds never rest on the platform account.
- `getClaimableBalance()` / `isClaimableBalanceGoneError()` — how the worker detects that a contributor already reclaimed a balance.

**`backend/src/services/recurring.js`** — the pledge engine:
- `createSubscription()` validates the input, rejects a commitment the wallet can't cover with `400 INSUFFICIENT_BALANCE_FOR_SUBSCRIPTION`, locks the balances on-chain, then stores the subscription and its schedule in one transaction.
- `cancelSubscription()` marks every pending period more than 7 days out as `cancellation_requested`; everything else — periods due sooner, and periods already claimed — comes back in `non_cancellable_balances` with a reason.
- `processDueSubscriptionBalances()` (the claim worker) claims due balances, records each as a contribution, moves `raised_amount`, and settles the subscription to `completed` (all periods claimed) or `cancelled` (a period was reclaimed) once nothing is pending.

**`backend/src/routes/subscriptions.js`** — `POST /api/campaigns/:id/subscriptions`, `DELETE /api/campaigns/:id/subscriptions/:subscriptionId`, and `GET /api/subscriptions/mine` for the dashboard, with OpenAPI annotations.

### Frontend

- **Campaign page** — a "Pledge Monthly" toggle below the contribute button: amount per period, monthly/quarterly/semi-annual selector, a 2–24 period slider, and the total commitment shown prominently. "Confirm & Lock Funds" opens a modal that spells out that the full amount leaves the wallet now into claimable balances, and asks for explicit confirmation.
- **Contributor dashboard → Subscriptions tab** — campaign name, amount, period, next payment date, and a Cancel button that reports how many periods were cancelled, how many couldn't be, and when the funds become reclaimable.

## Decisions worth flagging

**No BullMQ.** The issue specifies BullMQ for `SubscriptionClaimWorker`, but neither `bullmq` nor Redis is a dependency of this repo, and every other periodic job here runs on `node-cron`/`setInterval` from `src/index.js`. I followed the existing pattern with a daily interval rather than introducing a queue backend and a Redis service for one job. The worker function is exported and takes no arguments, so moving it onto a queue later is a drop-in change.

**The claim forwards in one transaction.** The issue says the worker claims "on behalf of the campaign wallet". A claimable balance can only be claimed by a named claimant, and the campaign wallet is multisig, so the platform claims and pays the campaign in a single atomic transaction instead.

**Claim contributions are written idempotently.** The ledger monitor also sees the payment leg of the claim, so both writers race for the same `tx_hash`. The worker inserts with `ON CONFLICT (tx_hash) DO NOTHING` and only moves `raised_amount` when its own insert landed — whichever writer gets there first records it, never both.

**Full amount is forwarded.** No platform fee is taken on subscription claims; the issue doesn't specify one, and `calcFee` applies at contribution time in the one-time flow. Easy to add if you want parity.

**Funds are locked before the DB write.** If persisting the schedule fails after the on-chain transaction succeeds, the error is logged with the balance IDs so it can be recovered; the contributor can also reclaim via their predicate. Worth a follow-up if you'd rather record intent first.

## How to test manually

Backend and frontend running per the README, on testnet.

1. Log in as a contributor with a funded wallet, open an active campaign, click **Pledge Monthly**.
2. Enter `10`, keep **Monthly**, set the slider to `6` — the panel shows `60 XLM` total commitment. Click **Confirm & Lock Funds**, confirm in the modal.
3. Check the schedule on-chain — 6 balances, each claimable by the platform:
   ```bash
   curl "https://horizon-testnet.stellar.org/claimable_balances?claimant=<PLATFORM_PUBLIC_KEY>&limit=20"
   ```
   Each record's second claimant is the contributor with `{"not": {"abs_before": ...}}` 30 days after that period's scheduled date.
4. Open **Dashboard → Subscriptions** — the pledge shows `0/6 paid` with its next payment date.
5. Click **Cancel** — periods more than 7 days out are cancelled; anything within 7 days or already claimed is reported as non-cancellable with an estimated reclaim date.
6. To watch the worker, set a balance's `scheduled_date` into the past and restart the backend (the worker runs once at startup, then daily):
   ```sql
   UPDATE subscription_balances SET scheduled_date = NOW() - INTERVAL '1 day' WHERE id = '<id>';
   ```
   The balance flips to `claimed`, a `subscription_claim` row lands in `contributions`, and the campaign's `raised_amount` moves.

## Verification

The Stellar layer was exercised against testnet while building this, not just mocked:

- A 6-period monthly subscription created **exactly 6** claimable balances, confirmed by querying Horizon for balances claimable by the platform account, with every returned ID matching the ones decoded from the result XDR.
- Horizon reported the contributor claimant as `{"not": {"abs_before": "…", "abs_before_epoch": "…"}}` at the scheduled date + 30 days.
- The claim-and-forward transaction moved the balance to the campaign wallet (`10000.0000000 → 10005.0000000` XLM) and left the balance gone from the ledger — the same signal the worker uses to detect a contributor reclaim.

The migration was applied against a real Postgres and its constraints checked (a 30-period subscription is rejected by `subscriptions_total_periods_check`).

`npm test` passes in both `backend/` (736) and `frontend/` (161); `npm run lint` is clean of new warnings in both, and `npm run build` succeeds.

## Acceptance criteria

| Criteria | Where |
|---|---|
| 6-period monthly subscription creates exactly 6 claimable balances, confirmed via Horizon | Verified on testnet (above); `recurring.test.js` asserts one balance per period |
| Each balance has the correct after_absolute_time predicate for the reclaim window | `not(before_absolute_time)` at scheduled date + 30 days — decoded from Horizon and asserted in `recurring.test.js` |
| Worker claims a due balance within 24 hours of `scheduled_date` | Daily worker on `scheduled_date <= NOW()`, also runs at startup |
| A claimed balance cannot be cancelled — appears in `non_cancellable_balances` | `cancelSubscription()` returns it with `reason: "already_claimed"` |
| Cancellation within 7 days of a schedule date is identified as non-cancellable | Notice cutoff in `cancelSubscription()`; `reason: "within_notice_period"` |
| Subscription transitions to `completed` when all balances are claimed | `settleSubscriptionStatus()` — tested for both the completed and still-pending cases |
