### PR TITLE
fix(withdrawals): bind Freighter withdrawal signatures to server-gene…

### DIFF
--- a/backend/src/routes/withdrawals.js
+++ b/backend/src/routes/withdrawals.js
@@ -12,6 +12,9 @@ const {
   submitSignedWithdrawal,
   isXdrExpired,
   PLATFORM_PUBLIC_KEY,
+  validateSubmittedWithdrawalXdr,
+  validateWithdrawalForPlatformSigning,
+  WithdrawalValidationError,
 } = require('../services/stellarService');
 const { calculateCreatorShare } = require('../services/feeRegistry');
 const {
@@ -314,7 +317,7 @@ router.post('/request', requireAuth, withdrawalValidation, validateRequest, asyn
 
 router.post('/:id/approve/creator', requireAuth, async (req, res) => {
   const { rows: requests } = await db.query(
-    `SELECT wr.*, c.creator_id, c.status AS campaign_status
+    `SELECT wr.*, c.creator_id, c.wallet_public_key AS campaign_wallet_public_key, c.asset_type, c.status AS campaign_status
      FROM withdrawal_requests wr
      JOIN campaigns c ON c.id = wr.campaign_id
      WHERE wr.id = $1`,
@@ -351,24 +354,16 @@ router.post('/:id/approve/creator', requireAuth, async (req, res) => {
       const { signed_xdr } = req.body || {};
       if (!signed_xdr) return res.status(400).json({ error: 'signed_xdr is required for freighter users' });
 
-      // Validate the signed_xdr contains a valid signature from the creator's public key
-      try {
-        // validate signature by verifying at least one signature matches user's public key
-        const tx = require('@stellar/stellar-sdk').TransactionBuilder.fromXDR(signed_xdr, require('../config/stellar').networkPassphrase);
-        const signer = require('@stellar/stellar-sdk').Keypair.fromPublicKey(userRow.wallet_public_key);
-        const signatureValid = tx.signatures.some((decorated) => {
-          try {
-            return signer.verify(tx.hash(), decorated.signature());
-          } catch (_err) {
-            return false;
-          }
-        });
-        if (!signatureValid) {
-          return res.status(422).json({ error: 'Signed transaction does not include a valid signature by the creator' });
-        }
-      } catch (err) {
-        return res.status(422).json({ error: 'Invalid signed_xdr' });
-      }
+      // Validate the signed_xdr matches server-generated unsigned_xdr and approved parameters
+      validateSubmittedWithdrawalXdr({
+        signedXdr: signed_xdr,
+        unsignedXdr: requestRow.unsigned_xdr,
+        creatorPublicKey: userRow.wallet_public_key,
+        campaignWalletPublicKey: requestRow.campaign_wallet_public_key,
+        expectedDestination: requestRow.destination_key,
+        expectedAsset: requestRow.asset_type,
+        expectedAmount: requestRow.amount,
+      });
 
       signedXdr = signed_xdr;
     } else {
@@ -390,6 +385,19 @@ router.post('/:id/approve/creator', requireAuth, async (req, res) => {
       withdrawal_id: req.params.id,
       error: err.message,
     });
+    if (
+      err.name === 'WithdrawalValidationError' ||
+      err.isValidationError ||
+      err.statusCode === 422 ||
+      err.message?.includes('signed_xdr') ||
+      err.message?.includes('unsigned_xdr') ||
+      err.message?.includes('Signed transaction') ||
+      err.message?.includes('Transaction') ||
+      err.message?.includes('destination') ||
+      err.message?.includes('does not match')
+    ) {
+      return res.status(422).json({ error: err.message });
+    }
     return res.status(503).json({ error: 'Creator wallet signing is unavailable; retry shortly.' });
   }
 
@@ -433,7 +441,7 @@ const platformApproveHandler = async (req, res) => {
     await client.query('BEGIN');
 
     const { rows: requests } = await client.query(
-      `SELECT wr.*, c.status AS campaign_status
+      `SELECT wr.*, c.status AS campaign_status, c.wallet_public_key AS campaign_wallet_public_key, c.asset_type, c.creator_id
        FROM withdrawal_requests wr
        JOIN campaigns c ON c.id = wr.campaign_id
        WHERE wr.id = $1
@@ -471,6 +479,32 @@ const platformApproveHandler = async (req, res) => {
       );
       await client.query('COMMIT');
       return res.status(410).json({ error: 'Withdrawal XDR has expired' });
+    }
+
+    // Fetch creator's public key for signature validation
+    const { rows: creatorUserRows } = await client.query(
+      'SELECT wallet_public_key FROM users WHERE id = $1',
+      [requestRow.requested_by]
+    );
+    const creatorPublicKey = creatorUserRows[0]?.wallet_public_key;
+
+    // Validate source, destination, asset, amount, sequence, network, and operation set before platform signing
+    try {
+      validateWithdrawalForPlatformSigning({
+        xdr: requestRow.unsigned_xdr,
+        creatorPublicKey,
+        campaignWalletPublicKey: requestRow.campaign_wallet_public_key,
+        expectedDestination: requestRow.destination_key,
+        expectedAsset: requestRow.asset_type,
+        expectedAmount: requestRow.amount,
+      });
+    } catch (valErr) {
+      await client.query('ROLLBACK');
+      logger.error('Withdrawal validation failed before platform signing', {
+        withdrawal_id: req.params.id,
+        error: valErr.message,
+      });
+      return res.status(422).json({ error: valErr.message });
     }
 
     fullySignedXdr = signTransactionXdr({

--- a/backend/src/routes/withdrawals.test.js
+++ b/backend/src/routes/withdrawals.test.js
@@ -3,6 +3,16 @@ const assert = require('node:assert/strict');
 const express = require('express');
 const request = require('supertest');
 const proxyquire = require('proxyquire').noCallThru();
+const {
+  Keypair,
+  TransactionBuilder,
+  Asset,
+  Operation,
+  Networks,
+} = require('@stellar/stellar-sdk');
+const actualStellarService = require('../services/stellarService');
+
+const TESTNET_PASSPHRASE = Networks.TESTNET;
 
 function buildApp({ queryImpl, stellarImpl, referralImpl, userId = 'creator-1', role = 'creator', platformApproverUserId } = {}) {
   const prevApprover = process.env.PLATFORM_APPROVER_USER_ID;
@@ -16,12 +26,36 @@ function buildApp({ queryImpl, stellarImpl, referralImpl, userId = 'creator-1', 
       thresholds: { med_threshold: 2 },
       signers: [{ key: 'GCREATOR', weight: 1 }, { key: 'GPLATFORM', weight: 1 }],
     }),
-    signTransactionXdr: () => 'xdr-signed',
-    signatureCountFromXdr: () => 2,
+    signTransactionXdr: (params) => {
+      if (params && typeof params.xdr === 'string' && params.xdr.startsWith('AAAA')) {
+        return actualStellarService.signTransactionXdr(params);
+      }
+      return 'xdr-signed';
+    },
+    signatureCountFromXdr: (xdr) => {
+      if (typeof xdr === 'string' && xdr.startsWith('AAAA')) {
+        return actualStellarService.signatureCountFromXdr(xdr);
+      }
+      return 2;
+    },
     submitSignedWithdrawal: async () => 'tx-hash',
     // Default: XDR is not expired. Override in specific tests via stellarImpl.
-    isXdrExpired: () => false,
+    isXdrExpired: (xdr) => {
+      if (typeof xdr === 'string' && xdr.startsWith('AAAA')) {
+        return actualStellarService.isXdrExpired(xdr);
+      }
+      return false;
+    },
     PLATFORM_PUBLIC_KEY: 'GPLATFORM',
+    validateSubmittedWithdrawalXdr: (params) => {
+      return actualStellarService.validateSubmittedWithdrawalXdr(params);
+    },
+    validateWithdrawalForPlatformSigning: (params) => {
+      if (params && typeof params.xdr === 'string' && params.xdr.startsWith('AAAA')) {
+        return actualStellarService.validateWithdrawalForPlatformSigning(params);
+      }
+      return true;
+    },
     ...stellarImpl,
   };
 
@@ -864,4 +898,730 @@ test('POST /api/withdrawals/:id/approve/platform settles the commissions it subm
   assert.equal(settled.length, 1);
   assert.equal(settled[0].referral_link_id, 'link-1');
   assert.equal(settled[0].commission_owed, '60.0000000');
+});
+
+function buildTestWithdrawalXdr({
+  campaignKeypair,
+  destinationKeypair,
+  amount = '10.0000000',
+  asset = Asset.native(),
+  operations = null,
+  sequence = '100',
+}) {
+  const account = {
+    accountId: () => campaignKeypair.publicKey(),
+    sequenceNumber: () => sequence,
+    incrementSequenceNumber: () => {},
+  };
+
+  const builder = new TransactionBuilder(account, {
+    fee: '100',
+    networkPassphrase: TESTNET_PASSPHRASE,
+  });
+
+  if (operations) {
+    for (const op of operations) {
+      builder.addOperation(op);
+    }
+  } else {
+    builder.addOperation(
+      Operation.payment({
+        destination: destinationKeypair.publicKey(),
+        asset,
+        amount: String(amount),
+      })
+    );
+  }
+
+  const tx = builder.setTimeout(3600).build();
+  return tx.toXDR();
+}
+
+test('POST /api/withdrawals/:id/approve/creator (Freighter) succeeds when signed_xdr matches server-generated unsigned_xdr', async () => {
+  const campaignKeypair = Keypair.random();
+  const creatorKeypair = Keypair.random();
+  const destinationKeypair = Keypair.random();
+
+  const unsignedXdr = buildTestWithdrawalXdr({
+    campaignKeypair,
+    destinationKeypair,
+    amount: '10.0000000',
+  });
+
+  const tx = TransactionBuilder.fromXDR(unsignedXdr, TESTNET_PASSPHRASE);
+  tx.sign(creatorKeypair);
+  const signedXdr = tx.toXDR();
+
+  const { app, cleanup } = buildApp({
+    userId: 'creator-1',
+    queryImpl: async (text) => {
+      if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
+      if (text.includes('SELECT creator_id FROM campaigns WHERE id')) {
+        return { rows: [{ creator_id: 'creator-1' }] };
+      }
+      if (text.includes('FROM withdrawal_requests wr')) {
+        return {
+          rows: [{
+            id: 'w-1',
+            status: 'pending',
+            creator_signed: false,
+            platform_signed: false,
+            unsigned_xdr: unsignedXdr,
+            campaign_id: '11111111-1111-1111-1111-111111111111',
+            campaign_wallet_public_key: campaignKeypair.publicKey(),
+            destination_key: destinationKeypair.publicKey(),
+            amount: '10.0000000',
+            asset_type: 'XLM',
+            campaign_status: 'active',
+          }],
+        };
+      }
+      if (text.includes('wallet_secret_encrypted') && text.includes('FROM users')) {
+        return {
+          rows: [{
+            wallet_secret_encrypted: null,
+            wallet_public_key: creatorKeypair.publicKey(),
+            wallet_type: 'freighter',
+          }],
+        };
+      }
+      if (text.includes('UPDATE withdrawal_requests') && text.includes('creator_signed = TRUE')) {
+        return { rows: [{ id: 'w-1', creator_signed: true, unsigned_xdr: signedXdr }] };
+      }
+      if (text.includes('INSERT INTO withdrawal_approval_events')) return { rows: [] };
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/w-1/approve/creator')
+    .set('Authorization', 'Bearer token')
+    .send({ signed_xdr: signedXdr });
+
+  cleanup();
+  assert.equal(response.status, 200);
+  assert.equal(response.body.creator_signed, true);
+});
+
+test('POST /api/withdrawals/:id/approve/creator (Freighter) rejects missing signed_xdr with 400', async () => {
+  const { app, cleanup } = buildApp({
+    userId: 'creator-1',
+    queryImpl: async (text) => {
+      if (text.includes('SELECT creator_id FROM campaigns WHERE id')) {
+        return { rows: [{ creator_id: 'creator-1' }] };
+      }
+      if (text.includes('FROM withdrawal_requests wr')) {
+        return {
+          rows: [{
+            id: 'w-1',
+            status: 'pending',
+            creator_signed: false,
+            platform_signed: false,
+            unsigned_xdr: 'xdr-base',
+            campaign_id: '11111111-1111-1111-1111-111111111111',
+            campaign_status: 'active',
+          }],
+        };
+      }
+      if (text.includes('wallet_secret_encrypted') && text.includes('FROM users')) {
+        return {
+          rows: [{
+            wallet_secret_encrypted: null,
+            wallet_public_key: 'GCREATOR',
+            wallet_type: 'freighter',
+          }],
+        };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/w-1/approve/creator')
+    .set('Authorization', 'Bearer token')
+    .send({});
+
+  cleanup();
+  assert.equal(response.status, 400);
+  assert.match(response.body.error, /signed_xdr is required/i);
+});
+
+test('POST /api/withdrawals/:id/approve/creator (Freighter) rejects tampered XDR with modified amount with 422', async () => {
+  const campaignKeypair = Keypair.random();
+  const creatorKeypair = Keypair.random();
+  const destinationKeypair = Keypair.random();
+
+  const serverUnsignedXdr = buildTestWithdrawalXdr({
+    campaignKeypair,
+    destinationKeypair,
+    amount: '10.0000000',
+  });
+
+  // Tampered transaction requesting 100 XLM instead of 10 XLM
+  const tamperedUnsignedXdr = buildTestWithdrawalXdr({
+    campaignKeypair,
+    destinationKeypair,
+    amount: '100.0000000',
+  });
+
+  const tx = TransactionBuilder.fromXDR(tamperedUnsignedXdr, TESTNET_PASSPHRASE);
+  tx.sign(creatorKeypair);
+  const tamperedSignedXdr = tx.toXDR();
+
+  const { app, cleanup } = buildApp({
+    userId: 'creator-1',
+    queryImpl: async (text) => {
+      if (text.includes('SELECT creator_id FROM campaigns WHERE id')) {
+        return { rows: [{ creator_id: 'creator-1' }] };
+      }
+      if (text.includes('FROM withdrawal_requests wr')) {
+        return {
+          rows: [{
+            id: 'w-1',
+            status: 'pending',
+            creator_signed: false,
+            platform_signed: false,
+            unsigned_xdr: serverUnsignedXdr,
+            campaign_id: '11111111-1111-1111-1111-111111111111',
+            campaign_wallet_public_key: campaignKeypair.publicKey(),
+            destination_key: destinationKeypair.publicKey(),
+            amount: '10.0000000',
+            asset_type: 'XLM',
+            campaign_status: 'active',
+          }],
+        };
+      }
+      if (text.includes('wallet_secret_encrypted') && text.includes('FROM users')) {
+        return {
+          rows: [{
+            wallet_secret_encrypted: null,
+            wallet_public_key: creatorKeypair.publicKey(),
+            wallet_type: 'freighter',
+          }],
+        };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/w-1/approve/creator')
+    .set('Authorization', 'Bearer token')
+    .send({ signed_xdr: tamperedSignedXdr });
+
+  cleanup();
+  assert.equal(response.status, 422);
+  assert.match(response.body.error, /Signed transaction does not match/i);
+});
+
+test('POST /api/withdrawals/:id/approve/creator (Freighter) rejects arbitrary destination with 422', async () => {
+  const campaignKeypair = Keypair.random();
+  const creatorKeypair = Keypair.random();
+  const approvedDestination = Keypair.random();
+  const attackerDestination = Keypair.random();
+
+  const serverUnsignedXdr = buildTestWithdrawalXdr({
+    campaignKeypair,
+    destinationKeypair: approvedDestination,
+    amount: '10.0000000',
+  });
+
+  // Tampered transaction targeting arbitrary attacker destination
+  const tamperedUnsignedXdr = buildTestWithdrawalXdr({
+    campaignKeypair,
+    destinationKeypair: attackerDestination,
+    amount: '10.0000000',
+  });
+
+  const tx = TransactionBuilder.fromXDR(tamperedUnsignedXdr, TESTNET_PASSPHRASE);
+  tx.sign(creatorKeypair);
+  const tamperedSignedXdr = tx.toXDR();
+
+  const { app, cleanup } = buildApp({
+    userId: 'creator-1',
+    queryImpl: async (text) => {
+      if (text.includes('SELECT creator_id FROM campaigns WHERE id')) {
+        return { rows: [{ creator_id: 'creator-1' }] };
+      }
+      if (text.includes('FROM withdrawal_requests wr')) {
+        return {
+          rows: [{
+            id: 'w-1',
+            status: 'pending',
+            creator_signed: false,
+            platform_signed: false,
+            unsigned_xdr: serverUnsignedXdr,
+            campaign_id: '11111111-1111-1111-1111-111111111111',
+            campaign_wallet_public_key: campaignKeypair.publicKey(),
+            destination_key: approvedDestination.publicKey(),
+            amount: '10.0000000',
+            asset_type: 'XLM',
+            campaign_status: 'active',
+          }],
+        };
+      }
+      if (text.includes('wallet_secret_encrypted') && text.includes('FROM users')) {
+        return {
+          rows: [{
+            wallet_secret_encrypted: null,
+            wallet_public_key: creatorKeypair.publicKey(),
+            wallet_type: 'freighter',
+          }],
+        };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/w-1/approve/creator')
+    .set('Authorization', 'Bearer token')
+    .send({ signed_xdr: tamperedSignedXdr });
+
+  cleanup();
+  assert.equal(response.status, 422);
+  assert.match(response.body.error, /Signed transaction does not match|destination does not match/i);
+});
+
+test('POST /api/withdrawals/:id/approve/creator (Freighter) rejects arbitrary asset with 422', async () => {
+  const campaignKeypair = Keypair.random();
+  const creatorKeypair = Keypair.random();
+  const destinationKeypair = Keypair.random();
+
+  const serverUnsignedXdr = buildTestWithdrawalXdr({
+    campaignKeypair,
+    destinationKeypair,
+    amount: '10.0000000',
+    asset: Asset.native(),
+  });
+
+  const usdcAsset = new Asset('USDC', 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5');
+  const tamperedUnsignedXdr = buildTestWithdrawalXdr({
+    campaignKeypair,
+    destinationKeypair,
+    amount: '10.0000000',
+    asset: usdcAsset,
+  });
+
+  const tx = TransactionBuilder.fromXDR(tamperedUnsignedXdr, TESTNET_PASSPHRASE);
+  tx.sign(creatorKeypair);
+  const tamperedSignedXdr = tx.toXDR();
+
+  const { app, cleanup } = buildApp({
+    userId: 'creator-1',
+    queryImpl: async (text) => {
+      if (text.includes('SELECT creator_id FROM campaigns WHERE id')) {
+        return { rows: [{ creator_id: 'creator-1' }] };
+      }
+      if (text.includes('FROM withdrawal_requests wr')) {
+        return {
+          rows: [{
+            id: 'w-1',
+            status: 'pending',
+            creator_signed: false,
+            platform_signed: false,
+            unsigned_xdr: serverUnsignedXdr,
+            campaign_id: '11111111-1111-1111-1111-111111111111',
+            campaign_wallet_public_key: campaignKeypair.publicKey(),
+            destination_key: destinationKeypair.publicKey(),
+            amount: '10.0000000',
+            asset_type: 'XLM',
+            campaign_status: 'active',
+          }],
+        };
+      }
+      if (text.includes('wallet_secret_encrypted') && text.includes('FROM users')) {
+        return {
+          rows: [{
+            wallet_secret_encrypted: null,
+            wallet_public_key: creatorKeypair.publicKey(),
+            wallet_type: 'freighter',
+          }],
+        };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/w-1/approve/creator')
+    .set('Authorization', 'Bearer token')
+    .send({ signed_xdr: tamperedSignedXdr });
+
+  cleanup();
+  assert.equal(response.status, 422);
+  assert.match(response.body.error, /Signed transaction does not match/i);
+});
+
+test('POST /api/withdrawals/:id/approve/creator (Freighter) rejects invalid signature with 422', async () => {
+  const campaignKeypair = Keypair.random();
+  const creatorKeypair = Keypair.random();
+  const wrongKeypair = Keypair.random();
+  const destinationKeypair = Keypair.random();
+
+  const unsignedXdr = buildTestWithdrawalXdr({
+    campaignKeypair,
+    destinationKeypair,
+    amount: '10.0000000',
+  });
+
+  // Signed by someone else, not creator
+  const tx = TransactionBuilder.fromXDR(unsignedXdr, TESTNET_PASSPHRASE);
+  tx.sign(wrongKeypair);
+  const signedXdr = tx.toXDR();
+
+  const { app, cleanup } = buildApp({
+    userId: 'creator-1',
+    queryImpl: async (text) => {
+      if (text.includes('SELECT creator_id FROM campaigns WHERE id')) {
+        return { rows: [{ creator_id: 'creator-1' }] };
+      }
+      if (text.includes('FROM withdrawal_requests wr')) {
+        return {
+          rows: [{
+            id: 'w-1',
+            status: 'pending',
+            creator_signed: false,
+            platform_signed: false,
+            unsigned_xdr: unsignedXdr,
+            campaign_id: '11111111-1111-1111-1111-111111111111',
+            campaign_wallet_public_key: campaignKeypair.publicKey(),
+            destination_key: destinationKeypair.publicKey(),
+            amount: '10.0000000',
+            asset_type: 'XLM',
+            campaign_status: 'active',
+          }],
+        };
+      }
+      if (text.includes('wallet_secret_encrypted') && text.includes('FROM users')) {
+        return {
+          rows: [{
+            wallet_secret_encrypted: null,
+            wallet_public_key: creatorKeypair.publicKey(),
+            wallet_type: 'freighter',
+          }],
+        };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/w-1/approve/creator')
+    .set('Authorization', 'Bearer token')
+    .send({ signed_xdr: signedXdr });
+
+  cleanup();
+  assert.equal(response.status, 422);
+  assert.match(response.body.error, /does not include a valid signature by the creator/i);
+});
+
+test('POST /api/withdrawals/:id/approve/creator (Freighter) rejects non-payment operation with 422', async () => {
+  const campaignKeypair = Keypair.random();
+  const creatorKeypair = Keypair.random();
+  const destinationKeypair = Keypair.random();
+
+  const serverUnsignedXdr = buildTestWithdrawalXdr({
+    campaignKeypair,
+    destinationKeypair,
+    amount: '10.0000000',
+  });
+
+  // Tampered transaction with accountMerge
+  const tamperedUnsignedXdr = buildTestWithdrawalXdr({
+    campaignKeypair,
+    destinationKeypair,
+    operations: [
+      Operation.accountMerge({
+        destination: destinationKeypair.publicKey(),
+      }),
+    ],
+  });
+
+  const tx = TransactionBuilder.fromXDR(tamperedUnsignedXdr, TESTNET_PASSPHRASE);
+  tx.sign(creatorKeypair);
+  const tamperedSignedXdr = tx.toXDR();
+
+  const { app, cleanup } = buildApp({
+    userId: 'creator-1',
+    queryImpl: async (text) => {
+      if (text.includes('SELECT creator_id FROM campaigns WHERE id')) {
+        return { rows: [{ creator_id: 'creator-1' }] };
+      }
+      if (text.includes('FROM withdrawal_requests wr')) {
+        return {
+          rows: [{
+            id: 'w-1',
+            status: 'pending',
+            creator_signed: false,
+            platform_signed: false,
+            unsigned_xdr: serverUnsignedXdr,
+            campaign_id: '11111111-1111-1111-1111-111111111111',
+            campaign_wallet_public_key: campaignKeypair.publicKey(),
+            destination_key: destinationKeypair.publicKey(),
+            amount: '10.0000000',
+            asset_type: 'XLM',
+            campaign_status: 'active',
+          }],
+        };
+      }
+      if (text.includes('wallet_secret_encrypted') && text.includes('FROM users')) {
+        return {
+          rows: [{
+            wallet_secret_encrypted: null,
+            wallet_public_key: creatorKeypair.publicKey(),
+            wallet_type: 'freighter',
+          }],
+        };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/w-1/approve/creator')
+    .set('Authorization', 'Bearer token')
+    .send({ signed_xdr: tamperedSignedXdr });
+
+  cleanup();
+  assert.equal(response.status, 422);
+  assert.match(response.body.error, /Signed transaction does not match|only payment operations are allowed/i);
+});
+
+test('POST /api/withdrawals/:id/approve/platform validates real XDR parameters before platform signing', async () => {
+  const campaignKeypair = Keypair.random();
+  const creatorKeypair = Keypair.random();
+  const destinationKeypair = Keypair.random();
+
+  const unsignedXdr = buildTestWithdrawalXdr({
+    campaignKeypair,
+    destinationKeypair,
+    amount: '10.0000000',
+  });
+
+  const tx = TransactionBuilder.fromXDR(unsignedXdr, TESTNET_PASSPHRASE);
+  tx.sign(creatorKeypair);
+  const creatorSignedXdr = tx.toXDR();
+
+  const { app, cleanup } = buildApp({
+    role: 'admin',
+    queryImpl: async (text) => {
+      if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
+      if (text.includes("SELECT role, is_admin FROM users WHERE id")) {
+        return { rows: [{ role: 'admin', is_admin: true }] };
+      }
+      if (text.includes('SELECT wr.*, c.status')) {
+        return {
+          rows: [{
+            id: 'w-1',
+            status: 'pending',
+            creator_signed: true,
+            platform_signed: false,
+            unsigned_xdr: creatorSignedXdr,
+            campaign_id: '11111111-1111-1111-1111-111111111111',
+            campaign_wallet_public_key: campaignKeypair.publicKey(),
+            destination_key: destinationKeypair.publicKey(),
+            amount: '10.0000000',
+            asset_type: 'XLM',
+            campaign_status: 'active',
+            requested_by: 'creator-1',
+          }],
+        };
+      }
+      if (text.includes('SELECT wallet_public_key FROM users WHERE id')) {
+        return { rows: [{ wallet_public_key: creatorKeypair.publicKey() }] };
+      }
+      if (text.includes('UPDATE withdrawal_requests') && text.includes("status = 'approved'")) {
+        return { rows: [{ id: 'w-1', status: 'approved' }] };
+      }
+      if (text.includes('UPDATE withdrawal_requests') && text.includes("status = 'submitted'")) {
+        return { rows: [{ id: 'w-1', status: 'submitted', tx_hash: 'tx-hash' }] };
+      }
+      if (text.includes('INSERT INTO withdrawal_approval_events')) return { rows: [] };
+      if (text.includes('UPDATE stellar_transactions')) return { rows: [] };
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/w-1/approve/platform')
+    .set('Authorization', 'Bearer token')
+    .send({});
+
+  cleanup();
+  assert.equal(response.status, 200);
+  assert.equal(response.body.status, 'submitted');
+});
+
+test('POST /api/withdrawals/:id/approve/platform rejects tampered arbitrary destination in stored XDR with 422', async () => {
+  const campaignKeypair = Keypair.random();
+  const creatorKeypair = Keypair.random();
+  const approvedDestination = Keypair.random();
+  const attackerDestination = Keypair.random();
+
+  // Attacker-directed XDR stored in DB
+  const attackerXdr = buildTestWithdrawalXdr({
+    campaignKeypair,
+    destinationKeypair: attackerDestination,
+    amount: '10.0000000',
+  });
+
+  const tx = TransactionBuilder.fromXDR(attackerXdr, TESTNET_PASSPHRASE);
+  tx.sign(creatorKeypair);
+  const creatorSignedAttackerXdr = tx.toXDR();
+
+  const { app, cleanup } = buildApp({
+    role: 'admin',
+    queryImpl: async (text) => {
+      if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
+      if (text.includes("SELECT role, is_admin FROM users WHERE id")) {
+        return { rows: [{ role: 'admin', is_admin: true }] };
+      }
+      if (text.includes('SELECT wr.*, c.status')) {
+        return {
+          rows: [{
+            id: 'w-1',
+            status: 'pending',
+            creator_signed: true,
+            platform_signed: false,
+            unsigned_xdr: creatorSignedAttackerXdr,
+            campaign_id: '11111111-1111-1111-1111-111111111111',
+            campaign_wallet_public_key: campaignKeypair.publicKey(),
+            destination_key: approvedDestination.publicKey(), // approved destination is different!
+            amount: '10.0000000',
+            asset_type: 'XLM',
+            campaign_status: 'active',
+            requested_by: 'creator-1',
+          }],
+        };
+      }
+      if (text.includes('SELECT wallet_public_key FROM users WHERE id')) {
+        return { rows: [{ wallet_public_key: creatorKeypair.publicKey() }] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/w-1/approve/platform')
+    .set('Authorization', 'Bearer token')
+    .send({});
+
+  cleanup();
+  assert.equal(response.status, 422);
+  assert.match(response.body.error, /destination does not match approved withdrawal destination/i);
+});
+
+test('POST /api/withdrawals/:id/approve/platform rejects stored XDR missing creator signature with 422', async () => {
+  const campaignKeypair = Keypair.random();
+  const creatorKeypair = Keypair.random();
+  const destinationKeypair = Keypair.random();
+
+  const unsignedXdr = buildTestWithdrawalXdr({
+    campaignKeypair,
+    destinationKeypair,
+    amount: '10.0000000',
+  });
+
+  const { app, cleanup } = buildApp({
+    role: 'admin',
+    queryImpl: async (text) => {
+      if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
+      if (text.includes("SELECT role, is_admin FROM users WHERE id")) {
+        return { rows: [{ role: 'admin', is_admin: true }] };
+      }
+      if (text.includes('SELECT wr.*, c.status')) {
+        return {
+          rows: [{
+            id: 'w-1',
+            status: 'pending',
+            creator_signed: true,
+            platform_signed: false,
+            unsigned_xdr: unsignedXdr, // Unsigned!
+            campaign_id: '11111111-1111-1111-1111-111111111111',
+            campaign_wallet_public_key: campaignKeypair.publicKey(),
+            destination_key: destinationKeypair.publicKey(),
+            amount: '10.0000000',
+            asset_type: 'XLM',
+            campaign_status: 'active',
+            requested_by: 'creator-1',
+          }],
+        };
+      }
+      if (text.includes('SELECT wallet_public_key FROM users WHERE id')) {
+        return { rows: [{ wallet_public_key: creatorKeypair.publicKey() }] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/w-1/approve/platform')
+    .set('Authorization', 'Bearer token')
+    .send({});
+
+  cleanup();
+  assert.equal(response.status, 422);
+  assert.match(response.body.error, /missing a valid creator signature/i);
+});
+
+test('POST /api/withdrawals/:id/approve/platform rejects stored XDR with non-payment operation with 422', async () => {
+  const campaignKeypair = Keypair.random();
+  const creatorKeypair = Keypair.random();
+  const destinationKeypair = Keypair.random();
+
+  const mergeXdr = buildTestWithdrawalXdr({
+    campaignKeypair,
+    destinationKeypair,
+    operations: [
+      Operation.accountMerge({
+        destination: destinationKeypair.publicKey(),
+      }),
+    ],
+  });
+
+  const tx = TransactionBuilder.fromXDR(mergeXdr, TESTNET_PASSPHRASE);
+  tx.sign(creatorKeypair);
+  const creatorSignedMergeXdr = tx.toXDR();
+
+  const { app, cleanup } = buildApp({
+    role: 'admin',
+    queryImpl: async (text) => {
+      if (text === 'BEGIN' || text === 'COMMIT' || text === 'ROLLBACK') return { rows: [] };
+      if (text.includes("SELECT role, is_admin FROM users WHERE id")) {
+        return { rows: [{ role: 'admin', is_admin: true }] };
+      }
+      if (text.includes('SELECT wr.*, c.status')) {
+        return {
+          rows: [{
+            id: 'w-1',
+            status: 'pending',
+            creator_signed: true,
+            platform_signed: false,
+            unsigned_xdr: creatorSignedMergeXdr,
+            campaign_id: '11111111-1111-1111-1111-111111111111',
+            campaign_wallet_public_key: campaignKeypair.publicKey(),
+            destination_key: destinationKeypair.publicKey(),
+            amount: '10.0000000',
+            asset_type: 'XLM',
+            campaign_status: 'active',
+            requested_by: 'creator-1',
+          }],
+        };
+      }
+      if (text.includes('SELECT wallet_public_key FROM users WHERE id')) {
+        return { rows: [{ wallet_public_key: creatorKeypair.publicKey() }] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const response = await request(app)
+    .post('/api/withdrawals/w-1/approve/platform')
+    .set('Authorization', 'Bearer token')
+    .send({});
+
+  cleanup();
+  assert.equal(response.status, 422);
+  assert.match(response.body.error, /only payment operations are allowed/i);
 });

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -699,6 +699,219 @@ function isXdrExpired(xdr) {
   }
 }
 
+class WithdrawalValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'WithdrawalValidationError';
+    this.statusCode = 422;
+    this.isValidationError = true;
+  }
+}
+
+function assetMatches(asset, expectedAssetCode) {
+  if (!asset || !expectedAssetCode) return true;
+  if (expectedAssetCode === 'XLM') {
+    return typeof asset.isNative === 'function' ? asset.isNative() : asset.code === 'XLM' || asset.type === 'native';
+  }
+  const code = typeof asset.getCode === 'function' ? asset.getCode() : asset.code;
+  return code === expectedAssetCode;
+}
+
+/**
+ * Validates that submitted signed XDR matches the server-generated unsigned XDR
+ * and complies with all expected parameters (source, destination, asset, amount, sequence, network, operations, creator signature).
+ */
+function validateSubmittedWithdrawalXdr({
+  signedXdr,
+  unsignedXdr,
+  creatorPublicKey,
+  campaignWalletPublicKey,
+  expectedDestination,
+  expectedAsset,
+  expectedAmount,
+}) {
+  if (!signedXdr) {
+    throw new WithdrawalValidationError('signed_xdr is required for freighter users');
+  }
+  if (!unsignedXdr) {
+    throw new WithdrawalValidationError('Server-generated unsigned_xdr is required to verify withdrawal');
+  }
+
+  let signedTx;
+  try {
+    signedTx = TransactionBuilder.fromXDR(signedXdr, networkPassphrase);
+  } catch (err) {
+    throw new WithdrawalValidationError('Invalid signed_xdr');
+  }
+
+  let unsignedTx;
+  try {
+    unsignedTx = TransactionBuilder.fromXDR(unsignedXdr, networkPassphrase);
+  } catch (err) {
+    throw new WithdrawalValidationError('Invalid server-generated unsigned_xdr');
+  }
+
+  // 1. Compare the signed transaction body/hash to the server-generated unsigned XDR
+  if (signedTx.hash().toString('hex') !== unsignedTx.hash().toString('hex')) {
+    throw new WithdrawalValidationError('Signed transaction does not match the server-generated withdrawal transaction');
+  }
+
+  // 2. Validate source
+  if (signedTx.source !== unsignedTx.source) {
+    throw new WithdrawalValidationError('Signed transaction source does not match unsigned transaction');
+  }
+  if (campaignWalletPublicKey && signedTx.source !== campaignWalletPublicKey) {
+    throw new WithdrawalValidationError('Transaction source account does not match campaign wallet');
+  }
+
+  // 3. Validate sequence
+  if (String(signedTx.sequence) !== String(unsignedTx.sequence)) {
+    throw new WithdrawalValidationError('Signed transaction sequence does not match unsigned transaction');
+  }
+
+  // 4. Validate operations
+  if (!signedTx.operations || signedTx.operations.length === 0) {
+    throw new WithdrawalValidationError('Transaction contains no operations');
+  }
+
+  for (const op of signedTx.operations) {
+    if (op.type !== 'payment') {
+      throw new WithdrawalValidationError(`Invalid operation type "${op.type}": only payment operations are allowed`);
+    }
+    if (expectedAsset && !assetMatches(op.asset, expectedAsset)) {
+      throw new WithdrawalValidationError('Transaction operation asset does not match campaign asset');
+    }
+  }
+
+  // Validate destination of primary payout
+  if (expectedDestination && signedTx.operations[0].destination !== expectedDestination) {
+    throw new WithdrawalValidationError('Transaction destination does not match approved withdrawal destination');
+  }
+
+  // Validate amounts
+  const firstAmount = parseFloat(signedTx.operations[0].amount);
+  if (isNaN(firstAmount) || firstAmount <= 0) {
+    throw new WithdrawalValidationError('Transaction payment amount must be greater than 0');
+  }
+
+  const totalAmount = signedTx.operations.reduce((sum, op) => sum + parseFloat(op.amount), 0);
+  if (expectedAmount && parseFloat(totalAmount.toFixed(7)) > parseFloat(expectedAmount)) {
+    throw new WithdrawalValidationError('Transaction total amount exceeds approved withdrawal amount');
+  }
+
+  // 5. Validate creator signature
+  if (!signedTx.signatures || signedTx.signatures.length === 0) {
+    throw new WithdrawalValidationError('Signed transaction does not include any signatures');
+  }
+
+  if (creatorPublicKey) {
+    let signer;
+    try {
+      signer = Keypair.fromPublicKey(creatorPublicKey);
+    } catch (err) {
+      throw new WithdrawalValidationError('Invalid creator public key');
+    }
+    const signatureValid = signedTx.signatures.some((decorated) => {
+      try {
+        return signer.verify(signedTx.hash(), decorated.signature());
+      } catch (_err) {
+        return false;
+      }
+    });
+    if (!signatureValid) {
+      throw new WithdrawalValidationError('Signed transaction does not include a valid signature by the creator');
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Validates a withdrawal transaction before platform signs it.
+ * Validates source, destination, asset, amount, sequence, network, operation set, and creator signature.
+ */
+function validateWithdrawalForPlatformSigning({
+  xdr,
+  creatorPublicKey,
+  campaignWalletPublicKey,
+  expectedDestination,
+  expectedAsset,
+  expectedAmount,
+}) {
+  if (!xdr) {
+    throw new WithdrawalValidationError('Withdrawal transaction XDR is required');
+  }
+
+  let tx;
+  try {
+    tx = TransactionBuilder.fromXDR(xdr, networkPassphrase);
+  } catch (err) {
+    throw new WithdrawalValidationError('Invalid withdrawal transaction XDR');
+  }
+
+  // Validate source
+  if (campaignWalletPublicKey && tx.source !== campaignWalletPublicKey) {
+    throw new WithdrawalValidationError('Transaction source account does not match campaign wallet');
+  }
+
+  // Validate sequence
+  if (!tx.sequence) {
+    throw new WithdrawalValidationError('Transaction sequence number is missing');
+  }
+
+  // Validate operations
+  if (!tx.operations || tx.operations.length === 0) {
+    throw new WithdrawalValidationError('Transaction contains no operations');
+  }
+
+  for (const op of tx.operations) {
+    if (op.type !== 'payment') {
+      throw new WithdrawalValidationError(`Invalid operation type "${op.type}": only payment operations are allowed`);
+    }
+    if (expectedAsset && !assetMatches(op.asset, expectedAsset)) {
+      throw new WithdrawalValidationError('Transaction operation asset does not match campaign asset');
+    }
+  }
+
+  // Validate primary destination
+  if (expectedDestination && tx.operations[0].destination !== expectedDestination) {
+    throw new WithdrawalValidationError('Transaction destination does not match approved withdrawal destination');
+  }
+
+  // Validate amounts
+  const firstAmount = parseFloat(tx.operations[0].amount);
+  if (isNaN(firstAmount) || firstAmount <= 0) {
+    throw new WithdrawalValidationError('Transaction payment amount must be greater than 0');
+  }
+
+  const totalAmount = tx.operations.reduce((sum, op) => sum + parseFloat(op.amount), 0);
+  if (expectedAmount && parseFloat(totalAmount.toFixed(7)) > parseFloat(expectedAmount)) {
+    throw new WithdrawalValidationError('Transaction total amount exceeds approved withdrawal amount');
+  }
+
+  // Validate creator signature
+  if (creatorPublicKey) {
+    let signer;
+    try {
+      signer = Keypair.fromPublicKey(creatorPublicKey);
+    } catch (err) {
+      throw new WithdrawalValidationError('Invalid creator public key');
+    }
+    const signatureValid = tx.signatures && tx.signatures.some((decorated) => {
+      try {
+        return signer.verify(tx.hash(), decorated.signature());
+      } catch (_err) {
+        return false;
+      }
+    });
+    if (!signatureValid) {
+      throw new WithdrawalValidationError('Transaction is missing a valid creator signature');
+    }
+  }
+
+  return true;
+}
+
 async function submitPreparedTransaction(xdr) {
   const tx = TransactionBuilder.fromXDR(xdr, networkPassphrase);
   const result = await server.submitTransaction(tx);
@@ -1139,4 +1352,7 @@ module.exports = {
   submitDisputeRefund,
   buildBatchRefundTransaction,
   ARBITRATOR_PUBLIC_KEY: ARBITRATOR_KEYPAIR.publicKey(),
+  validateSubmittedWithdrawalXdr,
+  validateWithdrawalForPlatformSigning,
+  WithdrawalValidationError,
 };


### PR DESCRIPTION
…rated XDR 

## Description
Fixes #698 by strictly binding Freighter withdrawal signatures to the server-generated unsigned XDR and validating all transaction fields before creator approval recording and platform signing.
#### 1. Server-Generated Unsigned XDR Comparison (`validateSubmittedWithdrawalXdr`)
- When a Freighter creator approves a withdrawal (`POST /api/withdrawals/:id/approve/creator`), the backend decodes the incoming `signed_xdr` and compares its transaction hash (`signedTx.hash()`) directly against the server-generated `unsigned_xdr` stored in the database.
- Validates that source account, sequence number, network, asset type, and destination match the withdrawal request and campaign wallet.
- Ensures all operations are valid `payment` operations and that the primary destination and total amounts strictly match the approved parameters.
- Validates the creator's cryptographic signature against their public key.
#### 2. Defense-in-Depth Pre-Signing Validation (`validateWithdrawalForPlatformSigning`)
- Before the platform signs `requestRow.unsigned_xdr` with `PLATFORM_SECRET_KEY` in `platformApproveHandler`, the backend verifies:
  - Source account matches the campaign wallet.
  - Operation set contains only `payment` operations.
  - Primary destination matches `requestRow.destination_key`.
  - Assets match `campaign.asset_type`.
  - Payout amounts do not exceed the approved request amount.
  - Creator's signature is verified on the stored transaction.
#### 3. Verification & Test Coverage
- Added automated test cases in `backend/src/routes/withdrawals.test.js`:
  - Freighter creator approval with valid signed XDR matching server-generated unsigned XDR (200 OK).
  - Rejection of missing `signed_xdr` for Freighter users (400 Bad Request).
  - Rejection of tampered XDR with modified payment amount (422 Unprocessable Entity).
  - Rejection of tampered XDR targeting an arbitrary destination (422 Unprocessable Entity).
  - Rejection of tampered XDR with mismatched asset (422 Unprocessable Entity).
  - Rejection of signed XDR with non-payment operations (422 Unprocessable Entity).
  - Rejection of signed XDR with invalid / non-creator signatures (422 Unprocessable Entity).
  - Platform approval validation with real Stellar transactions (200 OK).
  - Platform rejection of stored XDR with tampered arbitrary destination (422 Unprocessable Entity).
  - Platform rejection of stored XDR missing creator signature (422 Unprocessable Entity).
  - Platform rejection of stored XDR with non-payment operation (422 Unprocessable Entity).


## Acceptance Criteria

| Criteria | Status |
|----------|--------|
| Tier `claimed_count` decrements atomically with each contribution | ✅ `UPDATE ... SET claimed_count = claimed_count + 1` inside route transaction |
| Contribution rejected with 409 when tier is sold out | ✅ `reserveTierSlot()` returns null → `res.status(409)` |
| Concurrent contributions for the last slot handled correctly (only one succeeds) | ✅ Atomic `UPDATE ... WHERE claimed_count < tier_limit` with PostgreSQL row-level locking inside transaction |
| Tier sold-out state reflected in UI immediately | ✅ `claimed_count` is updated atomically in the route, so the next `listTiersWithAvailability()` query reflects the correct `remaining` |

## Testing

- [ ] Unit test `reserveTierSlot()` — success path
- [ ] Unit test `reserveTierSlot()` — sold-out path returns null
- [ ] Unit test `assignTierToContribution()` with explicit `tierId` — no double-increment
- [ ] Integration: contribute with valid `tier_id`, verify `claimed_count` incremented
- [ ] Integration: contribute with sold-out `tier_id`, verify 409 response
- [ ] Integration: concurrent contributions for last slot, verify exactly one 202 and one 409
