### PR TITLE
fix(treasury): verify auditor identity at service level for withdrawal approval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules/
 
+# Test coverage output
+coverage/
+
 # Environment files — never commit real secrets
 .env
 .env.*

--- a/backend/src/services/contractTreasury.js
+++ b/backend/src/services/contractTreasury.js
@@ -404,6 +404,10 @@ async function approvePendingWithdrawal(campaignId, pendingId, { approverId } = 
   }
   const auditor = await loadCustodialSigner(approverId, 'auditor', 'AUDITOR_WALLET_MISSING');
 
+  if (campaign.auditor_public_key && auditor.walletPublicKey !== campaign.auditor_public_key) {
+    throw fail('The signer does not match the configured auditor', 403, 'AUDITOR_MISMATCH');
+  }
+
   try {
     await withDecryptedWalletSecret(
       auditor.walletSecretEncrypted,

--- a/backend/src/services/contractTreasury.test.js
+++ b/backend/src/services/contractTreasury.test.js
@@ -355,7 +355,9 @@ test('approving a pending withdrawal completes exactly that row', async () => {
   let updateParams;
   const { service, calls } = build({
     queryImpl: async (text, params) => {
-      if (text.includes('FROM campaigns')) return { rows: [campaignRow()] };
+      if (text.includes('FROM campaigns')) {
+        return { rows: [campaignRow({ auditor_public_key: AUDITOR })] };
+      }
       if (text.includes('FROM users')) {
         return { rows: [userRow({ wallet_public_key: AUDITOR, wallet_secret_encrypted: 'auditor-secret' })] };
       }
@@ -393,7 +395,9 @@ test('approving without an authenticated approver is rejected before touching th
 test('approving an id the database does not hold is a 404', async () => {
   const { service } = build({
     queryImpl: async (text) => {
-      if (text.includes('FROM campaigns')) return { rows: [campaignRow()] };
+      if (text.includes('FROM campaigns')) {
+        return { rows: [campaignRow({ auditor_public_key: AUDITOR })] };
+      }
       if (text.includes('FROM users')) {
         return { rows: [userRow({ wallet_public_key: AUDITOR, wallet_secret_encrypted: 'auditor-secret' })] };
       }
@@ -404,6 +408,69 @@ test('approving an id the database does not hold is a 404', async () => {
     () => service.approvePendingWithdrawal(CAMPAIGN_ID, 99, { approverId: 'auditor-1' }),
     (err) => err.code === 'PENDING_NOT_FOUND' && err.statusCode === 404
   );
+});
+
+test('auditor whose wallet does not match the campaign auditor key is rejected', async () => {
+  const { service, calls } = build({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns')) {
+        // Campaign expects a different auditor than the one calling.
+        return { rows: [campaignRow({ auditor_public_key: CREATOR })] };
+      }
+      if (text.includes('FROM users')) {
+        return { rows: [userRow({ wallet_public_key: AUDITOR, wallet_secret_encrypted: 'auditor-secret' })] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  await assert.rejects(
+    () => service.approvePendingWithdrawal(CAMPAIGN_ID, 7, { approverId: 'auditor-1' }),
+    (err) => err.code === 'AUDITOR_MISMATCH' && err.statusCode === 403
+  );
+  assert.equal(calls.length, 0, 'must not reach the contract when the auditor mismatches');
+});
+
+test('a Freighter-only auditor cannot approve from the server', async () => {
+  const { service, calls } = build({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns')) {
+        return { rows: [campaignRow({ auditor_public_key: AUDITOR })] };
+      }
+      if (text.includes('FROM users')) {
+        return { rows: [userRow({ wallet_type: 'freighter', wallet_public_key: AUDITOR, wallet_secret_encrypted: null })] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  await assert.rejects(
+    () => service.approvePendingWithdrawal(CAMPAIGN_ID, 7, { approverId: 'auditor-1' }),
+    (err) => err.code === 'FREIGHTER_SIGNING_UNSUPPORTED' && err.statusCode === 501
+  );
+  assert.equal(calls.length, 0);
+});
+
+test('the auditor and platform accounts are distinct: approval signs with the auditor key', async () => {
+  const { service, calls } = build({
+    queryImpl: async (text) => {
+      if (text.includes('FROM campaigns')) {
+        return { rows: [campaignRow({ auditor_public_key: AUDITOR })] };
+      }
+      if (text.includes('FROM users')) {
+        return { rows: [userRow({ wallet_public_key: AUDITOR, wallet_secret_encrypted: 'auditor-secret' })] };
+      }
+      if (text.includes('UPDATE withdrawal_requests')) {
+        return { rows: [{ id: 'w-2', status: 'completed', amount: '9000.0000000' }] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  await service.approvePendingWithdrawal(CAMPAIGN_ID, 7, { approverId: 'auditor-1' });
+  assert.equal(calls[0].signerSecret, 'auditor-secret');
+  assert.notEqual(calls[0].signerSecret, process.env.PLATFORM_SECRET_KEY,
+    'approval must use the auditor key, not the platform key');
 });
 
 // ── live status ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #712

---

## Summary

Adds a defense-in-depth service-level auditor identity check in `approvePendingWithdrawal` so the loaded signer's wallet must match the campaign's configured `auditor_public_key`, preventing a non-auditor with a custodial wallet from bypassing the route middleware and signing on-chain.

## What changed

- **`contractTreasury.js`**: Added an explicit guard in `approvePendingWithdrawal` — after loading the auditor's custodial wallet, the function now verifies `auditor.walletPublicKey === campaign.auditor_public_key`. If they don't match, it throws a 403 `AUDITOR_MISMATCH` error before the contract is invoked.
- **`contractTreasury.test.js`**: Added 3 new tests and updated 2 existing tests:
  - ✅ Auditor wallet doesn't match campaign auditor key → 403 `AUDITOR_MISMATCH`
  - ✅ Freigher-only auditor cannot approve from the server → 501 `FREIGHTER_SIGNING_UNSUPPORTED`
  - ✅ Distinct auditor and platform accounts: approval signs with auditor key, not platform key
  - Updated existing approval tests to set `auditor_public_key: AUDITOR` on the campaign row so the service-level check is exercised
- **`.gitignore`**: Added `coverage/` to prevent test coverage output from being committed.

## Key design decisions

1. **Defense-in-depth**: The route middleware (`requireAuditor`) already checks that the caller's wallet matches the campaign auditor key. The new service-level check ensures that even if the service is called directly (bypassing the route), the auditor identity is verified. The contract itself enforces `auditor.require_auth()` on-chain as the ultimate guard.
2. **Conditional check**: The service-level check only fires when `campaign.auditor_public_key` is set, avoiding breaking backward compatibility for campaigns that may not have an auditor configured yet.
3. **No new error codes in `CONTRACT_ERRORS`**: `AUDITOR_MISMATCH` is a service-level error (not a Soroban contract error), so it's raised via the existing `fail()` utility without adding to the contract error ordinal map.

## Acceptance criteria checklist

- [x] **Implement an explicit auditor signing flow** — `approvePendingWithdrawal` uses `loadCustodialSigner(approverId, auditor, ...)` → decrypts the auditor's own wallet → passes `auditorSecret` as `signerSecret` to `soroban.invokeContract`
- [x] **Verify the signer matches the configured auditor address** — New service-level guard: `auditor.walletPublicKey !== campaign.auditor_public_key` → 403 `AUDITOR_MISMATCH`. Route middleware `requireAuditor` also checks at the HTTP layer.
- [x] **Add tests with distinct auditor and platform accounts** — Three new service tests cover auditor wallet mismatch (403), Freigher-only auditor rejection (501), and distinct auditor/platform key verification

## Test output & coverage

```
✔ 43 tests pass, 0 fail (24 service + 19 route)

File                  | % Stmts | % Branch | % Funcs | % Lines
routes/treasury.js    |   98.38 |    78.12 |     100 |   98.38
services/contractTreasury.js | 77.89 | 81.39 | 81.81 | 77.89
Overall               |   85.09 |     80.5 |    82.6 |   85.09
```

## Follow-ups

- The route-level `requireAuditor` middleware fetches the auditor key from the DB and compares it to the caller's `wallet_public_key`. This is already robust. Future work could cache the auditor key to avoid a DB round-trip per approval request.
- Consider adding an audit log entry when `AUDITOR_MISMATCH` fires to aid incident response.

## Security note

The contract's `approve_withdrawal` enforces `auditor.require_auth()` on-chain, so even without this service-level check, a wrong signer would cause a Soroban transaction failure. The new check provides an earlier, clearer rejection and prevents unnecessary RPC calls. The route middleware `requireAuditor` adds a third layer of verification.