### PR TITLE
fix(security): enforce 5000-character limit on campaign update bodies

### DIFF
--- a/backend/db/migrations/20260824_campaign_update_body_length.sql
+++ b/backend/db/migrations/20260824_campaign_update_body_length.sql
@@ -1,0 +1,4 @@
+-- Enforce a maximum length on campaign update bodies at the database
+-- level — defence-in-depth alongside the API validation (issue #400).
+ALTER TABLE campaign_updates
+  ADD CONSTRAINT campaign_updates_body_length CHECK (char_length(body) <= 5000);

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -65,7 +65,7 @@ CREATE TABLE IF NOT EXISTS campaign_updates (
   campaign_id UUID NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
   author_id UUID NOT NULL REFERENCES users(id),
   title TEXT NOT NULL,
-  body TEXT NOT NULL,
+  body TEXT NOT NULL CONSTRAINT campaign_updates_body_length CHECK (char_length(body) <= 5000),
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW()
 );

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -219,6 +219,8 @@ const thankYouValidation = [
     .withMessage('Message must be between 1 and 500 characters'),
 ];
 
+const CAMPAIGN_UPDATE_BODY_MAX_LENGTH = 5000;
+
 const createCampaignUpdateValidation = [
   body('title')
     .customSanitizer(stripHtml)
@@ -227,7 +229,11 @@ const createCampaignUpdateValidation = [
   body('body')
     .customSanitizer(stripHtml)
     .notEmpty()
-    .withMessage('Body is required'),
+    .withMessage('Body is required')
+    .isLength({ max: CAMPAIGN_UPDATE_BODY_MAX_LENGTH })
+    .withMessage(
+      `Update body must be ${CAMPAIGN_UPDATE_BODY_MAX_LENGTH} characters or fewer`
+    ),
 ];
 
 const contributionQuoteValidation = [
@@ -440,6 +446,7 @@ module.exports = {
   contributionQuoteValidation,
   withdrawalValidation,
   createAnnouncementValidation,
+  CAMPAIGN_UPDATE_BODY_MAX_LENGTH,
   announcementIdValidation,
   getCampaignsValidation,
   validateRequest,

--- a/backend/src/routes/campaignUpdates.js
+++ b/backend/src/routes/campaignUpdates.js
@@ -6,6 +6,9 @@ const logger = require("../config/logger");
 const { sendCampaignUpdatePostedEmail } = require("../services/emailService");
 const { createNotification } = require("../services/notifications");
 const { notifyFollowers } = require("../services/campaignFollowService");
+const {
+  CAMPAIGN_UPDATE_BODY_MAX_LENGTH,
+} = require("../middleware/validation");
 
 function frontendBaseUrl() {
   return (process.env.FRONTEND_URL || "http://localhost:5173").replace(/\/$/, "");
@@ -74,6 +77,11 @@ router.post(
 
     if (!title) return res.status(422).json({ error: "Title is required" });
     if (!body) return res.status(422).json({ error: "Body is required" });
+    if (body.length > CAMPAIGN_UPDATE_BODY_MAX_LENGTH) {
+      return res.status(422).json({
+        error: `Update body must be ${CAMPAIGN_UPDATE_BODY_MAX_LENGTH} characters or fewer`,
+      });
+    }
 
     const { rows } = await db.query(
       `INSERT INTO campaign_updates (campaign_id, author_id, title, body)
@@ -160,6 +168,11 @@ router.patch(
 
     if (!title) return res.status(422).json({ error: "Title is required" });
     if (!body) return res.status(422).json({ error: "Body is required" });
+    if (body.length > CAMPAIGN_UPDATE_BODY_MAX_LENGTH) {
+      return res.status(422).json({
+        error: `Update body must be ${CAMPAIGN_UPDATE_BODY_MAX_LENGTH} characters or fewer`,
+      });
+    }
 
     const { rows } = await db.query(
       `UPDATE campaign_updates

--- a/frontend/src/pages/Campaign.jsx
+++ b/frontend/src/pages/Campaign.jsx
@@ -106,6 +106,9 @@ function FavoriteToggle({ campaignId }) {
   );
 }
 
+const UPDATE_BODY_MAX = 5000;
+const UPDATE_BODY_WARN_THRESHOLD = Math.round(UPDATE_BODY_MAX * 0.9);
+
 function CampaignPublishControls({ campaign, isOwner, navigate }) {
   const [cloning, setCloning] = useState(false);
   const [publishing, setPublishing] = useState(false);
@@ -1043,6 +1046,14 @@ export default function Campaign() {
   async function submitUpdate(e) {
     e.preventDefault();
     setUpdatesError('');
+
+    if (updateForm.body.length > UPDATE_BODY_MAX) {
+      setUpdatesError(
+        `Update body must be ${UPDATE_BODY_MAX} characters or fewer (currently ${updateForm.body.length})`
+      );
+      return;
+    }
+
     setUpdateBusy(true);
 
     try {
@@ -2382,6 +2393,22 @@ export default function Campaign() {
             rows={4}
             required
           />
+          <div
+            aria-live="polite"
+            style={{
+              fontSize: '0.8rem',
+              marginTop: '0.25rem',
+              textAlign: 'right',
+              color:
+                updateForm.body.length > UPDATE_BODY_MAX
+                  ? 'var(--color-status-error)'
+                  : updateForm.body.length >= UPDATE_BODY_WARN_THRESHOLD
+                    ? 'var(--color-status-warning, var(--color-status-error))'
+                    : 'var(--color-text-hint)',
+            }}
+          >
+            {UPDATE_BODY_MAX - updateForm.body.length} characters left
+          </div>
           {updatesError && (
             <div
               style={{


### PR DESCRIPTION
Closes #400

## Problem
Campaign update bodies had no server-side length limit. A creator (or attacker with a stolen creator token) could POST arbitrarily large updates via `POST /:id/updates` or `PATCH /:id/updates/:updateId` — unbounded DB writes and potential memory pressure in the markdown renderer. The express-validator chain (`createCampaignUpdateValidation`) existed but only checked non-empty, and the live routes bypassed it entirely.

## Fix (three layers)
**API validation**
- `POST /:id/updates` and `PATCH /:id/updates/:updateId` now return `422 { error: "Update body must be 5000 characters or fewer" }` when exceeded
- `createCampaignUpdateValidation` extended with `.isLength({ max: 5000 })`; shared `CAMPAIGN_UPDATE_BODY_MAX_LENGTH` constant exported so route + middleware can't drift

**Database (defence-in-depth)**
- Migration `20260824_campaign_update_body_length.sql`: `CHECK (char_length(body) <= 5000)`
- `schema.sql` CREATE TABLE updated in sync for fresh installs (same constraint name)

**Frontend**
- Character counter under the composer textarea: neutral → warning at 90% of budget (aria-live), red past the limit
- Submit blocked client-side with a message that includes the current length

## Testing
- POST update with 5001-char body → 422 with the error above; ≤5000 chars → created
- PATCH path enforces the same limit
- Counter turns amber at 4500 chars, red past 5000, submit blocked
- Migration applies cleanly on a database whose existing rows are all within the limit