### PR TITLE
fix(#727,#728,#730): env-driven embed CSP, deploy rollback, migration tracking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ jobs:
             set -euo pipefail
             cd "$DEPLOY_PATH"
             git fetch origin main
+            git rev-parse HEAD > .previous-deploy-sha
             git reset --hard origin/main
 
             printf '%s\n' "NODE_ENV=production" \
@@ -71,6 +72,49 @@ jobs:
           echo "Health check failed after 10 attempts"
           exit 1
 
+      - name: Rollback on health check failure
+        if: failure()
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          envs: DATABASE_URL,JWT_SECRET,API_KEY_PEPPER,PLATFORM_SECRET_KEY,USDC_ISSUER,STELLAR_NETWORK,STELLAR_HORIZON_URL,FRONTEND_URL,DEPLOY_PATH,SENTRY_RELEASE
+          script: |
+            set -euo pipefail
+            cd "$DEPLOY_PATH"
+            if [ ! -f .previous-deploy-sha ]; then
+              echo "No previous deploy SHA recorded; skipping rollback"
+              exit 0
+            fi
+            PREVIOUS_SHA=$(cat .previous-deploy-sha)
+            echo "Rolling back to previous deployment SHA: $PREVIOUS_SHA"
+            git reset --hard "$PREVIOUS_SHA"
+            docker compose -f docker-compose.prod.yml up -d --build
+            docker compose -f docker-compose.prod.yml exec -T backend node db/migrate.js
+            echo "Rolled back and redeployed $PREVIOUS_SHA"
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          API_KEY_PEPPER: ${{ secrets.API_KEY_PEPPER }}
+          PLATFORM_SECRET_KEY: ${{ secrets.PLATFORM_SECRET_KEY }}
+          USDC_ISSUER: ${{ secrets.USDC_ISSUER }}
+          STELLAR_NETWORK: ${{ secrets.STELLAR_NETWORK }}
+          STELLAR_HORIZON_URL: ${{ secrets.STELLAR_HORIZON_URL }}
+          FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          SENTRY_RELEASE: ${{ github.sha }}
+
+      - name: Notify Slack on rollback
+        if: failure()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: failure
+          fields: repo,commit,author
+          text: Deployment failed health check and was automatically rolled back to the previous release on ${{ secrets.DEPLOY_HOST }}.
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
       - name: Post deploy status to Slack
         uses: 8398a7/action-slack@v3
         with:
@@ -78,4 +122,4 @@ jobs:
           text: Deployment to production completed.
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: always()
+        if: success()

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ Thumbs.db
 *.log
 npm-debug.log*
 
+# Deploy rollback marker (written by .github/workflows/deploy.yml on the host)
+.previous-deploy-sha
+
 # Agent / tool local config
 .claude/
 .kiro/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,11 @@
 PORT=3001
 NODE_ENV=development
 
+# Public-facing base URL of this backend. Used to derive the embed widget's
+# CSP connect-src (http/https and the matching ws/wss). Defaults to
+# http://localhost:3001. Set this on dev/staging/production as appropriate.
+# BACKEND_URL=https://api.crowdpay.com
+
 # ── Database ─────────────────────────────────────────────
 DATABASE_URL=postgres://crowdpay:crowdpay@localhost:5432/crowdpay
 # Database connection pool

--- a/backend/db/migrate.js
+++ b/backend/db/migrate.js
@@ -1,8 +1,15 @@
 require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
 
-const fs = require('fs');
-const path = require('path');
 const { Pool } = require('pg');
+const {
+  listUpMigrationFilenames,
+  readUpSql,
+  readDownSql,
+  fileHashFor,
+  downFilenameFor,
+  ensureSchemaMigrationsTable,
+  loadApplied,
+} = require('./migrateLib');
 
 // Match backend/.env.example and docker-compose db service defaults.
 process.env.DATABASE_URL =
@@ -10,40 +17,41 @@ process.env.DATABASE_URL =
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
-async function migrate() {
+const COMMAND = process.argv[2] || 'up';
+
+async function runUp() {
   const client = await pool.connect();
   try {
-    // Create migrations tracking table if it doesn't exist
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS schema_migrations (
-        filename TEXT PRIMARY KEY,
-        applied_at TIMESTAMPTZ DEFAULT NOW()
-      )
-    `);
+    await ensureSchemaMigrationsTable(client);
+    const appliedRows = await loadApplied(client);
+    const appliedMap = new Map(appliedRows.map((r) => [r.filename, r]));
 
-    const { rows: applied } = await client.query(
-      'SELECT filename FROM schema_migrations'
-    );
-    const appliedSet = new Set(applied.map((r) => r.filename));
-
-    const migrationsDir = path.join(__dirname, 'migrations');
-    const files = fs.readdirSync(migrationsDir)
-      .filter((f) => f.endsWith('.sql'))
-      .sort(); // alphabetical = chronological with date prefix
+    // Verify that already-applied migrations haven't been edited in place.
+    for (const file of listUpMigrationFilenames()) {
+      const record = appliedMap.get(file);
+      if (!record || !record.file_hash) continue;
+      if (record.file_hash !== fileHashFor(file)) {
+        throw new Error(
+          `Migration '${file}' was applied but its content has changed since then ` +
+            `(hash mismatch). Do not edit an applied migration - add a new one instead.`
+        );
+      }
+    }
 
     let count = 0;
-    for (const file of files) {
-      if (appliedSet.has(file)) {
+    for (const file of listUpMigrationFilenames()) {
+      if (appliedMap.has(file)) {
         console.log(`[migrate] Already applied: ${file}`);
         continue;
       }
-      const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
+      const sql = readUpSql(file);
+      const hash = fileHashFor(file);
       console.log(`[migrate] Applying: ${file}`);
       await client.query('BEGIN');
       await client.query(sql);
       await client.query(
-        'INSERT INTO schema_migrations (filename) VALUES ($1)',
-        [file]
+        'INSERT INTO schema_migrations (filename, file_hash) VALUES ($1, $2)',
+        [file, hash]
       );
       await client.query('COMMIT');
       count++;
@@ -51,15 +59,118 @@ async function migrate() {
 
     console.log(`[migrate] Done. ${count} migration(s) applied.`);
   } catch (err) {
-    await client.query('ROLLBACK').catch((rollbackErr) => {
-      console.error('[migrate] ROLLBACK failed:', rollbackErr.message);
-    });
+    await client.query('ROLLBACK').catch(() => {});
     console.error('[migrate] Failed:', err.message);
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     client.release();
     await pool.end();
   }
 }
 
-migrate();
+async function runStatus() {
+  const client = await pool.connect();
+  try {
+    await ensureSchemaMigrationsTable(client);
+    const appliedRows = await loadApplied(client);
+    const appliedMap = new Map(appliedRows.map((r) => [r.filename, r]));
+
+    const files = listUpMigrationFilenames();
+    const rows = files.map((file) => {
+      const record = appliedMap.get(file);
+      let status = 'PENDING';
+      let appliedAt = '';
+      if (record) {
+        appliedAt = record.applied_at instanceof Date
+          ? record.applied_at.toISOString()
+          : String(record.applied_at);
+        status =
+          record.file_hash && record.file_hash !== fileHashFor(file)
+            ? 'APPLIED (HASH MISMATCH)'
+            : 'APPLIED';
+      }
+      return { file, status, appliedAt };
+    });
+
+    console.log('Migration status:');
+    console.log('-----------------');
+    for (const r of rows) {
+      const at = r.appliedAt ? ` @ ${r.appliedAt}` : '';
+      console.log(`  ${r.status.padEnd(24)} ${r.file}${at}`);
+    }
+    const pending = rows.filter((r) => r.status === 'PENDING').length;
+    const applied = rows.length - pending;
+    console.log('-----------------');
+    console.log(`${applied} applied, ${pending} pending (${rows.length} total).`);
+  } catch (err) {
+    console.error('[migrate:status] Failed:', err.message);
+    process.exitCode = 1;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+async function runDown(count) {
+  const client = await pool.connect();
+  try {
+    await ensureSchemaMigrationsTable(client);
+    const appliedRows = await loadApplied(client);
+    const appliedSet = new Set(appliedRows.map((r) => r.filename));
+
+    const appliedSeq = listUpMigrationFilenames().filter((f) => appliedSet.has(f));
+    const toRollBack = appliedSeq.slice(-count).reverse();
+
+    if (toRollBack.length === 0) {
+      console.log('[migrate:down] No applied migrations to roll back.');
+      return;
+    }
+
+    for (const file of toRollBack) {
+      const down = readDownSql(file);
+      if (down === null || down === undefined) {
+        console.error(
+          `[migrate:down] No down migration found for '${file}' ` +
+            `(expected ${downFilenameFor(file)}). Skipping.`
+        );
+        continue;
+      }
+      console.log(`[migrate:down] Rolling back: ${file}`);
+      await client.query('BEGIN');
+      await client.query(down);
+      await client.query('DELETE FROM schema_migrations WHERE filename = $1', [file]);
+      await client.query('COMMIT');
+    }
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    console.error('[migrate:down] Failed:', err.message);
+    process.exitCode = 1;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+async function main() {
+  switch (COMMAND) {
+    case 'up':
+    case 'migrate':
+      await runUp();
+      break;
+    case 'status':
+      await runStatus();
+      break;
+    case 'down': {
+      const n = Number(process.argv[3]);
+      await runDown(Number.isFinite(n) ? n : 1);
+      break;
+    }
+    default:
+      console.error(`Unknown command: ${COMMAND}`);
+      console.error('Usage: node db/migrate.js [up|status|down [count]]');
+      process.exitCode = 1;
+      await pool.end();
+  }
+}
+
+main();

--- a/backend/db/migrateLib.js
+++ b/backend/db/migrateLib.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const MIGRATIONS_DIR = path.join(__dirname, 'migrations');
+const DOWN_SUFFIX = '.down.sql';
+
+function isUpMigration(filename) {
+  return filename.endsWith('.sql') && !filename.endsWith(DOWN_SUFFIX);
+}
+
+function sha256(str) {
+  return crypto.createHash('sha256').update(str).digest('hex');
+}
+
+function listUpMigrationFilenames() {
+  return fs.readdirSync(MIGRATIONS_DIR).filter(isUpMigration).sort();
+}
+
+function downFilenameFor(upFile) {
+  return upFile.replace(/\.sql$/, DOWN_SUFFIX);
+}
+
+function filePathFor(upFile) {
+  return path.join(MIGRATIONS_DIR, upFile);
+}
+
+function readUpSql(upFile) {
+  return fs.readFileSync(filePathFor(upFile), 'utf8');
+}
+
+function fileHashFor(upFile) {
+  return sha256(readUpSql(upFile));
+}
+
+function readDownSql(upFile) {
+  const downFile = downFilenameFor(upFile);
+  const p = filePathFor(downFile);
+  if (!fs.existsSync(p)) return null;
+  return fs.readFileSync(p, 'utf8');
+}
+
+async function ensureSchemaMigrationsTable(client) {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      filename TEXT PRIMARY KEY,
+      applied_at TIMESTAMPTZ DEFAULT NOW(),
+      file_hash TEXT
+    )
+  `);
+  // Backfill the hash column on databases created before hash tracking was added.
+  await client.query(
+    'ALTER TABLE schema_migrations ADD COLUMN IF NOT EXISTS file_hash TEXT'
+  );
+}
+
+async function loadApplied(client) {
+  const { rows } = await client.query(
+    'SELECT filename, file_hash, applied_at FROM schema_migrations'
+  );
+  return rows;
+}
+
+module.exports = {
+  MIGRATIONS_DIR,
+  DOWN_SUFFIX,
+  isUpMigration,
+  sha256,
+  listUpMigrationFilenames,
+  downFilenameFor,
+  readUpSql,
+  readDownSql,
+  fileHashFor,
+  ensureSchemaMigrationsTable,
+  loadApplied,
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,8 +9,11 @@
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "test": "NODE_ENV=test JWT_SECRET=testsecret API_KEY_PEPPER=testpeppersecret USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5 STELLAR_NETWORK=testnet PLATFORM_SECRET_KEY=SCVMQUS5EMTHWBLJTE5XCSCMHB2ZOVKRR4ATVTRPUNRCOGKRENIL3LHR ARBITRATOR_SECRET_KEY=SD5R3ADP7AC37OAYWYG73266DR2MBR6IJGXBLLAGCOWMTHLMPFAJMWPM STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org WALLET_SECRET_LOCAL_KEK=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= WALLET_ENCRYPTION_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa node --test src/**/*.test.js",
-    "migrate": "node db/migrate.js",
-    "migrate:fresh": "psql $DATABASE_URL -f db/schema.sql && node db/migrate.js",
+    "migrate": "node db/migrate.js up",
+    "migrate:up": "node db/migrate.js up",
+    "migrate:status": "node db/migrate.js status",
+    "migrate:down": "node db/migrate.js down",
+    "migrate:fresh": "psql $DATABASE_URL -f db/schema.sql && node db/migrate.js up",
     "rotate-wallet-secrets": "node src/scripts/rotateWalletSecrets.js"
   },
   "dependencies": {

--- a/backend/src/db/migrateLib.test.js
+++ b/backend/src/db/migrateLib.test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  isUpMigration,
+  downFilenameFor,
+  sha256,
+} = require('../../db/migrateLib');
+
+test('isUpMigration excludes .down.sql rollback scripts', () => {
+  assert.equal(isUpMigration('20260401_users.sql'), true);
+  assert.equal(isUpMigration('002_20260402_wallets.up.sql'), true);
+  assert.equal(isUpMigration('20260401_users.down.sql'), false);
+  assert.equal(isUpMigration('notes.txt'), false);
+});
+
+test('downFilenameFor derives the rollback filename from an up migration', () => {
+  assert.equal(downFilenameFor('20260401_users.sql'), '20260401_users.down.sql');
+  assert.equal(downFilenameFor('002_20260402_wallets.up.sql'), '002_20260402_wallets.up.down.sql');
+});
+
+test('sha256 is deterministic and matches the node crypto implementation', () => {
+  const expected = sha256('select 1;');
+  assert.equal(expected, sha256('select 1;'));
+  assert.equal(expected.length, 64);
+  assert.notEqual(sha256('select 1;'), sha256('select 2;'));
+});

--- a/backend/src/routes/embed.js
+++ b/backend/src/routes/embed.js
@@ -21,6 +21,31 @@ const {
 
 const DESCRIPTION_TRUNCATE_LENGTH = 140;
 
+/**
+ * Build the Content-Security-Policy for the embed widget from environment
+ * variables so dev/staging/self-hosted deployments work without hardcoding
+ * api.crowdpay.com. The WebSocket protocol is derived from the backend URL
+ * and localhost origins are only permitted in non-production environments.
+ */
+function buildEmbedCsp() {
+  const backendUrl = new URL(process.env.BACKEND_URL || 'http://localhost:3001');
+  const wsProtocol = backendUrl.protocol === 'https:' ? 'wss:' : 'ws:';
+
+  const connectSrc = [backendUrl.host, `${wsProtocol}//${backendUrl.host}`];
+
+  if (process.env.NODE_ENV !== 'production') {
+    connectSrc.push('http://localhost:3001', 'ws://localhost:3001');
+  }
+
+  return (
+    `frame-ancestors *; ` +
+    `default-src 'self'; ` +
+    `connect-src ${connectSrc.join(' ')}; ` +
+    `script-src 'self'; ` +
+    `style-src 'self'`
+  );
+}
+
 function truncateDescription(description) {
   if (!description) return '';
   return description.length > DESCRIPTION_TRUNCATE_LENGTH
@@ -267,18 +292,14 @@ router.get(
   ['/widget.html', '/widget'],
   (req, res) => {
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
-    res.setHeader(
-      'Content-Security-Policy',
-      "frame-ancestors *; default-src 'self'; connect-src api.crowdpay.com wss://api.crowdpay.com http://localhost:3001 ws://localhost:3001; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
-    );
+    res.setHeader('Content-Security-Policy', buildEmbedCsp());
     res.removeHeader('X-Frame-Options');
 
     const widgetPath = path.join(__dirname, '../../../frontend/public/embed/widget.html');
     if (fs.existsSync(widgetPath)) {
       return res.sendFile(widgetPath, {
         headers: {
-          'Content-Security-Policy':
-            "frame-ancestors *; default-src 'self'; connect-src api.crowdpay.com wss://api.crowdpay.com http://localhost:3001 ws://localhost:3001; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'",
+          'Content-Security-Policy': buildEmbedCsp(),
         },
       });
     }


### PR DESCRIPTION
## Summary

Implements #727 (embed widget CSP), #728 (deploy rollback), and #730 (migration version tracking). All three are non-breaking, additive improvements.

## #727 — Embed widget CSP hardcodes `api.crowdpay.com`

The embed widget route hardcoded `api.crowdpay.com` / `wss://api.crowdpay.com` in its `connect-src` CSP directive, which broke dev/staging and self-hosted deployments, and leaked `http://localhost:3001` into production. It also used `'unsafe-inline'` for `script-src`, weakening XSS protection.

**Fix** (`backend/src/routes/embed.js`):
- New `buildEmbedCsp()` derives `connect-src` from `process.env.BACKEND_URL` (protocol → `wss`/`ws`), so any deployment works without hardcoding the host.
- Localhost origins are only included when `NODE_ENV !== 'production'`.
- Removed `'unsafe-inline'` from `script-src`.
- Documented `BACKEND_URL` in `backend/.env.example`.

## #728 — Deploy workflow lacks rollback on health check failure

`.github/workflows/deploy.yml` deployed and ran a health check, but on failure left the broken build live with no rollback or team notification.

**Fix**:
- Deploy step records the previous commit to `.previous-deploy-sha` before resetting.
- New `Rollback on health check failure` step (`if: failure()`) SSHes to the host, `git reset --hard`s to the previous SHA, rebuilds containers, and runs migrations.
- New `Notify Slack on rollback` step alerts the team on failure.
- Slack success notification now only fires on `success()` to avoid duplicate failure alerts.

## #730 — Database migrations lack version tracking / state management

`backend/db/migrate.js` tracked applied migrations by filename only, with no content verification, no status view, and no rollback support.

**Fix**:
- `backend/db/migrateLib.js` (new): shared helpers; `isUpMigration` correctly excludes `.down.sql`, plus hash and down-filename helpers.
- `migrate.js` is now a CLI: `node db/migrate.js up|status|down [count]` (default `up`, backward compatible with the deploy workflow).
- Hash tracking: `schema_migrations` gains a `file_hash` column (`ADD COLUMN IF NOT EXISTS` backfills existing databases). Already-applied migrations are verified against their on-disk hash and abort loudly if edited in place.
- `migrate:status` shows `APPLIED` / `PENDING` / `APPLIED (HASH MISMATCH)` per migration.
- `migrate:down [count]` rolls back using `.down.sql` scripts (skips with a warning when absent).
- New npm scripts: `migrate`, `migrate:up`, `migrate:status`, `migrate:down`.
- New tests in `backend/src/db/migrateLib.test.js`.

## Notes
- Migration filenames were intentionally NOT renumbered and no per-file `.down.sql` scripts were authored for the 105 existing migrations, to avoid re-applying already-tracked migrations on live databases. The runner now supports `.down.sql` going forward.
- Verified: lint clean; `embed.test.js` (6) and `migrateLib.test.js` (3) pass. A live Postgres was unavailable (no server binary in this environment), so DB-touching paths were validated by review.

Closes #727
Closes #728
Closes #730
