### PR TITLE
feat: sign treasury withdrawal requests with creator authorization (closes #709)

### DIFF
--- a/backend/src/routes/treasury.js
+++ b/backend/src/routes/treasury.js
@@ -165,6 +165,7 @@ router.get(
  *       200: { description: "{ type: immediate | pending_auditor }" }
  *       403: { description: Not the campaign creator }
  *       422: { description: "A policy constraint rejected it: HOLD_PERIOD_NOT_ELAPSED, EXCEEDS_MAX_WITHDRAWAL_PCT, COOLDOWN_NOT_ELAPSED, INSUFFICIENT_BALANCE, TREASURY_PAUSED" }
+ *       501: { description: FREIGHTER_SIGNING_UNSUPPORTED - the creator's wallet is non-custodial and cannot yet sign contract calls server-side }
  */
 router.post(
   '/withdrawal',
@@ -213,6 +214,7 @@ router.post(
  *       403: { description: Not the campaign auditor }
  *       404: { description: PENDING_NOT_FOUND }
  *       409: { description: AUDITOR_NOT_CONFIGURED }
+ *       501: { description: FREIGHTER_SIGNING_UNSUPPORTED - the auditor's wallet is non-custodial and cannot yet sign contract calls server-side }
  */
 router.post(
   '/withdrawal/:pendingId/approve',
@@ -224,7 +226,9 @@ router.post(
       return res.status(400).json({ error: 'Invalid pending id', code: 'VALIDATION_ERROR' });
     }
     try {
-      const withdrawal = await treasury.approvePendingWithdrawal(req.params.id, pendingId);
+      const withdrawal = await treasury.approvePendingWithdrawal(req.params.id, pendingId, {
+        approverId: req.user.userId,
+      });
       return res.json(withdrawal);
     } catch (err) {
       return sendServiceError(res, err);

--- a/backend/src/routes/treasury.test.js
+++ b/backend/src/routes/treasury.test.js
@@ -289,11 +289,13 @@ test('POST /treasury/withdrawal is refused for a non-creator', async () => {
 
 test('POST /treasury/withdrawal/:pendingId/approve releases the parked withdrawal', async () => {
   let approvedId;
+  let approverId;
   const app = buildApp({
     queryImpl: ownerQuery(),
     treasuryStub: {
-      approvePendingWithdrawal: async (_campaignId, pendingId) => {
+      approvePendingWithdrawal: async (_campaignId, pendingId, opts) => {
         approvedId = pendingId;
+        approverId = opts?.approverId;
         return { id: 'w-2', status: 'completed' };
       },
     },
@@ -306,6 +308,9 @@ test('POST /treasury/withdrawal/:pendingId/approve releases the parked withdrawa
   assert.equal(res.status, 200);
   assert.equal(res.body.status, 'completed');
   assert.equal(approvedId, 7);
+  // The route must identify who is approving so the service can sign with the
+  // auditor's own key rather than a shared/platform one.
+  assert.equal(approverId, CREATOR_ID);
 });
 
 test('a user who is not the auditor cannot approve', async () => {

--- a/backend/src/services/contractTreasury.js
+++ b/backend/src/services/contractTreasury.js
@@ -4,6 +4,7 @@ const { nativeToScVal, Address, Keypair } = require('@stellar/stellar-sdk');
 const db = require('../config/database');
 const logger = require('../config/logger');
 const soroban = require('./sorobanService');
+const { withDecryptedWalletSecret } = require('./walletSecrets');
 
 /**
  * Compiled campaign_treasury WASM. Built from contracts/soroban with
@@ -133,6 +134,36 @@ function requireContractMode(campaign) {
     throw fail('This campaign does not use a contract treasury', 409, 'NOT_CONTRACT_WALLET');
   }
   return campaign.contract_id;
+}
+
+/**
+ * Loads the encrypted wallet secret for whichever user must satisfy
+ * `require_auth()` on-chain (the creator for request_withdrawal, the auditor for
+ * approve_withdrawal). The contract checks the caller's own address, so signing
+ * with PLATFORM_SECRET_KEY on their behalf is never valid — only their own key
+ * authorizes their own address.
+ */
+async function loadCustodialSigner(userId, role, missingCode) {
+  const { rows } = await db.query(
+    'SELECT wallet_type, wallet_public_key, wallet_secret_encrypted FROM users WHERE id = $1',
+    [userId]
+  );
+  const user = rows[0];
+  if (!user?.wallet_public_key) {
+    throw fail(`Campaign ${role} has no wallet`, 409, missingCode);
+  }
+  if (user.wallet_type === 'freighter') {
+    throw fail(
+      `Contract-treasury signing requires the ${role}'s server-held wallet key; non-custodial (Freighter) ${role} wallets are not yet supported here`,
+      501,
+      'FREIGHTER_SIGNING_UNSUPPORTED'
+    );
+  }
+  return {
+    userId,
+    walletPublicKey: user.wallet_public_key,
+    walletSecretEncrypted: user.wallet_secret_encrypted,
+  };
 }
 
 /**
@@ -316,15 +347,21 @@ async function indexContribution(campaignId, { contributor, amount, txHash }) {
 async function buildWithdrawalRequest(campaignId, { amount, destination, memo, requestedBy }) {
   const campaign = await loadCampaign(campaignId);
   const contractId = requireContractMode(campaign);
+  const creator = await loadCustodialSigner(campaign.creator_id, 'creator', 'CREATOR_WALLET_MISSING');
 
   let result;
   try {
-    result = await soroban.invokeContract({
-      contractId,
-      method: 'request_withdrawal',
-      args: [i128(amount), addressArg(destination), symbolArg(memo)],
-      signerSecret: process.env.PLATFORM_SECRET_KEY,
-    });
+    result = await withDecryptedWalletSecret(
+      creator.walletSecretEncrypted,
+      { userId: creator.userId, walletPublicKey: creator.walletPublicKey },
+      (creatorSecret) =>
+        soroban.invokeContract({
+          contractId,
+          method: 'request_withdrawal',
+          args: [i128(amount), addressArg(destination), symbolArg(memo)],
+          signerSecret: creatorSecret,
+        })
+    );
   } catch (err) {
     throw translateContractError(err);
   }
@@ -359,17 +396,26 @@ async function buildWithdrawalRequest(campaignId, { amount, destination, memo, r
 }
 
 /** Auditor sign-off; releases a withdrawal the contract parked. */
-async function approvePendingWithdrawal(campaignId, pendingId, { auditorSecret } = {}) {
+async function approvePendingWithdrawal(campaignId, pendingId, { approverId } = {}) {
   const campaign = await loadCampaign(campaignId);
   const contractId = requireContractMode(campaign);
+  if (!approverId) {
+    throw fail('Auditor approval requires the authenticated approver', 400, 'VALIDATION_ERROR');
+  }
+  const auditor = await loadCustodialSigner(approverId, 'auditor', 'AUDITOR_WALLET_MISSING');
 
   try {
-    await soroban.invokeContract({
-      contractId,
-      method: 'approve_withdrawal',
-      args: [nativeToScVal(Number(pendingId), { type: 'u32' })],
-      signerSecret: auditorSecret || process.env.PLATFORM_SECRET_KEY,
-    });
+    await withDecryptedWalletSecret(
+      auditor.walletSecretEncrypted,
+      { userId: auditor.userId, walletPublicKey: auditor.walletPublicKey },
+      (auditorSecret) =>
+        soroban.invokeContract({
+          contractId,
+          method: 'approve_withdrawal',
+          args: [nativeToScVal(Number(pendingId), { type: 'u32' })],
+          signerSecret: auditorSecret,
+        })
+    );
   } catch (err) {
     throw translateContractError(err);
   }

--- a/backend/src/services/contractTreasury.test.js
+++ b/backend/src/services/contractTreasury.test.js
@@ -15,6 +15,7 @@ const CAMPAIGN_ID = '11111111-1111-1111-1111-111111111111';
 // Real Stellar keys — Address.fromString validates, so placeholders will not do.
 const DEST = 'GAJZF6DOHVKNA4VYDMGEB4BOBV27VI6O5ERDGJP5TH6JPGIUAUSLNCRS';
 const CREATOR = 'GD3I6UAGVCRIWVC5SVFHIHARP7IXKBGKUL74JTCU64T5LCQKFPYAYCC5';
+const AUDITOR = 'GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI';
 
 function build({ queryImpl = async () => ({ rows: [] }), soroban = {} } = {}) {
   const calls = [];
@@ -36,6 +37,12 @@ function build({ queryImpl = async () => ({ rows: [] }), soroban = {} } = {}) {
     '../config/database': { query: queryImpl },
     '../config/logger': { info() {}, warn() {}, error() {} },
     './sorobanService': sorobanStub,
+    // Real wallet-secret encryption depends on env-configured key material the
+    // tests don't set up; the "encrypted" value stands in for the plaintext so
+    // assertions can check exactly which key reaches signerSecret.
+    './walletSecrets': {
+      withDecryptedWalletSecret: async (secret, _context, fn) => fn(secret),
+    },
   });
 
   return { service, calls };
@@ -52,6 +59,15 @@ function campaignRow(overrides = {}) {
     contract_id: 'CTREASURY',
     auditor_public_key: null,
     status: 'active',
+    ...overrides,
+  };
+}
+
+function userRow(overrides = {}) {
+  return {
+    wallet_type: 'custodial',
+    wallet_public_key: CREATOR,
+    wallet_secret_encrypted: 'creator-secret',
     ...overrides,
   };
 }
@@ -178,6 +194,7 @@ test('a withdrawal under the auditor threshold is recorded as completed immediat
     soroban: { invokeResult: null },
     queryImpl: async (text, params) => {
       if (text.includes('FROM campaigns')) return { rows: [campaignRow()] };
+      if (text.includes('FROM users')) return { rows: [userRow()] };
       if (text.includes('INSERT INTO withdrawal_requests')) {
         inserted = params;
         return { rows: [{ id: 'w-1', status: 'completed', contract_pending_id: null }] };
@@ -198,6 +215,10 @@ test('a withdrawal under the auditor threshold is recorded as completed immediat
   assert.equal(inserted[5], 'completed');
   assert.ok(inserted[7] instanceof Date, 'completed_at should be stamped');
   assert.equal(calls[0].method, 'request_withdrawal');
+  // request_withdrawal requires Soroban `creator.require_auth()`; signing with the
+  // platform key (or anyone else's) would fail on-chain, so the invocation must
+  // carry the creator's own key, not the platform's.
+  assert.equal(calls[0].signerSecret, 'creator-secret');
 });
 
 test('a withdrawal above the auditor threshold is parked as pending_auditor', async () => {
@@ -206,6 +227,7 @@ test('a withdrawal above the auditor threshold is parked as pending_auditor', as
     soroban: { invokeResult: 7 },
     queryImpl: async (text, params) => {
       if (text.includes('FROM campaigns')) return { rows: [campaignRow()] };
+      if (text.includes('FROM users')) return { rows: [userRow()] };
       if (text.includes('INSERT INTO withdrawal_requests')) {
         inserted = params;
         return { rows: [{ id: 'w-2', status: 'pending_auditor', contract_pending_id: 7 }] };
@@ -229,6 +251,57 @@ test('a withdrawal above the auditor threshold is parked as pending_auditor', as
   assert.equal(inserted[7], null);
 });
 
+test('the creator and platform accounts are distinct: requesting with only a platform key configured still signs as the creator', async () => {
+  const { service, calls } = build({
+    soroban: { invokeResult: null },
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns')) return { rows: [campaignRow()] };
+      if (text.includes('FROM users')) {
+        return { rows: [userRow({ wallet_public_key: CREATOR, wallet_secret_encrypted: 'creator-secret' })] };
+      }
+      if (text.includes('INSERT INTO withdrawal_requests')) {
+        return { rows: [{ id: 'w-1', status: 'completed', contract_pending_id: null }] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  await service.buildWithdrawalRequest(CAMPAIGN_ID, {
+    amount: '100',
+    destination: DEST,
+    memo: 'payout',
+    requestedBy: 'creator-1',
+  });
+
+  // The old bug always signed with PLATFORM_SECRET_KEY, which never satisfies
+  // `creator.require_auth()` unless the two keys are accidentally identical.
+  assert.equal(calls[0].signerSecret, 'creator-secret');
+  assert.notEqual(calls[0].signerSecret, process.env.PLATFORM_SECRET_KEY);
+});
+
+test('a creator without a custodial wallet cannot request a contract withdrawal from the server', async () => {
+  const { service } = build({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns')) return { rows: [campaignRow()] };
+      if (text.includes('FROM users')) {
+        return { rows: [userRow({ wallet_type: 'freighter', wallet_secret_encrypted: null })] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      service.buildWithdrawalRequest(CAMPAIGN_ID, {
+        amount: '100',
+        destination: DEST,
+        memo: 'payout',
+        requestedBy: 'creator-1',
+      }),
+    (err) => err.code === 'FREIGHTER_SIGNING_UNSUPPORTED' && err.statusCode === 501
+  );
+});
+
 test('a policy violation surfaces as its contract code and writes no row', async () => {
   let insertAttempted = false;
   const { service } = build({
@@ -241,6 +314,7 @@ test('a policy violation surfaces as its contract code and writes no row', async
     },
     queryImpl: async (text) => {
       if (text.includes('FROM campaigns')) return { rows: [campaignRow()] };
+      if (text.includes('FROM users')) return { rows: [userRow()] };
       if (text.includes('INSERT INTO withdrawal_requests')) insertAttempted = true;
       return { rows: [] };
     },
@@ -282,6 +356,9 @@ test('approving a pending withdrawal completes exactly that row', async () => {
   const { service, calls } = build({
     queryImpl: async (text, params) => {
       if (text.includes('FROM campaigns')) return { rows: [campaignRow()] };
+      if (text.includes('FROM users')) {
+        return { rows: [userRow({ wallet_public_key: AUDITOR, wallet_secret_encrypted: 'auditor-secret' })] };
+      }
       if (text.includes('UPDATE withdrawal_requests')) {
         updateParams = params;
         return { rows: [{ id: 'w-2', status: 'completed', amount: '9000.0000000' }] };
@@ -290,21 +367,41 @@ test('approving a pending withdrawal completes exactly that row', async () => {
     },
   });
 
-  const row = await service.approvePendingWithdrawal(CAMPAIGN_ID, 7);
+  const row = await service.approvePendingWithdrawal(CAMPAIGN_ID, 7, { approverId: 'auditor-1' });
   assert.equal(row.status, 'completed');
   assert.deepEqual(updateParams, [CAMPAIGN_ID, 7]);
   assert.equal(calls[0].method, 'approve_withdrawal');
+  // approve_withdrawal requires Soroban `auditor.require_auth()`; the platform key
+  // signs a different address and must not be substituted for the auditor's own.
+  assert.equal(calls[0].signerSecret, 'auditor-secret');
 });
 
-test('approving an id the database does not hold is a 404', async () => {
-  const { service } = build({
+test('approving without an authenticated approver is rejected before touching the contract', async () => {
+  const { service, calls } = build({
     queryImpl: async (text) => {
       if (text.includes('FROM campaigns')) return { rows: [campaignRow()] };
       return { rows: [] };
     },
   });
   await assert.rejects(
-    () => service.approvePendingWithdrawal(CAMPAIGN_ID, 99),
+    () => service.approvePendingWithdrawal(CAMPAIGN_ID, 7),
+    (err) => err.code === 'VALIDATION_ERROR' && err.statusCode === 400
+  );
+  assert.equal(calls.length, 0);
+});
+
+test('approving an id the database does not hold is a 404', async () => {
+  const { service } = build({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns')) return { rows: [campaignRow()] };
+      if (text.includes('FROM users')) {
+        return { rows: [userRow({ wallet_public_key: AUDITOR, wallet_secret_encrypted: 'auditor-secret' })] };
+      }
+      return { rows: [] };
+    },
+  });
+  await assert.rejects(
+    () => service.approvePendingWithdrawal(CAMPAIGN_ID, 99, { approverId: 'auditor-1' }),
     (err) => err.code === 'PENDING_NOT_FOUND' && err.statusCode === 404
   );
 });


### PR DESCRIPTION
## What I built

`backend/src/services/contractTreasury.js` signed every treasury contract call with `PLATFORM_SECRET_KEY`, including `request_withdrawal`. The contract's `request_withdrawal` calls `creator.require_auth()` (`contracts/soroban/contracts/campaign_treasury/src/lib.rs:244-245`), which only succeeds when the transaction is authorized by the creator's own key. Soroban resolves `require_auth()` for an address against the transaction's source account signature, so signing with the platform's key can never satisfy an auth check for the creator's address unless the two keys happen to be identical.

`buildWithdrawalRequest` now looks up the campaign creator's custodial wallet and signs `request_withdrawal` with the creator's own decrypted key, reusing the existing wallet-secret decryption pattern from `withdrawals.js`'s creator-approval flow.

While fixing this I found `approvePendingWithdrawal` had the identical bug: `approve_withdrawal` requires `auditor.require_auth()` on-chain, but the service always signed with `PLATFORM_SECRET_KEY` (the `auditorSecret` parameter it accepted was never actually supplied by the route). I fixed that the same way — the route now passes the authenticated approver's user id, and the service signs with that user's own decrypted key.

Platform-only calls (`receive_contribution`, `initialize`, `trigger_auto_refund`) were left untouched — I checked each against the contract's `require_auth()` calls and they're all correctly scoped already (`initialize` and `trigger_auto_refund` require no auth at all; `receive_contribution` correctly requires the platform).

## Decisions worth noting

- Added a shared `loadCustodialSigner(userId, role, missingCode)` helper since the creator and auditor paths need identical logic: look up the user's wallet, and reject with a clear `409` if they have no wallet.
- Non-custodial (Freighter) creators or auditors can't be signed for server-side today, since the backend never holds their secret key. Rather than silently falling back to the wrong key (the original bug) or building a full client-side Soroban-signing flow (a much larger change beyond this issue's scope), I added an explicit `501 FREIGHTER_SIGNING_UNSUPPORTED` error so the failure is clear instead of a wrong signature or an unexplained 500. Happy to scope a follow-up issue for Freighter support on this endpoint if wanted.

## How to test manually

1. Set up a campaign in contract mode with a custodial creator wallet and a custodial auditor wallet on testnet.
2. Fund it above the auditor threshold, then call `POST /api/campaigns/:id/treasury/withdrawal` as the creator — confirm it succeeds and the contract's `request_withdrawal` invocation is now signed by the creator's key (previously this would fail on-chain unless `PLATFORM_SECRET_KEY` happened to equal the creator's key).
3. Call `POST /api/campaigns/:id/treasury/withdrawal/:pendingId/approve` as the configured auditor — confirm it succeeds, signed by the auditor's key.
4. `cd backend && npm test -- contractTreasury.test.js treasury.test.js`

## Checklist

- [x] Creator signing implemented for `request_withdrawal`
- [x] Platform/auditor authorization preserved and separately validated (auditor now signs `approve_withdrawal` with its own key too; platform-only calls unchanged)
- [x] Integration-style coverage added asserting `request_withdrawal`/`approve_withdrawal` sign with the creator/auditor's own key, distinct from the platform key
- [ ] `npm test` — could not run in this environment (no `node_modules` installed); please run `cd backend && npm test` in review
- [x] No files added beyond what the issue required
- [x] PR is against `main`, branch is rebased and clean

Closes #709