### PR TITLE
security: validate externally rendered URLs and verify admin status from DB

### DIFF
--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -1085,7 +1085,13 @@ router.get('/:id', asyncHandler(async (req, res) => {
       const jwt = require('jsonwebtoken');
       const payload = jwt.verify(token, process.env.JWT_SECRET);
       if (payload && payload.userId) {
-        if (payload.is_admin) {
+        const { rows: userRows } = await db.query(
+          'SELECT is_admin FROM users WHERE id = $1',
+          [payload.userId]
+        );
+        const currentIsAdmin = userRows[0]?.is_admin === true;
+
+        if (currentIsAdmin) {
           userRole = 'owner';
         } else if (campaign.creator_id === payload.userId) {
           userRole = 'owner';
@@ -1093,7 +1099,7 @@ router.get('/:id', asyncHandler(async (req, res) => {
           userRole = await resolveUserCampaignRole(
             campaign.id,
             payload.userId,
-            payload.role === 'admin'
+            false
           );
         }
       }

--- a/backend/src/routes/campaigns.test.js
+++ b/backend/src/routes/campaigns.test.js
@@ -765,7 +765,7 @@ test('Analytics routes enforce requireAuth and requireCampaignMember', async () 
 
 function buildShareApp({ campaignExists = true, initialShareCount = 5, authUser } = {}) {
   let shareCount = initialShareCount;
-  const dedup = new Map(); // `${campaignId}:${actorHash}` -> lastSharedAtMs
+  const dedup = new Map();
   const WINDOW_MS = 60 * 60 * 1000;
 
   const queryImpl = async (text, params) => {
@@ -779,7 +779,7 @@ function buildShareApp({ campaignExists = true, initialShareCount = 5, authUser 
       const last = dedup.get(key);
       const now = Date.now();
       if (last !== undefined && now - last < WINDOW_MS) {
-        return { rows: [] }; // duplicate within window
+        return { rows: [] };
       }
       dedup.set(key, now);
       return { rows: [{ campaign_id: campaignId }] };
@@ -792,7 +792,7 @@ function buildShareApp({ campaignExists = true, initialShareCount = 5, authUser 
   };
 
   const app = buildApp({ queryImpl, authUser });
-  app.set('trust proxy', true); // so X-Forwarded-For actually changes req.ip in these tests
+  app.set('trust proxy', true);
   return app;
 }
 
@@ -813,7 +813,7 @@ test('POST /api/campaigns/:id/share does not recount a repeated share from the s
 
   assert.equal(first.body.share_count, 6);
   assert.equal(second.status, 200);
-  assert.equal(second.body.share_count, 6); // unchanged
+  assert.equal(second.body.share_count, 6);
 });
 
 test('POST /api/campaigns/:id/share counts shares from different actors independently', async () => {
@@ -830,10 +830,10 @@ test('POST /api/campaigns/:id/share dedups an authenticated user by user id, not
   const app = buildShareApp({ initialShareCount: 5, authUser: { userId: 'user-42' } });
 
   const first = await request(app).post('/api/campaigns/c-1/share').set('X-Forwarded-For', '1.2.3.4');
-  const second = await request(app).post('/api/campaigns/c-1/share').set('X-Forwarded-For', '9.9.9.9'); // same user, different IP
+  const second = await request(app).post('/api/campaigns/c-1/share').set('X-Forwarded-For', '9.9.9.9');
 
   assert.equal(first.body.share_count, 6);
-  assert.equal(second.body.share_count, 6); // still deduped by user id
+  assert.equal(second.body.share_count, 6);
 });
 
 test('POST /api/campaigns/:id/share returns 404 for a nonexistent campaign', async () => {
@@ -853,4 +853,56 @@ test('POST /api/campaigns/:id/share only counts one increment out of a concurren
 
   const counts = responses.map((r) => r.body.share_count);
   assert.ok(counts.every((c) => c === 1), `expected all responses to report share_count 1, got ${counts}`);
+});
+
+test('GET /api/campaigns/:id denies hidden campaign to demoted admin with stale JWT', async () => {
+  const jwt = require('jsonwebtoken');
+  const secret = process.env.JWT_SECRET || 'testsecret';
+  const token = jwt.sign(
+    {
+      userId: 'admin-1',
+      is_admin: true,
+      role: 'admin',
+      sub: 'admin-1',
+      iss: 'https://crowdpay.io',
+      aud: 'crowdpay-api',
+    },
+    secret,
+    { expiresIn: '1h' }
+  );
+
+  const queryImpl = async (text, params) => {
+    if (text.includes('SELECT is_admin FROM users WHERE id')) {
+      return { rows: [{ is_admin: false }] };
+    }
+    if (text.includes('FROM campaigns WHERE id')) {
+      return {
+        rows: [{
+          id: 'c-hidden',
+          title: 'Hidden Campaign',
+          is_hidden: true,
+          status: 'active',
+          deleted_at: null,
+          creator_id: 'creator-other',
+          contributor_count: 0,
+        }],
+      };
+    }
+    return { rows: [] };
+  };
+
+  const app = buildApp({
+    authUser: { userId: 'admin-1', role: 'admin' },
+    queryImpl,
+    campaignStatusImpl: {
+      refreshCampaignStatus: async () => ({ failed: null, funded: null }),
+      refreshActiveCampaignStatuses: async () => ({ failed: [], funded: [] }),
+    },
+  });
+
+  const res = await request(app)
+    .get('/api/campaigns/c-hidden')
+    .set('Authorization', `Bearer ${token}`);
+
+  assert.equal(res.status, 404);
 });

--- a/backend/src/routes/disputes.js
+++ b/backend/src/routes/disputes.js
@@ -13,18 +13,10 @@ const { parsePagination } = require('../utils/pagination');
 const asyncHandler = require('../utils/asyncHandler');
 const stellarService = require('../services/stellarService');
 const { ERROR_CODES, allocateProportionalRefunds } = require('../services/dispute');
+const { validateRenderUrl } = require('../utils/urlValidation');
 
 function frontendBaseUrl() {
   return (process.env.FRONTEND_URL || 'http://localhost:5173').replace(/\/$/, '');
-}
-
-function isValidEvidenceUrl(urlString) {
-  try {
-    const u = new URL(urlString);
-    return u.protocol === 'https:' || u.protocol === 'http:';
-  } catch {
-    return false;
-  }
 }
 
 async function logDisputeEvent(client, { disputeId, actorId, action, note }) {
@@ -46,8 +38,11 @@ router.post('/campaigns/:id/disputes', requireAuth, async (req, res) => {
   if (!description || !description.trim()) {
     return res.status(422).json({ error: 'description is required' });
   }
-  if (evidence_url !== undefined && evidence_url !== null && evidence_url !== '' && !isValidEvidenceUrl(evidence_url)) {
-    return res.status(422).json({ error: 'evidence_url must be a valid http(s) URL' });
+  if (evidence_url !== undefined && evidence_url !== null && evidence_url !== '') {
+    const { safe } = validateRenderUrl(evidence_url);
+    if (!safe) {
+      return res.status(422).json({ error: 'evidence_url must be a valid http(s) URL' });
+    }
   }
 
   const { rows: campaigns } = await db.query(

--- a/backend/src/routes/milestones.js
+++ b/backend/src/routes/milestones.js
@@ -31,6 +31,7 @@ const {
   sendMilestoneEvidenceSubmittedAdminEmail,
 } = require('../services/emailService');
 const asyncHandler = require('../utils/asyncHandler');
+const { validateRenderUrl } = require('../utils/urlValidation');
 
 function frontendBaseUrl() {
   return (process.env.FRONTEND_URL || 'http://localhost:5173').replace(/\/$/, '');
@@ -341,6 +342,11 @@ router.post('/:id/submit', requireAuth, async (req, res) => {
     return res.status(400).json({ error: 'destination_key must be a valid Stellar public key' });
   }
 
+  const { safe: urlSafe, reason: urlReason, normalized: normalizedUrl } = validateRenderUrl(evidenceUrl);
+  if (!urlSafe) {
+    return res.status(422).json({ error: `evidence_url is not valid: ${urlReason}` });
+  }
+
   const { rows: milestones } = await db.query(
     `SELECT m.*, c.creator_id, c.status AS campaign_status, c.title AS campaign_title,
             c.migration_in_progress
@@ -394,8 +400,8 @@ router.post('/:id/submit', requireAuth, async (req, res) => {
            completed_at = NOW()
        WHERE id = $4 AND status IN ('pending', 'rejected')
        RETURNING *`,
-      [
-        String(evidenceUrl).trim(),
+       [
+        normalizedUrl,
         String(evidenceDescription || '').trim() || null,
         destinationKey,
         req.params.id,

--- a/backend/src/routes/milestones.test.js
+++ b/backend/src/routes/milestones.test.js
@@ -341,3 +341,91 @@ test('POST /api/milestones/:id/approve prevents concurrent approval via atomic c
   assert.equal(res2.status, 409, 'second concurrent approval should be blocked');
   assert.match(res2.body.error, /already being processed|already claimed/i);
 });
+
+test('POST /api/milestones/:id/submit rejects javascript: scheme in evidence_url', async () => {
+  const { app, cleanup } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('FROM milestones m') && text.includes('JOIN campaigns')) {
+        return { rows: [milestoneRow()] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const res = await request(app)
+    .post(`/api/milestones/${MILESTONE_ID}/submit`)
+    .send({
+      evidence_url: 'javascript:alert(1)',
+      destination_key: VALID_DESTINATION,
+    });
+
+  cleanup();
+  assert.equal(res.status, 422);
+  assert.match(res.body.error, /evidence_url is not valid/i);
+});
+
+test('POST /api/milestones/:id/submit rejects data: scheme in evidence_url', async () => {
+  const { app, cleanup } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('FROM milestones m') && text.includes('JOIN campaigns')) {
+        return { rows: [milestoneRow()] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const res = await request(app)
+    .post(`/api/milestones/${MILESTONE_ID}/submit`)
+    .send({
+      evidence_url: 'data:text/html,<script>alert(1)</script>',
+      destination_key: VALID_DESTINATION,
+    });
+
+  cleanup();
+  assert.equal(res.status, 422);
+  assert.match(res.body.error, /evidence_url is not valid/i);
+});
+
+test('POST /api/milestones/:id/submit rejects malformed URL', async () => {
+  const { app, cleanup } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('FROM milestones m') && text.includes('JOIN campaigns')) {
+        return { rows: [milestoneRow()] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const res = await request(app)
+    .post(`/api/milestones/${MILESTONE_ID}/submit`)
+    .send({
+      evidence_url: 'not-a-valid-url',
+      destination_key: VALID_DESTINATION,
+    });
+
+  cleanup();
+  assert.equal(res.status, 422);
+  assert.match(res.body.error, /evidence_url is not valid/i);
+});
+
+test('POST /api/milestones/:id/submit rejects vbscript: scheme', async () => {
+  const { app, cleanup } = buildApp({
+    queryImpl: async (text) => {
+      if (text.includes('FROM milestones m') && text.includes('JOIN campaigns')) {
+        return { rows: [milestoneRow()] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const res = await request(app)
+    .post(`/api/milestones/${MILESTONE_ID}/submit`)
+    .send({
+      evidence_url: 'vbscript:MsgBox("XSS")',
+      destination_key: VALID_DESTINATION,
+    });
+
+  cleanup();
+  assert.equal(res.status, 422);
+  assert.match(res.body.error, /evidence_url is not valid/i);
+});

--- a/backend/src/utils/urlValidation.js
+++ b/backend/src/utils/urlValidation.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const ALLOWED_SCHEMES = new Set(['https:']);
+const DEV_ALLOWED_SCHEMES = new Set(['https:', 'http:']);
+
+/**
+ * Validate that a URL is safe for rendering as src/href.
+ *
+ * Only HTTPS is allowed in production. HTTP is permitted for localhost/127.0.0.1/::1
+ * in non-production environments. Dangerous schemes (javascript:, data:, vbscript:, etc.)
+ * are always rejected.
+ *
+ * @param {string} urlString
+ * @param {object} [options]
+ * @param {boolean} [options.allowLocalhostHttp] - allow http://localhost (default: NODE_ENV !== 'production')
+ * @returns {{ safe: boolean, reason: string, normalized: string }}
+ */
+function validateRenderUrl(urlString, options = {}) {
+  if (typeof urlString !== 'string' || !urlString.trim()) {
+    return { safe: false, reason: 'URL is required', normalized: '' };
+  }
+
+  const trimmed = urlString.trim();
+
+  let u;
+  try {
+    u = new URL(trimmed);
+  } catch {
+    return { safe: false, reason: 'Invalid URL format', normalized: '' };
+  }
+
+  const allowLocalhostHttp = options.allowLocalhostHttp !== undefined
+    ? options.allowLocalhostHttp
+    : process.env.NODE_ENV !== 'production';
+
+  const allowedSchemes = allowLocalhostHttp ? DEV_ALLOWED_SCHEMES : ALLOWED_SCHEMES;
+
+  if (!allowedSchemes.has(u.protocol)) {
+    return {
+      safe: false,
+      reason: `URL scheme "${u.protocol}" is not allowed. Only HTTPS is permitted${allowLocalhostHttp ? ' (HTTP allowed for localhost in development)' : ''}`,
+      normalized: '',
+    };
+  }
+
+  if (u.protocol === 'http:') {
+    const host = u.hostname.toLowerCase();
+    const isLocalhost = host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]';
+    if (!isLocalhost) {
+      return {
+        safe: false,
+        reason: 'HTTP is only allowed for localhost/127.0.0.1 in development',
+        normalized: '',
+      };
+    }
+  }
+
+  const normalized = u.href;
+
+  return { safe: true, reason: '', normalized };
+}
+
+/**
+ * Express middleware factory that validates a body field as a safe render URL.
+ *
+ * @param {string} fieldName - body field to validate (e.g. 'evidence_url')
+ * @param {object} [options]
+ * @param {boolean} [options.required] - if true, returns 400 when missing (default: false)
+ * @returns {Function} Express middleware
+ */
+function requireValidRenderUrl(fieldName, options = {}) {
+  return (req, res, next) => {
+    const value = req.body?.[fieldName];
+
+    if (!value || (typeof value === 'string' && !value.trim())) {
+      if (options.required) {
+        return res.status(400).json({ error: `${fieldName} is required` });
+      }
+      return next();
+    }
+
+    const { safe, reason, normalized } = validateRenderUrl(value, {
+      allowLocalhostHttp: process.env.NODE_ENV !== 'production',
+    });
+
+    if (!safe) {
+      return res.status(422).json({ error: `${fieldName} is not valid: ${reason}` });
+    }
+
+    req.body[fieldName] = normalized;
+    next();
+  };
+}
+
+module.exports = { validateRenderUrl, requireValidRenderUrl };

--- a/backend/src/utils/urlValidation.test.js
+++ b/backend/src/utils/urlValidation.test.js
@@ -1,0 +1,149 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { validateRenderUrl, requireValidRenderUrl } = require('./urlValidation');
+
+test('validateRenderUrl rejects empty/null/undefined input', () => {
+  assert.equal(validateRenderUrl(null).safe, false);
+  assert.equal(validateRenderUrl('').safe, false);
+  assert.equal(validateRenderUrl(undefined).safe, false);
+  assert.equal(validateRenderUrl('   ').safe, false);
+});
+
+test('validateRenderUrl rejects invalid URL format', () => {
+  assert.equal(validateRenderUrl('not-a-url').safe, false);
+  assert.equal(validateRenderUrl('://bad').safe, false);
+});
+
+test('validateRenderUrl rejects javascript: scheme', () => {
+  const result = validateRenderUrl('javascript:alert(1)');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /not allowed/i);
+});
+
+test('validateRenderUrl rejects data: scheme', () => {
+  const result = validateRenderUrl('data:text/html,<script>alert(1)</script>');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /not allowed/i);
+});
+
+test('validateRenderUrl rejects vbscript: scheme', () => {
+  const result = validateRenderUrl('vbscript:MsgBox("XSS")');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /not allowed/i);
+});
+
+test('validateRenderUrl rejects blob: scheme', () => {
+  const result = validateRenderUrl('blob:https://example.com/id');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /not allowed/i);
+});
+
+test('validateRenderUrl rejects file: scheme', () => {
+  const result = validateRenderUrl('file:///etc/passwd');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /not allowed/i);
+});
+
+test('validateRenderUrl allows https: URLs', () => {
+  const result = validateRenderUrl('https://example.com/image.png');
+  assert.equal(result.safe, true);
+  assert.equal(result.normalized, 'https://example.com/image.png');
+});
+
+test('validateRenderUrl allows https: with complex paths and query params', () => {
+  const url = 'https://cdn.example.com/path/to/file.pdf?token=abc123&sig=xyz';
+  const result = validateRenderUrl(url);
+  assert.equal(result.safe, true);
+  assert.equal(result.normalized, url);
+});
+
+test('validateRenderUrl rejects http: non-localhost URLs', () => {
+  const result = validateRenderUrl('http://example.com/image.png');
+  assert.equal(result.safe, false);
+  assert.match(result.reason, /HTTP is only allowed for localhost/i);
+});
+
+test('validateRenderUrl allows http: localhost in development', () => {
+  const prev = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'development';
+  const result = validateRenderUrl('http://localhost:3000/image.png');
+  process.env.NODE_ENV = prev;
+  assert.equal(result.safe, true);
+});
+
+test('validateRenderUrl allows http: 127.0.0.1 in development', () => {
+  const prev = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'development';
+  const result = validateRenderUrl('http://127.0.0.1:3000/image.png');
+  process.env.NODE_ENV = prev;
+  assert.equal(result.safe, true);
+});
+
+test('validateRenderUrl allows http: [::1] in development', () => {
+  const prev = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'development';
+  const result = validateRenderUrl('http://[::1]:3000/image.png');
+  process.env.NODE_ENV = prev;
+  assert.equal(result.safe, true);
+});
+
+test('validateRenderUrl rejects http: localhost in production', () => {
+  const prev = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'production';
+  const result = validateRenderUrl('http://localhost:3000/image.png');
+  process.env.NODE_ENV = prev;
+  assert.equal(result.safe, false);
+});
+
+test('validateRenderUrl normalizes URLs correctly', () => {
+  const result = validateRenderUrl('https://Example.COM/Path');
+  assert.equal(result.safe, true);
+  assert.equal(result.normalized, 'https://example.com/Path');
+});
+
+test('requireValidRenderUrl middleware passes through when field is missing and not required', () => {
+  const middleware = requireValidRenderUrl('evidence_url');
+  const req = { body: {} };
+  const res = { status: () => res, json: () => res };
+  let called = false;
+  middleware(req, res, () => { called = true; });
+  assert.equal(called, true);
+});
+
+test('requireValidRenderUrl middleware returns 400 when field is missing and required', () => {
+  const middleware = requireValidRenderUrl('evidence_url', { required: true });
+  const req = { body: {} };
+  let statusCode;
+  let body;
+  const res = {
+    status: (code) => { statusCode = code; return res; },
+    json: (data) => { body = data; return res; },
+  };
+  middleware(req, res, () => {});
+  assert.equal(statusCode, 400);
+  assert.match(body.error, /required/i);
+});
+
+test('requireValidRenderUrl middleware returns 422 for dangerous URL scheme', () => {
+  const middleware = requireValidRenderUrl('evidence_url');
+  const req = { body: { evidence_url: 'javascript:alert(1)' } };
+  let statusCode;
+  let body;
+  const res = {
+    status: (code) => { statusCode = code; return res; },
+    json: (data) => { body = data; return res; },
+  };
+  middleware(req, res, () => {});
+  assert.equal(statusCode, 422);
+  assert.match(body.error, /not valid/i);
+});
+
+test('requireValidRenderUrl middleware normalizes valid URL on req.body', () => {
+  const middleware = requireValidRenderUrl('evidence_url');
+  const req = { body: { evidence_url: 'https://Example.COM/Path' } };
+  let called = false;
+  const res = { status: () => res, json: () => res };
+  middleware(req, res, () => { called = true; });
+  assert.equal(called, true);
+  assert.equal(req.body.evidence_url, 'https://example.com/Path');
+});


### PR DESCRIPTION
## Summary

This PR addresses two security issues:

### #705 — Validate externally rendered media and evidence URLs
- Created a shared urlValidation utility (ackend/src/utils/urlValidation.js) that validates URLs for safe rendering as src/href
- Rejects dangerous schemes: javascript:, data:, bscript:, lob:, ile:
- Enforces HTTPS-only in production; allows HTTP for localhost in development
- Validates evidence_url in milestones/:id/submit against unsafe URL schemes
- Refactored disputes.js to use the shared utility instead of its local isValidEvidenceUrl

### #703 — Re-check current admin authorization for hidden campaigns
- Changed campaigns/:id GET to verify admin status from the database instead of trusting the stale is_admin claim from the JWT
- Demoted admins now lose access to hidden campaigns immediately, not at JWT expiry
- Added regression test for admin demotion with an unexpired token

## Tests
- 19 tests for urlValidation utility (schemes, normalization, middleware)
- 4 negative tests for milestone evidence URL validation (javascript:, data:, bscript:, malformed)
- 1 regression test for admin demotion on hidden campaigns
- All existing tests pass

Closes #705
Closes #703