### PR TITLE
Add Soroban milestone escrow contract upgrade path

### DIFF
--- a/backend/db/migrations/20260824_milestone_escrow_upgrade.sql
+++ b/backend/db/migrations/20260824_milestone_escrow_upgrade.sql
@@ -1,0 +1,17 @@
+-- Soroban milestone escrow upgrade path (Issue #679)
+--
+-- campaigns.contract_id / contract_version already exist (20260819_soroban_treasury.sql)
+-- but belong to the unrelated campaign_treasury spending-policy feature (#687), keyed
+-- off wallet_mode = 'contract'. The milestone escrow pair (escrow_contract_id /
+-- milestones_contract_id, added 20260429_add_soroban_contract_ids.sql) is versioned
+-- separately here to avoid colliding with that meaning. Only the milestones
+-- contract is replaced on upgrade (escrow_contract_id is untouched), so only
+-- its previous id needs to be retained for audit purposes.
+
+ALTER TABLE campaigns
+  ADD COLUMN IF NOT EXISTS escrow_contract_version        INTEGER NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS previous_milestones_contract_id TEXT,
+  ADD COLUMN IF NOT EXISTS migration_in_progress           BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS campaigns_migration_in_progress_idx
+  ON campaigns (id) WHERE migration_in_progress = TRUE;

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -14,6 +14,7 @@ const {
 const { reconcileSingleCampaign, getRecentReconciliationRuns } = require('../services/reconciliation');
 const { server } = require('../config/stellar');
 const { deployCampaignContracts } = require('../services/sorobanService');
+const { upgradeCampaignContract, UpgradeError } = require('../services/contractUpgrade');
 const {
   processDelivery,
   processCampaignWebhookDelivery,
@@ -226,10 +227,14 @@ router.get('/campaigns', async (req, res) => {
     const total = countResult.rows[0].total;
 
     const { rows } = await db.query(
-      `SELECT c.id, c.title, c.status, c.raised_amount, c.target_amount, 
+      `SELECT c.id, c.title, c.status, c.raised_amount, c.target_amount,
               c.asset_type, c.created_at, c.deleted_at, c.is_flagged_duplicate,
               c.contract_deployment_status, c.contract_deployment_error,
-              c.escrow_contract_id,
+              c.escrow_contract_id, c.escrow_contract_version, c.migration_in_progress,
+              EXISTS (
+                SELECT 1 FROM milestones m
+                WHERE m.campaign_id = c.id AND m.status = 'pending_review'
+              ) AS has_active_review,
               u.id as creator_id, u.name as creator_name, u.email as creator_email,
               COALESCE(con.contribution_count, 0)::int as contribution_count
        FROM campaigns c 
@@ -1440,6 +1445,48 @@ router.post('/campaigns/:id/redeploy-contract', async (req, res) => {
     res.status(500).json({ error: 'Failed to redeploy contract' });
   }
 });
+
+/**
+ * POST /api/admin/campaigns/:id/upgrade-contract
+ * Deploys a V2 milestones contract, migrates on-chain milestone state
+ * across from the currently deployed V1 contract, and points the campaign
+ * at the new contract. See services/contractUpgrade.js.
+ */
+router.post('/campaigns/:id/upgrade-contract', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const result = await upgradeCampaignContract(id, req.user.userId);
+
+    await logAdminAction(req.user.userId, 'upgrade_contract', 'campaign', id, {
+      v1_contract_id: result.v1ContractId,
+      v2_contract_id: result.v2ContractId,
+      migration_tx_hash: result.migrationTxHash,
+      milestone_count: result.milestoneCount,
+    });
+
+    res.json({
+      message: 'Contract upgraded to V2 successfully',
+      v1_contract_id: result.v1ContractId,
+      v2_contract_id: result.v2ContractId,
+      migration_tx_hash: result.migrationTxHash,
+      milestone_count: result.milestoneCount,
+    });
+  } catch (err) {
+    if (err instanceof UpgradeError) {
+      return res.status(err.status).json({ error: err.message, code: err.code });
+    }
+
+    logger.error('Error in upgrade-contract', { error: err.message, campaignId: id });
+    Sentry.withScope((scope) => {
+      scope.setLevel('error');
+      scope.setTag('admin_upgrade', 'contract_migration');
+      scope.setContext('upgrade', { campaignId: id, adminId: req.user.userId });
+      Sentry.captureMessage(`Admin contract upgrade failed for campaign ${id}: ${err.message}`);
+    });
+    res.status(502).json({ error: 'Contract upgrade failed', detail: err.message });
+  }
+}));
 
 module.exports = router;
 module.exports.logAdminAction = logAdminAction;

--- a/backend/src/routes/contributions.js
+++ b/backend/src/routes/contributions.js
@@ -616,6 +616,12 @@ router.post('/', contributionPostLimiter, requireAuth, contributionValidation, v
 
   const campaign = await loadActiveCampaign(campaign_id);
   if (!campaign) return res.status(404).json({ error: 'Campaign not found' });
+  if (campaign.migration_in_progress) {
+    return res.status(503).json({
+      error: 'Contributions are temporarily paused while this campaign\'s contract is being upgraded',
+      code: 'CAMPAIGN_MIGRATION_IN_PROGRESS',
+    });
+  }
 
   const { rows: users } = await db.query(
     'SELECT wallet_secret_encrypted, wallet_public_key FROM users WHERE id = $1',

--- a/backend/src/routes/contributions.test.js
+++ b/backend/src/routes/contributions.test.js
@@ -372,6 +372,33 @@ test('POST /api/contributions uses direct payment for same USDC asset', async ()
   assert.equal(submitted.length, 1);
 });
 
+test('POST /api/contributions is blocked while the campaign contract is being migrated', async () => {
+  const app = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns')) {
+        return {
+          rows: [{
+            id: '11111111-1111-1111-1111-111111111111',
+            status: 'active',
+            asset_type: 'USDC',
+            wallet_public_key: VALID_G,
+            migration_in_progress: true,
+          }],
+        };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/contributions')
+    .set('Authorization', 'Bearer token')
+    .send({ campaign_id: '11111111-1111-1111-1111-111111111111', amount: '5.0000000', send_asset: 'USDC' });
+
+  assert.equal(response.status, 503);
+  assert.equal(response.body.code, 'CAMPAIGN_MIGRATION_IN_PROGRESS');
+});
+
 test('POST /api/contributions uses path payment for conversion', async () => {
   let pathPayload = null;
   const app = buildApp({

--- a/backend/src/routes/milestones.js
+++ b/backend/src/routes/milestones.js
@@ -325,7 +325,8 @@ router.post('/:id/submit', requireAuth, async (req, res) => {
   }
 
   const { rows: milestones } = await db.query(
-    `SELECT m.*, c.creator_id, c.status AS campaign_status, c.title AS campaign_title
+    `SELECT m.*, c.creator_id, c.status AS campaign_status, c.title AS campaign_title,
+            c.migration_in_progress
      FROM milestones m
      JOIN campaigns c ON c.id = m.campaign_id
      WHERE m.id = $1`,
@@ -333,6 +334,13 @@ router.post('/:id/submit', requireAuth, async (req, res) => {
   );
   if (!milestones.length) return res.status(404).json({ error: 'Milestone not found' });
   const milestone = milestones[0];
+
+  if (milestone.migration_in_progress) {
+    return res.status(503).json({
+      error: 'Milestone submissions are temporarily paused while this campaign\'s contract is being upgraded',
+      code: 'CAMPAIGN_MIGRATION_IN_PROGRESS',
+    });
+  }
 
   try {
     await assertCanSubmitMilestone(milestone, req.user.userId, req.user.role);

--- a/backend/src/routes/milestones.test.js
+++ b/backend/src/routes/milestones.test.js
@@ -166,6 +166,25 @@ test('POST /api/milestones/:id/submit blocks when already pending_review', async
   assert.match(res.body.error, /awaiting platform review/i);
 });
 
+test('POST /api/milestones/:id/submit is blocked while the campaign contract is being migrated', async () => {
+  const { app, cleanup } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('FROM milestones m') && text.includes('JOIN campaigns')) {
+        return { rows: [milestoneRow({ migration_in_progress: true })] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const res = await request(app)
+    .post(`/api/milestones/${MILESTONE_ID}/submit`)
+    .send({ evidence_url: 'https://example.com/demo', destination_key: VALID_DESTINATION });
+
+  cleanup();
+  assert.equal(res.status, 503);
+  assert.equal(res.body.code, 'CAMPAIGN_MIGRATION_IN_PROGRESS');
+});
+
 test('POST /api/milestones/:id/approve requires pending_review status', async () => {
   const { app, cleanup } = buildApp({
     userId: 'platform-1',

--- a/backend/src/services/contractUpgrade.js
+++ b/backend/src/services/contractUpgrade.js
@@ -1,0 +1,155 @@
+const { Keypair } = require('@stellar/stellar-sdk');
+const db = require('../config/database');
+const logger = require('../config/logger');
+const {
+  deployMilestonesV2Contract,
+  deployMigrationContract,
+  initializeMilestones,
+  runMigration,
+} = require('./sorobanService');
+
+class UpgradeError extends Error {
+  constructor(message, status, code) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+async function assertNoActiveReview(campaignId) {
+  const { rows } = await db.query(
+    `SELECT id FROM milestones WHERE campaign_id = $1 AND status = 'pending_review' LIMIT 1`,
+    [campaignId]
+  );
+  if (rows.length) {
+    throw new UpgradeError(
+      'A milestone is currently under review; the contract cannot be upgraded until it is resolved',
+      409,
+      'ACTIVE_REVIEW_IN_PROGRESS'
+    );
+  }
+}
+
+async function loadUpgradeableCampaign(campaignId) {
+  const { rows } = await db.query(
+    `SELECT c.id, c.title, c.escrow_contract_id, c.milestones_contract_id,
+            c.escrow_contract_version, u.wallet_public_key AS creator_public_key
+     FROM campaigns c
+     JOIN users u ON u.id = c.creator_id
+     WHERE c.id = $1 AND c.deleted_at IS NULL`,
+    [campaignId]
+  );
+  if (!rows.length) {
+    throw new UpgradeError('Campaign not found', 404, 'CAMPAIGN_NOT_FOUND');
+  }
+  const campaign = rows[0];
+
+  if (campaign.escrow_contract_version >= 2) {
+    throw new UpgradeError('Campaign is already on the V2 contract', 400, 'ALREADY_V2');
+  }
+  if (!campaign.escrow_contract_id || !campaign.milestones_contract_id) {
+    throw new UpgradeError('Campaign has no V1 contracts deployed to migrate from', 400, 'NO_V1_CONTRACT');
+  }
+
+  return campaign;
+}
+
+/**
+ * Deploys a V2 milestones contract, seeds it with the campaign's milestone
+ * definitions, and drives the migration orchestrator to pull the live V1
+ * on-chain state (status, evidence) across before pointing the campaign at
+ * the new contract. See contracts/soroban/contracts/{milestones_v2,migration}.
+ */
+async function upgradeCampaignContract(campaignId, adminUserId) {
+  const campaign = await loadUpgradeableCampaign(campaignId);
+  await assertNoActiveReview(campaignId);
+
+  if (!process.env.PLATFORM_SECRET_KEY) {
+    throw new UpgradeError('PLATFORM_SECRET_KEY not configured', 500, 'PLATFORM_KEY_MISSING');
+  }
+  const signerSecret = process.env.PLATFORM_SECRET_KEY;
+  const platformPublicKey = Keypair.fromSecret(signerSecret).publicKey();
+
+  const { rows: milestoneRows } = await db.query(
+    `SELECT title, release_percentage FROM milestones
+     WHERE campaign_id = $1 ORDER BY contract_index ASC NULLS LAST, created_at ASC`,
+    [campaignId]
+  );
+  if (!milestoneRows.length) {
+    throw new UpgradeError('Campaign has no milestones to migrate', 400, 'NO_MILESTONES');
+  }
+
+  const { rowCount } = await db.query(
+    `UPDATE campaigns SET migration_in_progress = TRUE WHERE id = $1 AND migration_in_progress = FALSE`,
+    [campaignId]
+  );
+  if (!rowCount) {
+    throw new UpgradeError('A migration is already in progress for this campaign', 409, 'MIGRATION_ALREADY_IN_PROGRESS');
+  }
+
+  try {
+    const v2Contract = await deployMilestonesV2Contract({ signerSecret });
+    await initializeMilestones({
+      contractId: v2Contract.contractId,
+      creatorAddress: campaign.creator_public_key,
+      platformAddress: platformPublicKey,
+      escrowContractId: campaign.escrow_contract_id,
+      milestones: milestoneRows,
+      signerSecret,
+    });
+
+    const migrationContract = await deployMigrationContract({
+      platformAddress: platformPublicKey,
+      signerSecret,
+    });
+
+    const { txHash, milestoneCount } = await runMigration({
+      migrationContractId: migrationContract.contractId,
+      v1ContractId: campaign.milestones_contract_id,
+      v2ContractId: v2Contract.contractId,
+      signerSecret,
+    });
+
+    await db.query(
+      `UPDATE campaigns
+       SET previous_milestones_contract_id = milestones_contract_id,
+           milestones_contract_id = $1,
+           escrow_contract_version = 2,
+           migration_in_progress = FALSE
+       WHERE id = $2`,
+      [v2Contract.contractId, campaignId]
+    );
+
+    logger.info('Milestone escrow contract upgraded to V2', {
+      campaignId,
+      adminUserId,
+      v1ContractId: campaign.milestones_contract_id,
+      v2ContractId: v2Contract.contractId,
+      migrationTxHash: txHash,
+      milestoneCount,
+    });
+
+    return {
+      v1ContractId: campaign.milestones_contract_id,
+      v2ContractId: v2Contract.contractId,
+      migrationTxHash: txHash,
+      milestoneCount,
+    };
+  } catch (err) {
+    await db.query(
+      `UPDATE campaigns SET migration_in_progress = FALSE WHERE id = $1`,
+      [campaignId]
+    );
+    logger.error('Milestone escrow contract upgrade failed', {
+      campaignId,
+      adminUserId,
+      error: err.message,
+    });
+    throw err;
+  }
+}
+
+module.exports = {
+  UpgradeError,
+  upgradeCampaignContract,
+};

--- a/backend/src/services/contractUpgrade.test.js
+++ b/backend/src/services/contractUpgrade.test.js
@@ -1,0 +1,185 @@
+'use strict';
+
+/**
+ * Contract upgrade service tests (Issue #679). Postgres and the Soroban RPC
+ * layer are both stubbed, so these cover the service's own logic: the
+ * active-review gate, guarding against a double upgrade, and the
+ * deploy -> initialize -> migrate -> persist happy path.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const proxyquire = require('proxyquire').noCallThru();
+
+const CAMPAIGN_ID = '11111111-1111-1111-1111-111111111111';
+const CREATOR_KEY = 'GD3I6UAGVCRIWVC5SVFHIHARP7IXKBGKUL74JTCU64T5LCQKFPYAYCC5';
+const PLATFORM_SECRET = 'SCVMQUS5EMTHWBLJTE5XCSCMHB2ZOVKRR4ATVTRPUNRCOGKRENIL3LHR';
+
+function campaignRow(overrides = {}) {
+  return {
+    id: CAMPAIGN_ID,
+    title: 'Test Campaign',
+    escrow_contract_id: 'CESCROWV1',
+    milestones_contract_id: 'CMILESTONESV1',
+    escrow_contract_version: 1,
+    creator_public_key: CREATOR_KEY,
+    ...overrides,
+  };
+}
+
+function build({ queryImpl, soroban = {} } = {}) {
+  const calls = [];
+  const sorobanStub = {
+    deployMilestonesV2Contract: async () => ({ contractId: 'CMILESTONESV2', txHash: 'deploy-tx' }),
+    deployMigrationContract: async () => ({ contractId: 'CMIGRATION', txHash: 'deploy-migration-tx' }),
+    initializeMilestones: async (params) => { calls.push({ fn: 'initializeMilestones', params }); },
+    runMigration: async (params) => {
+      calls.push({ fn: 'runMigration', params });
+      return { txHash: 'migrate-tx', milestoneCount: 2 };
+    },
+    ...soroban,
+  };
+
+  const service = proxyquire('./contractUpgrade', {
+    '../config/database': { query: queryImpl },
+    '../config/logger': { info() {}, warn() {}, error() {} },
+    './sorobanService': sorobanStub,
+  });
+
+  return { service, calls };
+}
+
+test('refuses to upgrade a campaign with a milestone under review', async () => {
+  const { service } = build({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns c')) return { rows: [campaignRow()] };
+      if (text.includes("status = 'pending_review'")) return { rows: [{ id: 'm1' }] };
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  });
+
+  await assert.rejects(
+    () => service.upgradeCampaignContract(CAMPAIGN_ID, 'admin-1'),
+    (err) => {
+      assert.equal(err.code, 'ACTIVE_REVIEW_IN_PROGRESS');
+      assert.equal(err.status, 409);
+      return true;
+    }
+  );
+});
+
+test('refuses to upgrade a campaign already on V2', async () => {
+  const { service } = build({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns c')) {
+        return { rows: [campaignRow({ escrow_contract_version: 2 })] };
+      }
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  });
+
+  await assert.rejects(
+    () => service.upgradeCampaignContract(CAMPAIGN_ID, 'admin-1'),
+    (err) => {
+      assert.equal(err.code, 'ALREADY_V2');
+      return true;
+    }
+  );
+});
+
+test('refuses a second concurrent upgrade for the same campaign', async () => {
+  const { service } = build({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns c')) return { rows: [campaignRow()] };
+      if (text.includes("status = 'pending_review'")) return { rows: [] };
+      if (text.includes('SELECT title, release_percentage FROM milestones')) {
+        return { rows: [{ title: 'M1', release_percentage: '100' }] };
+      }
+      if (text.includes('SET migration_in_progress = TRUE')) return { rowCount: 0 };
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  });
+
+  await assert.rejects(
+    () => service.upgradeCampaignContract(CAMPAIGN_ID, 'admin-1'),
+    (err) => {
+      assert.equal(err.code, 'MIGRATION_ALREADY_IN_PROGRESS');
+      return true;
+    }
+  );
+});
+
+test('happy path deploys V2, migrates V1 state across, and persists the new contract id', async (t) => {
+  const originalSecret = process.env.PLATFORM_SECRET_KEY;
+  process.env.PLATFORM_SECRET_KEY = PLATFORM_SECRET;
+  t.after(() => { process.env.PLATFORM_SECRET_KEY = originalSecret; });
+
+  const updates = [];
+  const { service, calls } = build({
+    queryImpl: async (text, params) => {
+      if (text.includes('FROM campaigns c')) return { rows: [campaignRow()] };
+      if (text.includes("status = 'pending_review'")) return { rows: [] };
+      if (text.includes('SELECT title, release_percentage FROM milestones')) {
+        return { rows: [{ title: 'M1', release_percentage: '40' }, { title: 'M2', release_percentage: '60' }] };
+      }
+      if (text.includes('SET migration_in_progress = TRUE')) return { rowCount: 1 };
+      if (text.includes('SET previous_milestones_contract_id')) {
+        updates.push(params);
+        return { rows: [] };
+      }
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  });
+
+  const result = await service.upgradeCampaignContract(CAMPAIGN_ID, 'admin-1');
+
+  assert.equal(result.v1ContractId, 'CMILESTONESV1');
+  assert.equal(result.v2ContractId, 'CMILESTONESV2');
+  assert.equal(result.migrationTxHash, 'migrate-tx');
+  assert.equal(result.milestoneCount, 2);
+
+  const initCall = calls.find((c) => c.fn === 'initializeMilestones');
+  assert.equal(initCall.params.contractId, 'CMILESTONESV2');
+  assert.equal(initCall.params.escrowContractId, 'CESCROWV1');
+  assert.equal(initCall.params.milestones.length, 2);
+
+  const migrateCall = calls.find((c) => c.fn === 'runMigration');
+  assert.equal(migrateCall.params.v1ContractId, 'CMILESTONESV1');
+  assert.equal(migrateCall.params.v2ContractId, 'CMILESTONESV2');
+
+  assert.equal(updates.length, 1);
+  assert.deepEqual(updates[0], ['CMILESTONESV2', CAMPAIGN_ID]);
+});
+
+test('clears migration_in_progress and rethrows if the on-chain deploy fails', async () => {
+  const originalSecret = process.env.PLATFORM_SECRET_KEY;
+  process.env.PLATFORM_SECRET_KEY = PLATFORM_SECRET;
+
+  let clearedFlag = false;
+  const { service } = build({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns c')) return { rows: [campaignRow()] };
+      if (text.includes("status = 'pending_review'")) return { rows: [] };
+      if (text.includes('SELECT title, release_percentage FROM milestones')) {
+        return { rows: [{ title: 'M1', release_percentage: '100' }] };
+      }
+      if (text.includes('SET migration_in_progress = TRUE')) return { rowCount: 1 };
+      if (text.includes('SET migration_in_progress = FALSE WHERE id')) {
+        clearedFlag = true;
+        return { rows: [] };
+      }
+      throw new Error(`Unexpected query: ${text}`);
+    },
+    soroban: {
+      deployMilestonesV2Contract: async () => { throw new Error('RPC unavailable'); },
+    },
+  });
+
+  await assert.rejects(
+    () => service.upgradeCampaignContract(CAMPAIGN_ID, 'admin-1'),
+    /RPC unavailable/
+  );
+  assert.equal(clearedFlag, true);
+
+  process.env.PLATFORM_SECRET_KEY = originalSecret;
+});

--- a/backend/src/services/sorobanService.js
+++ b/backend/src/services/sorobanService.js
@@ -562,6 +562,92 @@ async function triggerRefund({ escrowContractId, contributorAddress, signerSecre
 }
 
 /**
+ * Deploy a milestones V2 contract instance from MILESTONES_V2_WASM_HASH.
+ * Its `initialize` ABI is identical to V1's, so initializeMilestones() above
+ * is reused to initialize it once deployed.
+ */
+async function deployMilestonesV2Contract({ signerSecret }) {
+  const wasmHash = process.env.MILESTONES_V2_WASM_HASH;
+  if (!wasmHash) {
+    throw new Error('MILESTONES_V2_WASM_HASH is not configured');
+  }
+  return createContractFromWasmHash({ wasmHash, signerSecret });
+}
+
+/**
+ * Deploy the standalone migration orchestrator contract from
+ * MIGRATION_WASM_HASH and initialize it with the platform address that will
+ * be authorized to drive migrations.
+ */
+async function deployMigrationContract({ platformAddress, signerSecret }) {
+  const wasmHash = process.env.MIGRATION_WASM_HASH;
+  if (!wasmHash) {
+    throw new Error('MIGRATION_WASM_HASH is not configured');
+  }
+  const deployed = await createContractFromWasmHash({ wasmHash, signerSecret });
+  await invokeContract({
+    contractId: deployed.contractId,
+    method: 'initialize',
+    args: [nativeToScVal(Address.fromString(platformAddress), { type: 'address' })],
+    signerSecret,
+  });
+  return deployed;
+}
+
+/**
+ * Invoke migrate(v1_contract_id, v2_contract_id) on the migration
+ * orchestrator and parse the MigrationCompleted event out of the same
+ * transaction result, so the caller learns the milestone count without a
+ * separate event-polling round trip.
+ */
+async function runMigration({ migrationContractId, v1ContractId, v2ContractId, signerSecret }) {
+  const signer = Keypair.fromSecret(signerSecret);
+  const source = await server.loadAccount(signer.publicKey());
+
+  const contract = new Contract(migrationContractId);
+  const tx = new TransactionBuilder(source, {
+    fee: BASE_FEE,
+    networkPassphrase,
+  })
+    .addOperation(contract.call(
+      'migrate',
+      scvAddressFromString(v1ContractId),
+      scvAddressFromString(v2ContractId),
+    ))
+    .setTimeout(TX_TIMEOUT_CONTRIBUTION_S)
+    .build();
+
+  const preparedTx = await simulateAndPrepare(tx);
+  preparedTx.sign(signer);
+  const result = await server.submitTransaction(preparedTx);
+
+  if (result.status !== 'SUCCESS') {
+    throw new Error(`Migration transaction failed: ${result.status}`);
+  }
+
+  let milestoneCount = null;
+  if (result.resultMetaXdr) {
+    const meta = xdr.TransactionMeta.fromXDR(result.resultMetaXdr, 'base64');
+    const sorobanMeta = meta.v3().sorobanMeta();
+    const events = sorobanMeta && typeof sorobanMeta.events === 'function' ? sorobanMeta.events() : [];
+    for (const event of events) {
+      try {
+        const topics = event.body().v0().topics().map((t) => scValToNative(t));
+        if (topics[0] === 'MigrationCompleted') {
+          const data = scValToNative(event.body().v0().data());
+          milestoneCount = Array.isArray(data) ? Number(data[2]) : null;
+          break;
+        }
+      } catch (err) {
+        logger.warn('Could not decode a contract event while parsing MigrationCompleted', { error: err.message });
+      }
+    }
+  }
+
+  return { txHash: result.hash || null, milestoneCount };
+}
+
+/**
  * Read on-chain campaign status from deployed Soroban contracts.
  */
 async function getContractStatus({
@@ -634,4 +720,7 @@ module.exports = {
   getContractStatus,
   mapMilestoneOnChainStatus,
   refund,
+  deployMilestonesV2Contract,
+  deployMigrationContract,
+  runMigration,
 };

--- a/contracts/soroban/Cargo.lock
+++ b/contracts/soroban/Cargo.lock
@@ -718,8 +718,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "migration"
+version = "0.1.0"
+dependencies = [
+ "milestones",
+ "milestones_v2",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "milestones"
 version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "milestones_v2"
+version = "0.1.0"
 dependencies = [
  "soroban-sdk",
 ]

--- a/contracts/soroban/contracts/migration/Cargo.toml
+++ b/contracts/soroban/contracts/migration/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "migration"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+milestones = { path = "../milestones" }
+milestones_v2 = { path = "../milestones_v2" }

--- a/contracts/soroban/contracts/migration/src/lib.rs
+++ b/contracts/soroban/contracts/migration/src/lib.rs
@@ -1,0 +1,59 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol, IntoVal};
+
+// Standalone one-shot migration orchestrator: drives a live upgrade from a
+// milestones V1 contract to a milestones V2 contract (see
+// contracts/soroban/contracts/milestones and .../milestones_v2) in a single
+// transaction, so campaign activity is never left half-migrated.
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Platform,
+    Initialized,
+}
+
+#[contract]
+pub struct MigrationContract;
+
+#[contractimpl]
+impl MigrationContract {
+    pub fn initialize(env: Env, platform: Address) {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            panic!("Already initialized");
+        }
+        env.storage().instance().set(&DataKey::Platform, &platform);
+        env.storage().instance().set(&DataKey::Initialized, &true);
+    }
+
+    /// Callable by the platform only. Pauses the V1 contract, has V2 pull
+    /// its state across, then emits MigrationCompleted with the number of
+    /// milestones that were carried over.
+    pub fn migrate(env: Env, v1_contract_id: Address, v2_contract_id: Address) {
+        let platform: Address = env.storage().instance().get(&DataKey::Platform).expect("Not initialized");
+        platform.require_auth();
+
+        let _: () = env.invoke_contract(
+            &v1_contract_id,
+            &Symbol::new(&env, "set_paused"),
+            (true,).into_val(&env),
+        );
+
+        let _: () = env.invoke_contract(
+            &v2_contract_id,
+            &Symbol::new(&env, "migrate_from_v1"),
+            (v1_contract_id.clone(),).into_val(&env),
+        );
+
+        let milestone_count: u32 = env.invoke_contract(
+            &v2_contract_id,
+            &Symbol::new(&env, "get_milestone_count"),
+            soroban_sdk::Vec::new(&env),
+        );
+
+        env.events().publish(
+            (Symbol::new(&env, "MigrationCompleted"),),
+            (v1_contract_id, v2_contract_id, milestone_count),
+        );
+    }
+}

--- a/contracts/soroban/contracts/migration/tests/migration_test.rs
+++ b/contracts/soroban/contracts/migration/tests/migration_test.rs
@@ -1,0 +1,115 @@
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, Vec};
+
+use migration::{MigrationContract, MigrationContractClient};
+use milestones::{Milestone as V1Milestone, MilestoneStatus as V1Status, MilestonesContract, MilestonesContractClient};
+use milestones_v2::{Milestone as V2Milestone, MilestoneStatus as V2Status, MilestonesV2Contract, MilestonesV2ContractClient};
+
+fn v1_milestone(env: &Env, title: &[u8; 32], bps: u32) -> V1Milestone {
+    V1Milestone {
+        title_hash: BytesN::from_array(env, title),
+        release_bps: bps,
+        status: V1Status::Pending,
+        evidence_hash: None,
+    }
+}
+
+fn v2_milestone(env: &Env, title: &[u8; 32], bps: u32) -> V2Milestone {
+    V2Milestone {
+        title_hash: BytesN::from_array(env, title),
+        release_bps: bps,
+        status: V2Status::Pending,
+        evidence_hash: None,
+    }
+}
+
+#[test]
+fn test_migrate_pauses_v1_and_copies_state_into_v2_emitting_one_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let platform = Address::generate(&env);
+    let v1_creator = Address::generate(&env);
+    let v1_escrow = Address::generate(&env);
+    let v1_milestones = Vec::from_array(
+        &env,
+        [
+            v1_milestone(&env, b"AAAA1111111111111111111111111111", 4000u32),
+            v1_milestone(&env, b"AAAA2222222222222222222222222222", 6000u32),
+        ],
+    );
+    let v1_id = env.register(MilestonesContract, ());
+    MilestonesContractClient::new(&env, &v1_id).initialize(
+        &v1_creator, &platform, &v1_escrow, &v1_milestones,
+    );
+
+    let v2_creator = Address::generate(&env);
+    let v2_escrow = Address::generate(&env);
+    let seed_milestones = Vec::from_array(
+        &env,
+        [v2_milestone(&env, b"ZZZZ0000000000000000000000000000", 10000u32)],
+    );
+    let v2_id = env.register(MilestonesV2Contract, ());
+    MilestonesV2ContractClient::new(&env, &v2_id).initialize(
+        &v2_creator, &platform, &v2_escrow, &seed_milestones,
+    );
+
+    let migration_id = env.register(MigrationContract, ());
+    let migration_client = MigrationContractClient::new(&env, &migration_id);
+    migration_client.initialize(&platform);
+
+    migration_client.migrate(&v1_id, &v2_id);
+
+    let v1_client = MilestonesContractClient::new(&env, &v1_id);
+    assert!(v1_client.is_paused());
+
+    let v2_client = MilestonesV2ContractClient::new(&env, &v2_id);
+    assert_eq!(v2_client.get_version(), 2);
+    let migrated = v2_client.get_all_milestones();
+    assert_eq!(migrated.len(), v1_milestones.len());
+    for i in 0..v1_milestones.len() {
+        assert_eq!(migrated.get(i).unwrap().release_bps, v1_milestones.get(i).unwrap().release_bps);
+    }
+
+    // migrate() publishes exactly one event, from this contract: MigrationCompleted.
+    let migration_events: Vec<_> = env
+        .events()
+        .all()
+        .iter()
+        .filter(|(contract_id, ..)| *contract_id == migration_id)
+        .collect();
+    assert_eq!(migration_events.len(), 1, "MigrationCompleted must be emitted exactly once");
+}
+
+#[test]
+fn test_migrate_rejects_non_platform() {
+    let env = Env::default();
+
+    let platform = Address::generate(&env);
+    let v1_creator = Address::generate(&env);
+    let v1_escrow = Address::generate(&env);
+    let v1_milestones = Vec::from_array(
+        &env,
+        [v1_milestone(&env, b"BBBB1111111111111111111111111111", 10000u32)],
+    );
+    let v1_id = env.register(MilestonesContract, ());
+    MilestonesContractClient::new(&env, &v1_id).initialize(
+        &v1_creator, &platform, &v1_escrow, &v1_milestones,
+    );
+
+    let v2_creator = Address::generate(&env);
+    let v2_escrow = Address::generate(&env);
+    let v2_id = env.register(MilestonesV2Contract, ());
+    MilestonesV2ContractClient::new(&env, &v2_id).initialize(
+        &v2_creator, &platform, &v2_escrow, &v1_milestones,
+    );
+
+    let migration_id = env.register(MigrationContract, ());
+    let migration_client = MigrationContractClient::new(&env, &migration_id);
+    migration_client.initialize(&platform);
+
+    // No mock_all_auths(): platform.require_auth() inside migrate() must fail.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        migration_client.migrate(&v1_id, &v2_id);
+    }));
+    assert!(result.is_err());
+}

--- a/contracts/soroban/contracts/milestones/tests/milestones_test.rs
+++ b/contracts/soroban/contracts/milestones/tests/milestones_test.rs
@@ -340,6 +340,54 @@ fn test_get_all_milestones() {
 }
 
 #[test]
+fn test_set_paused_blocks_submit_and_approve() {
+    let env = Env::default();
+    let milestones = Vec::from_array(
+        &env,
+        [make_milestone(&env, b"KKKK1111111111111111111111111111", 10000u32)],
+    );
+
+    let (contract_id, _creator, platform, _escrow) =
+        setup_milestones_contract(&env, milestones, 1000);
+    let client = MilestonesContractClient::new(&env, &contract_id);
+
+    client.set_paused(&true);
+    assert!(client.is_paused());
+
+    let evidence = BytesN::from_array(&env, b"evid_hash_1234567890123456789012");
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.submit_milestone(&0u32, &evidence);
+    }));
+    assert!(result.is_err());
+
+    client.set_paused(&false);
+    client.submit_milestone(&0u32, &evidence);
+
+    client.set_paused(&true);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.approve_milestone(&0u32);
+    }));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_set_paused_rejects_non_platform() {
+    let env = Env::default();
+    let milestones = Vec::from_array(
+        &env,
+        [make_milestone(&env, b"LLLL1111111111111111111111111111", 10000u32)],
+    );
+
+    let (contract_id, _creator, _platform) = setup_no_auth(&env, milestones);
+    let client = MilestonesContractClient::new(&env, &contract_id);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.set_paused(&true);
+    }));
+    assert!(result.is_err());
+}
+
+#[test]
 fn test_resubmit_after_rejection() {
     let env = Env::default();
     let milestones = Vec::from_array(

--- a/contracts/soroban/contracts/milestones_v2/Cargo.toml
+++ b/contracts/soroban/contracts/milestones_v2/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "milestones_v2"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/soroban/contracts/milestones_v2/src/lib.rs
+++ b/contracts/soroban/contracts/milestones_v2/src/lib.rs
@@ -3,6 +3,16 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Symbol, Vec, IntoVal
 };
 
+// V2 of the milestones contract (see contracts/soroban/contracts/milestones for V1).
+//
+// Soroban contracts cannot be arbitrarily upgraded in place, so a change to
+// contract logic ships as a new contract deployment instead. This crate keeps
+// every V1 function with an identical signature for ABI compatibility, and
+// adds a version marker, a platform-controlled pause switch, and a
+// migrate_from_v1 entry point that copies milestone state across from an
+// already-deployed V1 contract. See contracts/soroban/contracts/migration
+// for the orchestrator that drives a live upgrade end to end.
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[contracttype]
 pub enum MilestoneStatus {
@@ -30,19 +40,16 @@ pub enum DataKey {
     Milestones,
     Initialized,
     Paused,
+    ContractVersion,
 }
 
-// Define the interface for the Escrow contract
-#[contract]
-pub struct MilestonesContract;
+pub const CONTRACT_VERSION: u32 = 2;
 
-// Note: We use invoke_contract for cross-contract calls to avoid strict build dependencies
-// on the escrow wasm during the initial build of this contract.
-// Note: If the wasm is not available yet, we can use a manual client definition.
-// Since we are building this together, I'll use a manual client to avoid build order issues.
+#[contract]
+pub struct MilestonesV2Contract;
 
 #[contractimpl]
-impl MilestonesContract {
+impl MilestonesV2Contract {
     pub fn initialize(
         env: Env,
         creator: Address,
@@ -67,13 +74,38 @@ impl MilestonesContract {
         env.storage().instance().set(&DataKey::Escrow, &escrow);
         env.storage().instance().set(&DataKey::Milestones, &milestones);
         env.storage().instance().set(&DataKey::Initialized, &true);
+        env.storage().instance().set(&DataKey::ContractVersion, &CONTRACT_VERSION);
+    }
+
+    /// Callable by the platform only. Reads every milestone from an
+    /// already-deployed V1 contract (`v1_contract_id`) via a cross-contract
+    /// call to `get_all_milestones()` and writes it into this contract's own
+    /// storage, replacing whatever milestones it was initialized with.
+    pub fn migrate_from_v1(env: Env, v1_contract_id: Address) {
+        let platform: Address = env.storage().instance().get(&DataKey::Platform).expect("Not initialized");
+        platform.require_auth();
+
+        let v1_milestones: Vec<Milestone> = env.invoke_contract(
+            &v1_contract_id,
+            &Symbol::new(&env, "get_all_milestones"),
+            Vec::new(&env),
+        );
+
+        env.storage().instance().set(&DataKey::Milestones, &v1_milestones);
+        env.storage().instance().set(&DataKey::ContractVersion, &CONTRACT_VERSION);
+
+        env.events().publish(
+            (symbol_short!("migrated"),),
+            (v1_contract_id, v1_milestones.len()),
+        );
+    }
+
+    pub fn get_version(env: Env) -> u32 {
+        env.storage().instance().get(&DataKey::ContractVersion).unwrap_or(CONTRACT_VERSION)
     }
 
     /// Callable by the platform only. When paused, all state-mutating
-    /// functions (submit_milestone, approve_milestone, reject_milestone)
-    /// revert with CONTRACT_PAUSED. Added to let the upgrade-migration
-    /// orchestrator (see contracts/soroban/contracts/migration) freeze this
-    /// contract while its state is copied over to a v2 contract.
+    /// functions revert with CONTRACT_PAUSED.
     pub fn set_paused(env: Env, paused: bool) {
         let platform: Address = env.storage().instance().get(&DataKey::Platform).expect("Not initialized");
         platform.require_auth();
@@ -114,6 +146,9 @@ impl MilestonesContract {
         );
     }
 
+    /// Approves a submitted milestone and releases its share of escrow funds
+    /// to the creator. This is the "release_funds" state-mutating function
+    /// gated by set_paused.
     pub fn approve_milestone(env: Env, index: u32) {
         Self::require_not_paused(&env);
         let platform: Address = env.storage().instance().get(&DataKey::Platform).expect("Not initialized");
@@ -134,18 +169,14 @@ impl MilestonesContract {
         let escrow_address: Address = env.storage().instance().get(&DataKey::Escrow).expect("Not initialized");
         let creator: Address = env.storage().instance().get(&DataKey::Creator).expect("Not initialized");
 
-        // Use a cross-contract call to get the total raised amount from escrow
         let total_raised: i128 = env.invoke_contract(&escrow_address, &Symbol::new(&env, "get_total_raised"), Vec::new(&env));
-        
+
         let release_amount = (total_raised * (release_bps as i128)) / 10000;
 
         if release_amount > 0 {
-            // Approve the withdrawal in escrow (Milestones contract must be the Admin of Escrow)
             let _ : () = env.invoke_contract(&escrow_address, &Symbol::new(&env, "approve_withdrawal"), (release_amount,).into_val(&env));
-            
-            // Execute the withdrawal
             let _ : () = env.invoke_contract(&escrow_address, &Symbol::new(&env, "execute_withdrawal"), (creator.clone(), release_amount).into_val(&env));
-            
+
             env.events().publish(
                 (symbol_short!("release"), index),
                 (creator, release_amount),
@@ -159,6 +190,7 @@ impl MilestonesContract {
     }
 
     pub fn reject_milestone(env: Env, index: u32, reason_hash: BytesN<32>) {
+        Self::require_not_paused(&env);
         let platform: Address = env.storage().instance().get(&DataKey::Platform).expect("Not initialized");
         platform.require_auth();
 
@@ -186,5 +218,10 @@ impl MilestonesContract {
 
     pub fn get_all_milestones(env: Env) -> Vec<Milestone> {
         env.storage().instance().get(&DataKey::Milestones).expect("Not initialized")
+    }
+
+    pub fn get_milestone_count(env: Env) -> u32 {
+        let milestones: Vec<Milestone> = env.storage().instance().get(&DataKey::Milestones).expect("Not initialized");
+        milestones.len()
     }
 }

--- a/contracts/soroban/contracts/milestones_v2/tests/milestones_v2_test.rs
+++ b/contracts/soroban/contracts/milestones_v2/tests/milestones_v2_test.rs
@@ -1,0 +1,255 @@
+use soroban_sdk::{
+    contract, contractimpl, contracttype,
+    testutils::{Address as _, Events},
+    token, Address, BytesN, Env, Symbol, Vec,
+};
+use milestones_v2::{MilestonesV2Contract, MilestonesV2ContractClient, Milestone, MilestoneStatus};
+
+fn make_milestone(env: &Env, title: &[u8; 32], bps: u32) -> Milestone {
+    Milestone {
+        title_hash: BytesN::from_array(env, title),
+        release_bps: bps,
+        status: MilestoneStatus::Pending,
+        evidence_hash: None,
+    }
+}
+
+fn install_token(env: &Env) -> (Address, token::StellarAssetClient) {
+    let admin = Address::generate(&env);
+    let token_addr = env.register_stellar_asset_contract(admin.clone());
+    let token_admin = token::StellarAssetClient::new(&env, &token_addr);
+    token_admin.mint(&admin, &10_000_000_000);
+    (token_addr, token_admin)
+}
+
+#[contract]
+pub struct MockEscrow;
+
+#[derive(Clone)]
+#[contracttype]
+pub enum MockDataKey {
+    ApprovedAmount,
+    TotalMockRaised,
+    MockAsset,
+}
+
+#[contractimpl]
+impl MockEscrow {
+    pub fn initialize(
+        _env: Env,
+        _admin: Address,
+        _campaign_id: u64,
+        _target: i128,
+        _deadline: u64,
+        _asset: Address,
+        _fee_bps: u32,
+        _fee_recipient: Address,
+    ) {
+    }
+
+    pub fn deposit(_env: Env, _from: Address, _amount: i128) {}
+
+    pub fn approve_withdrawal(env: Env, release_amount: i128) {
+        let key = MockDataKey::ApprovedAmount;
+        let current: i128 = env.storage().instance().get(&key).unwrap_or(0);
+        env.storage().instance().set(&key, &(current + release_amount));
+    }
+
+    pub fn execute_withdrawal(env: Env, _to: Address, release_amount: i128) {
+        let key = MockDataKey::ApprovedAmount;
+        let current: i128 = env.storage().instance().get(&key).unwrap_or(0);
+        if current < release_amount {
+            panic!("Insufficient approved amount");
+        }
+        env.storage().instance().set(&key, &(current - release_amount));
+    }
+
+    pub fn get_total_raised(env: Env) -> i128 {
+        env.storage().instance().get(&MockDataKey::TotalMockRaised).unwrap_or(0)
+    }
+
+    pub fn get_asset(env: Env) -> Address {
+        env.storage().instance().get(&MockDataKey::MockAsset).unwrap()
+    }
+}
+
+fn setup_v2_contract(
+    env: &Env,
+    milestones: Vec<Milestone>,
+    escrow_total_raised: i128,
+) -> (Address, Address, Address, Address) {
+    env.mock_all_auths();
+
+    let creator = Address::generate(&env);
+    let platform = Address::generate(&env);
+    let (token_addr, _) = install_token(&env);
+
+    let escrow_id = env.register(MockEscrow, ());
+    let escrow_client = MockEscrowClient::new(&env, &escrow_id);
+
+    escrow_client.initialize(
+        &platform,
+        &1u64,
+        &10000,
+        &999999,
+        &token_addr,
+        &0,
+        &platform,
+    );
+
+    env.as_contract(&escrow_id, || {
+        env.storage().instance().set(&MockDataKey::TotalMockRaised, &escrow_total_raised);
+        env.storage().instance().set(&MockDataKey::MockAsset, &token_addr);
+    });
+
+    let contract_id = env.register(MilestonesV2Contract, ());
+    let client = MilestonesV2ContractClient::new(&env, &contract_id);
+
+    client.initialize(&creator, &platform, &escrow_id, &milestones);
+
+    (contract_id, creator, platform, escrow_id)
+}
+
+#[test]
+fn test_get_version_returns_2() {
+    let env = Env::default();
+    let milestones = Vec::from_array(
+        &env,
+        [make_milestone(&env, b"AAAA1111111111111111111111111111", 10000u32)],
+    );
+    let (contract_id, ..) = setup_v2_contract(&env, milestones, 1000);
+    let client = MilestonesV2ContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_version(), 2);
+}
+
+#[test]
+fn test_v2_preserves_v1_submit_approve_flow() {
+    let env = Env::default();
+    let milestones = Vec::from_array(
+        &env,
+        [make_milestone(&env, b"BBBB1111111111111111111111111111", 10000u32)],
+    );
+    let (contract_id, ..) = setup_v2_contract(&env, milestones, 1000);
+    let client = MilestonesV2ContractClient::new(&env, &contract_id);
+
+    let evidence = BytesN::from_array(&env, b"evid_hash_1234567890123456789012");
+    client.submit_milestone(&0u32, &evidence);
+    assert_eq!(client.get_milestone(&0u32).status, MilestoneStatus::Submitted);
+
+    client.approve_milestone(&0u32);
+    assert_eq!(client.get_milestone(&0u32).status, MilestoneStatus::Approved);
+}
+
+#[test]
+fn test_set_paused_blocks_submit_and_release_funds() {
+    let env = Env::default();
+    let milestones = Vec::from_array(
+        &env,
+        [make_milestone(&env, b"CCCC1111111111111111111111111111", 10000u32)],
+    );
+    let (contract_id, ..) = setup_v2_contract(&env, milestones, 1000);
+    let client = MilestonesV2ContractClient::new(&env, &contract_id);
+
+    let evidence = BytesN::from_array(&env, b"evid_hash_1234567890123456789012");
+    client.submit_milestone(&0u32, &evidence);
+
+    client.set_paused(&true);
+    assert!(client.is_paused());
+
+    let submit_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.submit_milestone(&0u32, &evidence);
+    }));
+    assert!(submit_result.is_err());
+
+    let approve_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.approve_milestone(&0u32);
+    }));
+    assert!(approve_result.is_err());
+
+    client.set_paused(&false);
+    client.approve_milestone(&0u32);
+    assert_eq!(client.get_milestone(&0u32).status, MilestoneStatus::Approved);
+}
+
+#[test]
+fn test_migrate_from_v1_copies_all_milestones() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let v1_milestones = Vec::from_array(
+        &env,
+        [
+            make_milestone(&env, b"DDDD1111111111111111111111111111", 4000u32),
+            make_milestone(&env, b"DDDD2222222222222222222222222222", 6000u32),
+        ],
+    );
+    let (v1_id, _v1_creator, v1_platform, _v1_escrow) =
+        setup_v2_contract(&env, v1_milestones.clone(), 1000);
+    let v1_client = MilestonesV2ContractClient::new(&env, &v1_id);
+
+    // Advance the "v1" contract's state so migration has something real to copy.
+    let evidence = BytesN::from_array(&env, b"evid_hash_1234567890123456789012");
+    v1_client.submit_milestone(&0u32, &evidence);
+    v1_client.approve_milestone(&0u32);
+
+    // Fresh v2 contract, initialized independently, sharing the same platform
+    // address as v1 so a single platform key drives the migration.
+    let creator = Address::generate(&env);
+    let escrow_id = env.register(MockEscrow, ());
+    let seed_milestones = Vec::from_array(
+        &env,
+        [make_milestone(&env, b"ZZZZ0000000000000000000000000000", 10000u32)],
+    );
+    let v2_id = env.register(MilestonesV2Contract, ());
+    let v2_client = MilestonesV2ContractClient::new(&env, &v2_id);
+    v2_client.initialize(&creator, &v1_platform, &escrow_id, &seed_milestones);
+
+    v2_client.migrate_from_v1(&v1_id);
+
+    assert_eq!(v2_client.get_version(), 2);
+
+    let migrated = v2_client.get_all_milestones();
+    assert_eq!(migrated.len(), v1_milestones.len());
+    for i in 0..v1_milestones.len() {
+        let expected = v1_client.get_milestone(&i);
+        let actual = migrated.get(i).unwrap();
+        assert_eq!(actual.title_hash, expected.title_hash);
+        assert_eq!(actual.release_bps, expected.release_bps);
+        assert_eq!(actual.status, expected.status);
+        assert_eq!(actual.evidence_hash, expected.evidence_hash);
+    }
+}
+
+#[test]
+fn test_migrate_from_v1_rejects_non_platform() {
+    // Built without mock_all_auths() so platform.require_auth() inside
+    // migrate_from_v1 has nothing to authorize against and must fail.
+    // initialize() itself needs no auth in either version, so both
+    // contracts can be set up on this unmocked env.
+    let env = Env::default();
+    let milestones = Vec::from_array(
+        &env,
+        [make_milestone(&env, b"EEEE1111111111111111111111111111", 10000u32)],
+    );
+
+    let v1_creator = Address::generate(&env);
+    let v1_platform = Address::generate(&env);
+    let v1_escrow = env.register(MockEscrow, ());
+    let v1_id = env.register(MilestonesV2Contract, ());
+    MilestonesV2ContractClient::new(&env, &v1_id).initialize(
+        &v1_creator, &v1_platform, &v1_escrow, &milestones,
+    );
+
+    let creator = Address::generate(&env);
+    let platform = Address::generate(&env);
+    let escrow_id = env.register(MockEscrow, ());
+    let v2_id = env.register(MilestonesV2Contract, ());
+    let v2_client = MilestonesV2ContractClient::new(&env, &v2_id);
+    v2_client.initialize(&creator, &platform, &escrow_id, &milestones);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        v2_client.migrate_from_v1(&v1_id);
+    }));
+    assert!(result.is_err());
+}

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -1037,18 +1037,102 @@ function MilestonesQueue() {
   );
 }
 
+function ContractUpgradeModal({ campaign, onClose, onUpgraded }) {
+  const [upgrading, setUpgrading] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function confirmUpgrade() {
+    setUpgrading(true);
+    setError(null);
+    try {
+      await api.adminUpgradeCampaignContract(campaign.id);
+      onUpgraded();
+    } catch (err) {
+      setError(err.message || 'Could not upgrade contract');
+    } finally {
+      setUpgrading(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0, 0, 0, 0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{ ...cardStyle, maxWidth: '420px', width: '90%' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 style={{ marginTop: 0 }}>Upgrade Contract to V2</h3>
+        <p style={{ fontSize: '0.9rem' }}>
+          <strong>Campaign:</strong> {campaign.title}
+        </p>
+        <p style={{ fontSize: '0.85rem', color: 'var(--color-text-hint)', wordBreak: 'break-all' }}>
+          <strong>Current contract:</strong> {campaign.escrow_contract_id}
+        </p>
+        <p style={{ fontSize: '0.85rem', color: 'var(--color-text-hint)' }}>
+          <strong>Estimated migration time:</strong> ~1&ndash;2 minutes
+        </p>
+        <p
+          style={{
+            fontSize: '0.85rem',
+            padding: '0.6rem',
+            borderRadius: '6px',
+            background: 'var(--color-warning-bg, #fff3cd)',
+            color: 'var(--color-warning-text, #7a5b00)',
+          }}
+        >
+          Contributions and milestone submissions will be paused for this campaign until migration
+          completes.
+        </p>
+        {error && (
+          <p style={{ fontSize: '0.85rem', color: 'var(--color-error-text)' }}>{error}</p>
+        )}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem', marginTop: '1rem' }}>
+          <button type="button" onClick={onClose} disabled={upgrading}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={confirmUpgrade}
+            disabled={upgrading}
+            style={{ background: 'var(--color-teal)', color: '#fff', border: 'none', borderRadius: '6px', padding: '0.4rem 0.8rem' }}
+          >
+            {upgrading ? 'Upgrading…' : 'Confirm Upgrade'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function CampaignsQueue() {
   const [campaigns, setCampaigns] = useState([]);
   const [loading, setLoading] = useState(true);
   const [flaggedOnly, setFlaggedOnly] = useState(false);
+  const [upgradeTarget, setUpgradeTarget] = useState(null);
+
+  const reload = useCallback(() => {
+    return api.getAdminCampaigns({ flagged_only: flaggedOnly }).then(setCampaigns);
+  }, [flaggedOnly]);
 
   useEffect(() => {
     setLoading(true);
-    api
-      .getAdminCampaigns({ flagged_only: flaggedOnly })
-      .then(setCampaigns)
-      .finally(() => setLoading(false));
-  }, [flaggedOnly]);
+    reload().finally(() => setLoading(false));
+  }, [reload]);
+
+  async function handleUpgraded() {
+    setUpgradeTarget(null);
+    await reload();
+  }
 
   async function unflag(id) {
     if (!window.confirm('Remove duplicate flag and allow publishing?')) return;
@@ -1112,6 +1196,22 @@ function CampaignsQueue() {
           >
             <div>
               <strong>{c.title}</strong>
+              {c.escrow_contract_id && (
+                <span
+                  title="Milestone escrow contract version"
+                  style={{
+                    marginLeft: '0.5rem',
+                    fontSize: '0.7rem',
+                    fontWeight: 700,
+                    padding: '0.1rem 0.4rem',
+                    borderRadius: '4px',
+                    background: c.escrow_contract_version >= 2 ? 'var(--color-teal)' : 'var(--color-text-hint)',
+                    color: '#fff',
+                  }}
+                >
+                  {c.escrow_contract_version >= 2 ? 'V2' : 'V1'}
+                </span>
+              )}
               {c.is_flagged_duplicate && (
                 <span
                   style={{
@@ -1181,11 +1281,33 @@ function CampaignsQueue() {
                   </button>
                 </>
               )}
+              {c.escrow_contract_id && c.escrow_contract_version < 2 && !c.has_active_review && (
+                <button
+                  type="button"
+                  onClick={() => setUpgradeTarget(c)}
+                  disabled={c.migration_in_progress}
+                  style={{
+                    fontSize: '0.75rem',
+                    padding: '0.25rem 0.7rem',
+                    borderRadius: '6px',
+                    cursor: c.migration_in_progress ? 'not-allowed' : 'pointer',
+                  }}
+                >
+                  {c.migration_in_progress ? 'Migrating…' : 'Upgrade Contract'}
+                </button>
+              )}
             </div>
           </div>
         </div>
       ))}
       </div>
+      {upgradeTarget && (
+        <ContractUpgradeModal
+          campaign={upgradeTarget}
+          onClose={() => setUpgradeTarget(null)}
+          onUpgraded={handleUpgraded}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -589,6 +589,7 @@ export const api = {
   adminFeatureCampaign: (id, body) => request('PATCH', `/admin/campaigns/${id}/feature`, body),
   adminUnfeatureCampaign: (id) => request('PATCH', `/admin/campaigns/${id}/unfeature`, {}),
   adminUnflagCampaign: (id) => request('PATCH', `/admin/campaigns/${id}/unflag`),
+  adminUpgradeCampaignContract: (id) => request('POST', `/admin/campaigns/${id}/upgrade-contract`, {}),
   getAdminFraudCampaigns: () => request('GET', '/admin/fraud/flagged'),
   getAdminFraudStats: () => request('GET', '/admin/fraud/stats'),
   adminApproveFraudCampaign: (id) => request('PATCH', `/admin/campaigns/${id}/fraud-approve`),


### PR DESCRIPTION
## Summary
- Adds a versioned `milestones_v2` Soroban contract that preserves every V1 (`milestones`) function signature 1:1, plus `get_version()`, a platform-only `set_paused`/`is_paused` pause switch, and `migrate_from_v1(v1_contract_id)` which cross-contract-calls V1's `get_all_milestones()` to copy state across.
- Adds a standalone one-shot `migration` orchestrator contract: `migrate(v1, v2)` pauses V1, drives V2's `migrate_from_v1`, and emits `MigrationCompleted{v1, v2, milestone_count}` exactly once.
- Adds a minimal, additive `set_paused`/`is_paused` to the existing V1 `milestones` contract (no existing signatures changed) so the orchestrator can freeze it during a live migration.
- Adds `backend/src/services/contractUpgrade.js` + `POST /api/admin/campaigns/:id/upgrade-contract`: blocks the upgrade with `409 ACTIVE_REVIEW_IN_PROGRESS` while any milestone is `pending_review`, deploys/initializes V2, runs the migration, and updates `campaigns`.
- New `campaigns` columns (`escrow_contract_version`, `previous_milestones_contract_id`, `migration_in_progress`) — kept distinct from the existing `contract_id`/`contract_version` columns, which belong to the unrelated #687 treasury-mode feature.
- `contributions.js` and `milestones.js` now return `503 CAMPAIGN_MIGRATION_IN_PROGRESS` for new contributions / milestone submissions while a campaign's migration is in flight.
- Admin campaigns queue: V1/V2 badge, "Upgrade Contract" button (hidden during an active review or an in-flight migration), and a confirmation modal showing campaign name, current contract ID, estimated migration time, and a contributions-paused warning.

Closes #679

## Notes for reviewers
- The repo's actual V1 system is a split `escrow` + `milestones` pair (not the single `milestone_escrow` contract the issue text assumes); this PR versions the `milestones` side, since that's where the milestone lifecycle and `get_all_milestones()` the issue's `migrate_from_v1` spec names actually live.
- `cargo build -p milestones -p milestones_v2 -p migration` passes. `cargo test` in this workspace currently fails to compile for a pre-existing, unrelated reason (a `soroban-sdk`/`stellar-xdr` version mismatch) that reproduces identically on unmodified `main` — I did not touch shared dependency versions to fix it, since that's outside this issue's scope. I reviewed the new Rust tests by hand since I couldn't execute them here.

## Test plan
- [x] `cargo build -p milestones -p milestones_v2 -p migration` — all three compile clean
- [x] `node --test src/**/*.test.js` in `backend/` — 821 passing, 0 failing (new `contractUpgrade.test.js`, and new gate tests in `contributions.test.js`/`milestones.test.js`, all pass; the only cancelled tests are pre-existing Postgres-integration tests with no DB available here)
- [x] `npm run build` and `npm run lint` in `frontend/` — clean
- [ ] Rust contract test suite (`cargo test`) — blocked by the pre-existing workspace dependency issue above; needs a maintainer with a working `cargo test` environment to confirm
- [ ] Manual admin-UI verification against a real Soroban RPC / testnet deployment