### PR TITLE
docs(api): document the campaign referral endpoints in the OpenAPI spec

### DIFF
--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -2308,6 +2308,45 @@ router.get('/:id/referrals', requireAuth, requireCampaignMember('owner'), asyncH
 
 // ── Referral & affiliate program (#675) ──────────────────────────────────────
 
+/**
+ * @openapi
+ * /api/campaigns/{id}/referrals:
+ *   post:
+ *     tags: [Campaigns]
+ *     summary: Enable or update the campaign's referral program (creator only)
+ *     description: >
+ *       Creates the referral program for a campaign, or updates the terms of an
+ *       existing one. Updating the commission rate does not invalidate referral
+ *       links that have already been issued.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [commissionPercentage, maxReferrers]
+ *             properties:
+ *               commissionPercentage:
+ *                 type: number
+ *                 description: Percentage of each referred contribution paid to the referrer (1-20)
+ *                 example: 10
+ *               maxReferrers:
+ *                 type: integer
+ *                 description: Maximum number of referrers that may claim a link (1-100)
+ *                 example: 25
+ *     responses:
+ *       201: { description: Referral program created or updated }
+ *       400: { description: commissionPercentage or maxReferrers outside the allowed range }
+ *       403: { description: Forbidden }
+ *       404: { description: Campaign not found }
+ */
 // POST /campaigns/:id/referrals — creator enables referrals on the campaign
 router.post('/:id/referrals', requireAuth, requireCampaignMember('owner'), asyncHandler(async (req, res) => {
   const { commissionPercentage, maxReferrers } = req.body || {};
@@ -2322,6 +2361,24 @@ router.post('/:id/referrals', requireAuth, requireCampaignMember('owner'), async
   }
 }));
 
+/**
+ * @openapi
+ * /api/campaigns/{id}/referrals/program:
+ *   get:
+ *     tags: [Campaigns]
+ *     summary: Get the campaign's public referral program terms
+ *     description: >
+ *       Public endpoint used by the share page to show the commission rate and
+ *       how many of the referrer slots have already been claimed.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200: { description: Program terms plus the current referrer_count }
+ *       404: { description: This campaign does not have a referral program }
+ */
 // GET /campaigns/:id/referrals/program — public program terms
 router.get('/:id/referrals/program', asyncHandler(async (req, res) => {
   const program = await getReferralProgram(req.params.id);
@@ -2333,6 +2390,39 @@ router.get('/:id/referrals/program', asyncHandler(async (req, res) => {
   res.json({ ...program, referrer_count: rows[0]?.total || 0 });
 }));
 
+/**
+ * @openapi
+ * /api/campaigns/{id}/referrals/links:
+ *   post:
+ *     tags: [Campaigns]
+ *     summary: Claim a trackable referral link for the authenticated user
+ *     description: >
+ *       Issues a unique 8-character referral code for the caller. The call is
+ *       idempotent: a user who already holds a link for this campaign gets the
+ *       same code back with a 200 instead of a 201. Contributions made through
+ *       the returned shareUrl are attributed on-chain via the Stellar
+ *       transaction memo (`ref:<code>`).
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: The caller already held a link; the existing code is returned
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 code: { type: string, example: "a1b2c3d4" }
+ *                 shareUrl: { type: string, example: "https://crowdpay.com/c/<campaignId>?ref=a1b2c3d4" }
+ *       201: { description: A new referral link was issued }
+ *       404: { description: This campaign does not have a referral program }
+ *       409: { description: REFERRER_LIMIT_REACHED - the maxReferrers cap is full }
+ */
 // POST /campaigns/:id/referrals/links — any registered user claims a referrer link
 router.post('/:id/referrals/links', requireAuth, asyncHandler(async (req, res) => {
   try {
@@ -2349,6 +2439,28 @@ router.post('/:id/referrals/links', requireAuth, asyncHandler(async (req, res) =
   }
 }));
 
+/**
+ * @openapi
+ * /api/campaigns/{id}/referrals/commissions:
+ *   get:
+ *     tags: [Campaigns]
+ *     summary: Referrer breakdown with commission owed (creator only)
+ *     description: >
+ *       Powers the campaign analytics Referrals tab: every referrer with their
+ *       referred contribution count, total referred amount, and the commission
+ *       still owed to them at the next withdrawal.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200: { description: Program terms and the per-referrer commission breakdown }
+ *       403: { description: Forbidden }
+ *       404: { description: This campaign does not have a referral program }
+ */
 // GET /campaigns/:id/referrals/commissions — creator-only referrer breakdown
 router.get('/:id/referrals/commissions', requireAuth, requireCampaignMember('owner'), asyncHandler(async (req, res) => {
   const data = await listCampaignReferrers(req.params.id);

--- a/backend/src/routes/campaigns.referralDocs.test.js
+++ b/backend/src/routes/campaigns.referralDocs.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const swaggerJsdoc = require('swagger-jsdoc');
+
+// The OpenAPI spec is assembled from @openapi JSDoc blocks in the route files
+// (see the swaggerJsdoc call in src/index.js). These assertions pin the referral
+// endpoints so the annotations are not dropped by a future merge.
+const spec = swaggerJsdoc({
+  definition: {
+    openapi: '3.0.0',
+    info: { title: 'CrowdPay API', version: '1.0.0' },
+    components: {
+      securitySchemes: {
+        bearerAuth: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+      },
+    },
+  },
+  apis: [path.join(__dirname, '*.js')],
+});
+
+test('the campaign referral endpoints are documented in the OpenAPI spec', () => {
+  const documented = {
+    '/api/campaigns/{id}/referrals': 'post',
+    '/api/campaigns/{id}/referrals/program': 'get',
+    '/api/campaigns/{id}/referrals/links': 'post',
+    '/api/campaigns/{id}/referrals/commissions': 'get',
+  };
+
+  for (const [route, method] of Object.entries(documented)) {
+    const operation = spec.paths?.[route]?.[method];
+    assert.ok(operation, `${method.toUpperCase()} ${route} is missing from the OpenAPI spec`);
+    assert.ok(operation.summary, `${method.toUpperCase()} ${route} has no summary`);
+    assert.ok(operation.responses, `${method.toUpperCase()} ${route} documents no responses`);
+  }
+});
+
+test('the authenticated referral endpoints declare bearer auth', () => {
+  const authenticated = [
+    ['/api/campaigns/{id}/referrals', 'post'],
+    ['/api/campaigns/{id}/referrals/links', 'post'],
+    ['/api/campaigns/{id}/referrals/commissions', 'get'],
+  ];
+
+  for (const [route, method] of authenticated) {
+    const { security } = spec.paths[route][method];
+    assert.ok(
+      Array.isArray(security) && security.some((s) => 'bearerAuth' in s),
+      `${method.toUpperCase()} ${route} should require bearerAuth`
+    );
+  }
+});
+
+test('the public program endpoint is not marked as requiring auth', () => {
+  const operation = spec.paths['/api/campaigns/{id}/referrals/program'].get;
+  assert.equal(operation.security, undefined);
+});
+
+test('claiming a referral link documents the cap and missing-program failures', () => {
+  const { responses } = spec.paths['/api/campaigns/{id}/referrals/links'].post;
+  // 409 is REFERRER_LIMIT_REACHED, 404 is a campaign without a referral program.
+  assert.ok(responses['409'], 'the maxReferrers cap response is undocumented');
+  assert.ok(responses['404'], 'the missing-program response is undocumented');
+  assert.ok(responses['201'], 'the created response is undocumented');
+  assert.ok(responses['200'], 'the idempotent re-claim response is undocumented');
+});


### PR DESCRIPTION
**Title:** `docs(api): document the campaign referral endpoints in the OpenAPI spec`

---

## Description

Closes #675

### Context — why the referral code is already in `main`

The implementation for #675 was merged in **#685**. That PR carried the wrong description: I pasted the body from my earlier reward-tier work, so it opened with `Closes #397` instead of `Closes #675`. The branch and the commits were correct — all eight referral commits (`65276f5`…`a951a5e`) merged as `b4073c9` — but because of the wrong closing reference, **#675 was never linked to the PR that implemented it and is still open**.

For the record, no harm came to #397: it had already been closed on 2026-07-28 by #626 (`innocentharuna`), which is where `reserveTierSlot` actually came from. The stray keyword re-referenced an issue that was already closed a month earlier.

This PR completes the remaining piece of #675 and closes it properly. Raising it this way was agreed with the maintainer.

### What this PR actually changes

#685 shipped four campaign-scoped referral endpoints that were reachable but **undocumented** — they did not appear at `/api/docs`, so the generated OpenAPI spec described only part of the campaign surface:

| Endpoint | Auth | Now documents |
|---|---|---|
| `POST /api/campaigns/{id}/referrals` | creator | commission/cap request body, `400` on out-of-range values |
| `GET /api/campaigns/{id}/referrals/program` | public | program terms + `referrer_count`, `404` when referrals are off |
| `POST /api/campaigns/{id}/referrals/links` | any user | `201` vs the idempotent `200` re-claim, `409 REFERRER_LIMIT_REACHED` |
| `GET /api/campaigns/{id}/referrals/commissions` | creator | per-referrer commission breakdown |

The spec is assembled by `swagger-jsdoc` from `@openapi` blocks in `src/routes/*.js` (see `src/index.js`), so this is four JSDoc blocks in `campaigns.js` following the same style as the existing `/api/campaigns/{id}/tiers` annotations. `/api/referrals/links` was already annotated in `referrals.js` and is unchanged.

Documented paths in the generated spec go from 36 to 40.

## Tests

New `src/routes/campaigns.referralDocs.test.js` (4 tests) asserts the four routes are present in the generated spec, that the three authenticated ones declare `bearerAuth`, that the public program endpoint does **not**, and that the `409` cap and `200`/`201` claim outcomes stay documented.

These annotations are plain comments — nothing else in the suite would notice if a future merge dropped them, and that is not hypothetical: `47bd95c` had to restore a `RecurringPledgeForm` import lost in the referral merge. I verified the test is not vacuous by stashing the annotated `campaigns.js` and re-running it: all 4 tests fail without the annotations and pass with them.

```bash
cd backend && npm run lint && npm test
# lint: 0 errors (78 pre-existing warnings, unchanged)
# tests: 774/775 pass
```

The one failure is `GET /api/campaigns/recommended returns personalized campaign suggestions`, which is unrelated to this change and fails only under full-suite parallel load — it ran for 28 minutes before giving up, and passes in ~1s when its file is run on its own. Nothing here touches that route; the diff is four comment blocks and one new test file.

### Manual verification

```bash
cd backend && npm run dev
open http://localhost:3001/api/docs        # the four routes appear under Campaigns
curl -s localhost:3001/api/docs/openapi.json | jq '.paths | keys[] | select(contains("referrals"))'
```

## Checklist

- [x] `npm run lint` and `npm test` pass in `backend/`
- [x] No behavioural change — annotations, plus one new test file
- [x] PR is against `main` and rebased on current `main`
