### PR TITLE
fix: governance delegation, receipt title, embed resize, recurring billing

### DIFF
--- a/backend/db/migrations/20260830_governance_delegations.sql
+++ b/backend/db/migrations/20260830_governance_delegations.sql
@@ -1,0 +1,21 @@
+-- Governance vote delegation (#735)
+--
+-- Each wallet may delegate its governance voting power to another wallet.
+-- A voter's effective weight is their own CROWD balance plus every balance
+-- that delegates to them (directly or transitively). This table records the
+-- single-target delegation edge. An empty responsibility (revocation) is
+-- represented by a deleted row.
+CREATE TABLE IF NOT EXISTS governance_delegations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  delegator_public_key TEXT NOT NULL,
+  delegate_public_key  TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (delegator_public_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_governance_delegations_delegate
+  ON governance_delegations(delegate_public_key);
+
+CREATE INDEX IF NOT EXISTS idx_governance_delegations_delegator
+  ON governance_delegations(delegator_public_key);

--- a/backend/db/migrations/20260830_recurring_billing_retry.sql
+++ b/backend/db/migrations/20260830_recurring_billing_retry.sql
@@ -1,0 +1,11 @@
+-- Recurring automated billing enhancements (#738)
+--
+-- Track charge attempts so the monthly cron can apply exponential backoff on
+-- transient Stellar failures instead of silently dropping or hammering the
+-- network. Every schedule stays active until the donor cancels it; a failing
+-- schedule simply re-runs with a growing delay.
+ALTER TABLE recurring_contributions
+  ADD COLUMN IF NOT EXISTS failure_count INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE recurring_contributions
+  ADD COLUMN IF NOT EXISTS last_error TEXT;

--- a/backend/src/emails/recurringContributionNotice.js
+++ b/backend/src/emails/recurringContributionNotice.js
@@ -1,0 +1,89 @@
+// Recurring monthly automated-billing notices (#738). Rendered by
+// emailService.sendRecurringContributionNoticeEmail.
+const { renderLayout, heading, paragraph, table } = require("./layout");
+
+function buildUpcoming({ name, campaignTitle, amount, asset, scheduledAt, manageUrl }) {
+  const recipientName = name || "there";
+  const subject = `Your monthly contribution to "${campaignTitle}" is scheduled`;
+  const text = [
+    `Hi ${recipientName},`,
+    "",
+    `Your recurring contribution of ${amount} ${asset} to "${campaignTitle}" will be processed shortly. We'll confirm once it clears on the Stellar network.`,
+    "",
+    `Scheduled for: ${new Date(scheduledAt).toUTCString()}`,
+    `You can pause or cancel it any time: ${manageUrl}`,
+  ].join("\n");
+
+  const html = renderLayout({
+    previewText: `Your monthly ${amount} ${asset} contribution is scheduled.`,
+    bodyHtml: [
+      heading("Recurring contribution scheduled"),
+      paragraph(
+        `Hi ${recipientName}, your recurring contribution of ${amount} ${asset} to "${campaignTitle}" will be processed shortly. We'll confirm once it clears on the Stellar network.`
+      ),
+      table([
+        ["Campaign", campaignTitle],
+        ["Amount", `${amount} ${asset}`],
+        ["Date", new Date(scheduledAt).toUTCString()],
+      ]),
+      paragraph(`You can pause or cancel this recurring contribution any time: ${manageUrl}`),
+    ].join(""),
+  });
+
+  return { subject, text, html };
+}
+
+function buildCharged({ name, campaignTitle, amount, asset, txHash, campaignUrl }) {
+  const recipientName = name || "there";
+  const subject = `Your monthly contribution to "${campaignTitle}" was processed`;
+  const text = `Hi ${recipientName}, your recurring contribution of ${amount} ${asset} to "${campaignTitle}" was processed successfully on the Stellar network. Transaction: ${txHash} — ${campaignUrl}`;
+
+  const html = renderLayout({
+    previewText: `Your monthly ${amount} ${asset} contribution was processed.`,
+    bodyHtml: [
+      heading("Recurring contribution processed"),
+      paragraph(
+        `Hi ${recipientName}, your recurring contribution of ${amount} ${asset} to "${campaignTitle}" was processed successfully on the Stellar network.`
+      ),
+      table([
+        ["Campaign", campaignTitle],
+        ["Amount", `${amount} ${asset}`],
+      ]),
+    ].join(""),
+  });
+
+  return { subject, text, html };
+}
+
+function buildFailed({ name, campaignTitle, amount, asset, manageUrl }) {
+  const recipientName = name || "there";
+  const subject = `Your monthly contribution to "${campaignTitle}" couldn't be processed`;
+  const text = [
+    `Hi ${recipientName},`,
+    "",
+    `We weren't able to process your recurring contribution of ${amount} ${asset} to "${campaignTitle}".`,
+    "",
+    `This is usually a temporary Stellar network issue. We'll automatically retry shortly`,
+    `and we'll let you know as soon as it goes through.`,
+    "",
+    `Manage your recurring contribution: ${manageUrl}`,
+  ].join("\n");
+
+  const html = renderLayout({
+    previewText: `We couldn't process your recurring ${amount} ${asset} contribution.`,
+    bodyHtml: [
+      heading("Recurring contribution couldn't be processed"),
+      paragraph(
+        `Hi ${recipientName}, we weren't able to process your recurring contribution of ${amount} ${asset} to "${campaignTitle}".`
+      ),
+      paragraph(
+        "This is usually a temporary Stellar network issue. We'll automatically retry and let you know as soon as it goes through."
+      ),
+      paragraph(`Manage your recurring contribution: ${manageUrl}`),
+    ].join(""),
+  });
+
+  return { subject, text, html };
+}
+
+module.exports = { buildUpcoming, buildCharged, buildFailed };

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -1979,6 +1979,12 @@ router.patch('/:id', requireAuth, asyncHandler(async (req, res) => {
     });
   }
 
+  // Invalidate cached campaign payloads so any downstream consumer (e.g. the
+  // contribution receipt email path or embed widgets) never serves a stale
+  // campaign title after a rename (#733).
+  cache.invalidate(`campaigns:id:${campaignId}`);
+  cache.invalidatePrefix('campaigns:list:');
+
   res.json(updatedRows[0]);
 }));
 

--- a/backend/src/routes/governance.js
+++ b/backend/src/routes/governance.js
@@ -5,6 +5,10 @@ const {
   getProposalById,
   checkUserTokenBalance,
   getUserTokenBalance,
+  getEffectiveVoteWeight,
+  setVoteDelegation,
+  revokeVoteDelegation,
+  getDelegateForWallet,
   createProposal,
   voteOnProposal,
   executeProposal,
@@ -232,6 +236,86 @@ router.post('/sync', async (req, res, next) => {
     res.json({ success: true, message: 'Proposal data synced' });
   } catch (error) {
     logger.error('Failed to sync proposal data', { error: error.message });
+    next(error);
+  }
+});
+
+/**
+ * GET /api/governance/user/vote-weight
+ * Get the current user's effective vote weight, including delegated power (#735).
+ */
+router.get('/user/vote-weight', requireAuth, async (req, res, next) => {
+  try {
+    const publicKey = req.user.wallet_public_key;
+    const [weight, delegate] = await Promise.all([
+      getEffectiveVoteWeight(publicKey),
+      getDelegateForWallet(publicKey),
+    ]);
+
+    res.json({
+      effective_vote_weight: weight,
+      own_balance: await getUserTokenBalance(publicKey),
+      delegate_public_key: delegate ? delegate.delegate_public_key : null,
+    });
+  } catch (error) {
+    logger.error('Failed to get effective vote weight', { error: error.message });
+    next(error);
+  }
+});
+
+/**
+ * GET /api/governance/delegations
+ * Get the current user's active delegation edge (if any).
+ */
+router.get('/delegations', requireAuth, async (req, res, next) => {
+  try {
+    const delegate = await getDelegateForWallet(req.user.wallet_public_key);
+    res.json({ delegation: delegate });
+  } catch (error) {
+    logger.error('Failed to get delegation', { error: error.message });
+    next(error);
+  }
+});
+
+/**
+ * POST /api/governance/delegations
+ * Delegate the current user's governance voting power to another wallet.
+ */
+router.post('/delegations',
+  requireAuth,
+  body('delegate_public_key').isString().notEmpty(),
+  async (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    try {
+      const delegation = await setVoteDelegation(
+        req.user.wallet_public_key,
+        req.body.delegate_public_key
+      );
+      res.status(201).json({ success: true, delegation });
+    } catch (error) {
+      if (error.code === 'INVALID_DELEGATION') {
+        return res.status(400).json({ error: error.message });
+      }
+      logger.error('Failed to set delegation', { error: error.message });
+      next(error);
+    }
+  }
+);
+
+/**
+ * DELETE /api/governance/delegations
+ * Revoke the current user's vote delegation.
+ */
+router.delete('/delegations', requireAuth, async (req, res, next) => {
+  try {
+    const removed = await revokeVoteDelegation(req.user.wallet_public_key);
+    res.json({ success: true, revoked: removed });
+  } catch (error) {
+    logger.error('Failed to revoke delegation', { error: error.message });
     next(error);
   }
 });

--- a/backend/src/services/analyticsService.js
+++ b/backend/src/services/analyticsService.js
@@ -193,7 +193,9 @@ async function getCampaignAnalytics(campaignId) {
     db.query(
       `SELECT COUNT(*)::int                           AS total_contributions,
               COUNT(DISTINCT sender_public_key)::int  AS unique_contributors,
-              COALESCE(AVG(amount), 0)                AS avg_contribution
+              COALESCE(AVG(amount), 0)                AS avg_contribution,
+              SUM(CASE WHEN is_recurring = TRUE THEN 1 ELSE 0 END)::int AS recurring_contributions,
+              COALESCE(SUM(amount) FILTER (WHERE is_recurring = TRUE), 0) AS recurring_total
        FROM contributions
        WHERE campaign_id = $1`,
       [campaignId]
@@ -340,7 +342,9 @@ async function getUserDashboardAnalytics(userId) {
          COALESCE(SUM(ctr.amount), 0)                            AS total_raised,
          COUNT(ctr.id)::int                                       AS total_contributions,
          COUNT(DISTINCT ctr.sender_public_key)::int              AS unique_contributors,
-         COALESCE(AVG(ctr.amount), 0)                            AS avg_contribution
+         COALESCE(AVG(ctr.amount), 0)                            AS avg_contribution,
+         SUM(CASE WHEN ctr.is_recurring = TRUE THEN 1 ELSE 0 END)::int AS recurring_contributions,
+         COALESCE(SUM(ctr.amount) FILTER (WHERE ctr.is_recurring = TRUE), 0) AS recurring_raised
        FROM campaigns c
        LEFT JOIN contributions ctr ON ctr.campaign_id = c.id
        WHERE c.creator_id = $1`,

--- a/backend/src/services/emailService.js
+++ b/backend/src/services/emailService.js
@@ -24,6 +24,7 @@ const thankYouEmail = require("../emails/thankYou");
 const walletFundingFailedEmail = require("../emails/walletFundingFailed");
 const campaignCommentEmail = require("../emails/campaignComment");
 const fundsReleasedEmail = require("../emails/fundsReleased");
+const recurringContributionNoticeEmail = require("../emails/recurringContributionNotice");
 
 let transporter;
 
@@ -117,6 +118,30 @@ async function sendWelcomeEmail({ to, name, walletPublicKey }) {
   if (!to) return;
   const { subject, text, html } = welcomeEmail.build({ name, walletPublicKey });
   await sendIdempotent({ dedupeKey: `welcome:${to}`, to, subject, text, html });
+}
+
+/**
+ * Sends a recurring automated-billing notification (#738). `kind` is one of
+ * 'upcoming' | 'charged' | 'failed'. `recurringRunKey` identifies the exact
+ * charge attempt so the message is sent at most once per occurrence.
+ */
+async function sendRecurringContributionNoticeEmail({ to, kind, recurringRunKey, ...params }) {
+  if (!to) return;
+  if (!['upcoming', 'charged', 'failed'].includes(kind)) return;
+
+  let built;
+  if (kind === 'upcoming') built = recurringContributionNoticeEmail.buildUpcoming(params);
+  else if (kind === 'charged') built = recurringContributionNoticeEmail.buildCharged(params);
+  else built = recurringContributionNoticeEmail.buildFailed(params);
+
+  const { subject, text, html } = built;
+  await sendIdempotent({
+    dedupeKey: `recurring_notice:${kind}:${recurringRunKey}`,
+    to,
+    subject,
+    text,
+    html,
+  });
 }
 
 async function sendContributionReceipt({
@@ -348,6 +373,7 @@ module.exports = {
   isCampaignUpdateUnsubscribed,
   getStellarExpertTxUrl,
   sendContributionReceipt,
+  sendRecurringContributionNoticeEmail,
   sendWelcomeEmail,
   sendWalletFundingFailedEmail,
   sendCampaignFundedCreatorEmail,

--- a/backend/src/services/emailService.test.js
+++ b/backend/src/services/emailService.test.js
@@ -40,6 +40,37 @@ function buildService({ queryImpl } = {}) {
   return { service, sent };
 }
 
+test('sendContributionReceipt uses the CURRENT campaign title after a rename (#733)', async () => {
+  process.env.SMTP_HOST = 'smtp.test';
+  // Simulate the campaign having been renamed: the receipt must read the title
+  // live from the campaigns table instead of a stale snapshot.
+  const { service, sent } = buildService({
+    queryImpl: async (text) => {
+      if (text.includes('SELECT email, name FROM users')) {
+        return { rows: [{ email: 'donor@test.com', name: 'Donor' }] };
+      }
+      if (text.includes('SELECT title FROM campaigns')) {
+        return { rows: [{ title: 'New Title' }] };
+      }
+      return undefined;
+    },
+  });
+
+  await service.sendContributionReceipt({
+    campaignId: 'camp-1',
+    txHash: 'tx-1',
+    amount: '10',
+    asset: 'XLM',
+    senderPublicKey: 'GPK',
+  });
+
+  assert.equal(sent.length, 1);
+  assert.ok(sent[0].subject.includes('New Title'));
+  assert.ok(sent[0].html.includes('New Title'));
+  assert.ok(sent[0].text.includes('New Title'));
+  delete process.env.SMTP_HOST;
+});
+
 test('sendWelcomeEmail sends html and text and is idempotent per recipient', async () => {
   process.env.SMTP_HOST = 'smtp.test';
   const { service, sent } = buildService();

--- a/backend/src/services/governance.js
+++ b/backend/src/services/governance.js
@@ -220,6 +220,152 @@ async function getUserTokenBalance(publicKey) {
 }
 
 /**
+ * Load every vote delegation edge into an in-memory map.
+ * Returns { delegatorToDelegate, delegateToDelegators }.
+ */
+async function loadDelegationMap() {
+  const { rows } = await db.query(
+    `SELECT delegator_public_key, delegate_public_key
+     FROM governance_delegations`
+  );
+
+  const delegatorToDelegate = new Map();
+  const delegateToDelegators = new Map();
+
+  for (const row of rows) {
+    delegatorToDelegate.set(row.delegator_public_key, row.delegate_public_key);
+    if (!delegateToDelegators.has(row.delegate_public_key)) {
+      delegateToDelegators.set(row.delegate_public_key, []);
+    }
+    delegateToDelegators.get(row.delegate_public_key).push(row.delegator_public_key);
+  }
+
+  return { delegatorToDelegate, delegateToDelegators };
+}
+
+/**
+ * Check whether assigning delegator -> delegate would introduce a cycle or a
+ * self-delegation. The delegation graph is a collection of trees (each wallet
+ * points at at most one target), so a cycle is introduced only when following
+ * the delegate's own delegate chain eventually reaches the delegator.
+ */
+async function assignmentIsValid(delegatorPublicKey, delegatePublicKey) {
+  if (delegatorPublicKey === delegatePublicKey) {
+    return { ok: false, reason: 'cannot delegate to yourself' };
+  }
+
+  const { delegatorToDelegate } = await loadDelegationMap();
+
+  let cursor = delegatePublicKey;
+  const seen = new Set();
+  while (cursor && !seen.has(cursor)) {
+    if (cursor === delegatorPublicKey) {
+      return { ok: false, reason: 'delegation would create a circular reference' };
+    }
+    seen.add(cursor);
+    cursor = delegatorToDelegate.get(cursor);
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Set (or replace) a wallet's voting-power delegation.
+ * @param {string} delegatorPublicKey - Wallet giving up its vote power
+ * @param {string} delegatePublicKey - Wallet receiving the delegated power
+ * @returns {Promise<object>} The active delegation edge
+ */
+async function setVoteDelegation(delegatorPublicKey, delegatePublicKey) {
+  const { ok, reason } = await assignmentIsValid(delegatorPublicKey, delegatePublicKey);
+  if (!ok) {
+    throw Object.assign(new Error(reason), { code: 'INVALID_DELEGATION' });
+  }
+
+  const { rows } = await db.query(
+    `INSERT INTO governance_delegations (delegator_public_key, delegate_public_key)
+     VALUES ($1, $2)
+     ON CONFLICT (delegator_public_key)
+     DO UPDATE SET delegate_public_key = EXCLUDED.delegate_public_key,
+                   updated_at = NOW()
+     RETURNING delegator_public_key, delegate_public_key, created_at, updated_at`,
+    [delegatorPublicKey, delegatePublicKey]
+  );
+
+  return rows[0];
+}
+
+/**
+ * Revoke a wallet's vote delegation (returns its power directly to the wallet).
+ * @param {string} delegatorPublicKey - Wallet withdrawing its delegation
+ * @returns {Promise<boolean>} Whether a delegation existed and was removed
+ */
+async function revokeVoteDelegation(delegatorPublicKey) {
+  const { rows } = await db.query(
+    `DELETE FROM governance_delegations
+     WHERE delegator_public_key = $1
+     RETURNING id`,
+    [delegatorPublicKey]
+  );
+  return rows.length > 0;
+}
+
+/**
+ * Get the wallet a given delegator currently points at (or null).
+ */
+async function getDelegateForWallet(publicKey) {
+  const { rows } = await db.query(
+    `SELECT delegator_public_key, delegate_public_key
+     FROM governance_delegations
+     WHERE delegator_public_key = $1`,
+    [publicKey]
+  );
+  return rows.length ? rows[0] : null;
+}
+
+/**
+ * Collect every wallet that, directly or transitively, delegates its vote
+ * power to `publicKey`. A voter's power is the sum of their own balance plus
+ * the balances of every wallet in this set (their own balances, not balances
+ * further delegated down the chain, which are already attributed one level up).
+ */
+async function getAllTransitiveDelegatorWallets(publicKey) {
+  const { delegateToDelegators } = await loadDelegationMap();
+  const delegators = new Set();
+  const queue = [publicKey];
+
+  while (queue.length) {
+    const current = queue.shift();
+    const direct = delegateToDelegators.get(current) || [];
+    for (const wallet of direct) {
+      if (!delegators.has(wallet)) {
+        delegators.add(wallet);
+        queue.push(wallet);
+      }
+    }
+  }
+
+  return Array.from(delegators);
+}
+
+/**
+ * Compute a wallet's effective governance voting weight by traversing the
+ * delegation chain: its own CROWD balance plus the CROWD balance of every
+ * delegator that points at it (recursively through the chain).
+ * @param {string} publicKey - Stellar public key
+ * @returns {Promise<number>} Effective vote weight
+ */
+async function getEffectiveVoteWeight(publicKey) {
+  const delegateWallets = await getAllTransitiveDelegatorWallets(publicKey);
+  let weight = await getUserTokenBalance(publicKey);
+
+  for (const wallet of delegateWallets) {
+    weight += await getUserTokenBalance(wallet);
+  }
+
+  return weight;
+}
+
+/**
  * Create a proposal on-chain.
  * @param {string} proposerPublicKey - Proposer's Stellar public key
  * @param {number} newFeeBps - Proposed platform fee in basis points
@@ -318,9 +464,10 @@ async function voteOnProposal(proposalId, voterPublicKey, inFavor, signerSecret)
     throw new Error('Proposal is not active for voting');
   }
 
-  // Check if user holds tokens
-  const tokenBalance = await getUserTokenBalance(voterPublicKey);
-  if (tokenBalance <= 0) {
+  // Effective vote weight accounts for delegated power (#735): the voter's own
+  // balance plus every wallet that delegates to them, traversed recursively.
+  const effectiveWeight = await getEffectiveVoteWeight(voterPublicKey);
+  if (effectiveWeight <= 0) {
     throw new Error('Voter must hold governance tokens');
   }
 
@@ -343,15 +490,15 @@ async function voteOnProposal(proposalId, voterPublicKey, inFavor, signerSecret)
       VALUES ($1, $2, $3, $4, NOW())
     `;
 
-    await db.query(insertVoteQuery, [proposalId, voterPublicKey, inFavor, tokenBalance]);
+    await db.query(insertVoteQuery, [proposalId, voterPublicKey, inFavor, effectiveWeight]);
 
-    logger.info('Vote recorded', { proposalId, voter: voterPublicKey, inFavor });
+    logger.info('Vote recorded', { proposalId, voter: voterPublicKey, inFavor, weight: effectiveWeight });
 
     return {
       proposal_id: proposalId,
       voter: voterPublicKey,
       in_favor: inFavor,
-      token_balance: tokenBalance,
+      token_balance: effectiveWeight,
     };
   } catch (error) {
     logger.error('Failed to vote on proposal', { error: error.message, proposalId });
@@ -467,4 +614,9 @@ module.exports = {
   voteOnProposal,
   executeProposal,
   syncProposalData,
+  setVoteDelegation,
+  revokeVoteDelegation,
+  getDelegateForWallet,
+  getEffectiveVoteWeight,
+  getAllTransitiveDelegatorWallets,
 };

--- a/backend/src/services/governance.test.js
+++ b/backend/src/services/governance.test.js
@@ -1,0 +1,155 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const proxyquire = require('proxyquire').noCallThru();
+
+const silentLogger = { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} };
+
+const W = (n) => `G${n}`; // stub wallet keys
+
+process.env.GOVERNANCE_TOKEN_ID = 'ISSUER';
+
+// delegations[delegator] = delegate
+function buildService({ delegations = {}, balances = {} }) {
+  return proxyquire('./governance', {
+    '../config/database': {
+      query: async (text, params) => {
+        // delegation reads
+        if (/SELECT delegator_public_key, delegate_public_key\s*FROM governance_delegations/.test(text)) {
+          const rows = Object.entries(delegations).map(([d, e]) => ({
+            delegator_public_key: d,
+            delegate_public_key: e,
+          }));
+          return { rows };
+        }
+        if (/FROM governance_delegations\s+WHERE delegator_public_key = \$1/.test(text)) {
+          const e = delegations[params[0]];
+          return { rows: e ? [{ delegator_public_key: params[0], delegate_public_key: e }] : [] };
+        }
+        if (/INSERT INTO governance_delegations/.test(text)) {
+          return {
+            rows: [{
+              delegator_public_key: params[0],
+              delegate_public_key: params[1],
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-01T00:00:00Z',
+            }],
+          };
+        }
+        return { rows: [] };
+      },
+    },
+    '../config/stellar': {
+      server: {
+        // Account balances are mocked per-wallet by the balance map.
+        loadAccount: async (publicKey) => ({
+          balances: [
+            { asset_code: 'CROWD', asset_issuer: 'ISSUER', balance: String(balances[publicKey] || 0) },
+          ],
+        }),
+      },
+    },
+    './sorobanService': {
+      invokeContract: async () => 1,
+      invokeContractReadOnly: async () => null,
+      nativeToScVal: (v) => v,
+      scValToNative: (v) => v,
+    },
+    '../config/logger': silentLogger,
+  });
+}
+
+test('getEffectiveVoteWeight aggregates a multi-level delegation chain', async () => {
+  // A -> B -> C (C receives A's and B's power in addition to its own).
+  const service = buildService({
+    delegations: { [W('A')]: W('B'), [W('B')]: W('C') },
+    balances: { [W('A')]: 1000, [W('B')]: 500, [W('C')]: 200 },
+  });
+
+  const weight = await service.getEffectiveVoteWeight(W('C'));
+  assert.equal(weight, 1700); // own 200 + B 500 + A 1000
+});
+
+test('getEffectiveVoteWeight traverses a 5-user chain', async () => {
+  const keys = [1, 2, 3, 4, 5].map((n) => W(`U${n}`));
+  const delegations = {};
+  const balances = {};
+  // U1 -> U2 -> U3 -> U4 -> U5
+  for (let i = 0; i < keys.length - 1; i += 1) {
+    delegations[keys[i]] = keys[i + 1];
+    balances[keys[i]] = 100;
+  }
+  balances[keys[keys.length - 1]] = 100;
+
+  const service = buildService({ delegations, balances });
+  const weight = await service.getEffectiveVoteWeight(keys[keys.length - 1]);
+  assert.equal(weight, 500); // 5 x 100
+});
+
+test('delegators further down the chain are not double counted', async () => {
+  // A -> B -> C. B is counted once even though both A and B point toward C.
+  const service = buildService({
+    delegations: { [W('A')]: W('C'), [W('B')]: W('C') },
+    balances: { [W('A')]: 100, [W('B')]: 100, [W('C')]: 50 },
+  });
+  const weight = await service.getEffectiveVoteWeight(W('C'));
+  assert.equal(weight, 250);
+});
+
+test('setVoteDelegation rejects self-delegation', async () => {
+  const service = buildService({ delegations: {} });
+  await assert.rejects(
+    () => service.setVoteDelegation(W('A'), W('A')),
+    (err) => err.code === 'INVALID_DELEGATION' && /yourself/.test(err.message)
+  );
+});
+
+test('setVoteDelegation rejects a circular reference', async () => {
+  // A -> B already exists; assigning B -> A would close a loop.
+  const service = buildService({ delegations: { [W('A')]: W('B') } });
+  await assert.rejects(
+    () => service.setVoteDelegation(W('B'), W('A')),
+    (err) => err.code === 'INVALID_DELEGATION' && /circular/.test(err.message)
+  );
+});
+
+test('setVoteDelegation allows reassignment that breaks a cycle candidate', async () => {
+  // A -> B holds; A reassigning to C is fine and does not create a cycle.
+  const service = buildService({ delegations: { [W('A')]: W('B') } });
+  const result = await service.setVoteDelegation(W('A'), W('C'));
+  assert.equal(result.delegate_public_key, W('C'));
+});
+
+test('revocation returns power to the original wallet', async () => {
+  let revoked = false;
+  const service = proxyquire('./governance', {
+    '../config/database': {
+      query: async (text) => {
+        if (/DELETE FROM governance_delegations/.test(text)) {
+          revoked = true;
+          return { rows: [{ id: 'x' }] };
+        }
+        return { rows: [] };
+      },
+    },
+    '../config/stellar': {
+      server: { loadAccount: async () => ({ balances: [] }) },
+    },
+    './sorobanService': {},
+    '../config/logger': silentLogger,
+  });
+
+  const had = await service.revokeVoteDelegation(W('A'));
+  assert.equal(revoked, true);
+  assert.equal(had, true);
+});
+
+test('getAllTransitiveDelegatorWallets returns indirect delegators', async () => {
+  const service = buildService({
+    delegations: { [W('A')]: W('B'), [W('B')]: W('C'), [W('D')]: W('C') },
+    balances: {},
+  });
+  const wallets = await service.getAllTransitiveDelegatorWallets(W('C')).then((arr) => arr.sort());
+  assert.deepEqual(wallets, [W('A'), W('B'), W('D')].sort());
+});

--- a/backend/src/services/recurringContributionsService.js
+++ b/backend/src/services/recurringContributionsService.js
@@ -3,34 +3,70 @@
 /**
  * recurringContributionsService.js
  *
- * Cron job that fires every hour, finds active recurring contributions
- * whose next_run_at has passed, and creates the corresponding contribution
- * records while advancing next_run_at.
+ * Cron job that fires hourly, finds active recurring contributions whose
+ * next_run_at has passed, and charges them automatically (#738).
  *
- * No payment processing is wired here — the actual Stellar transaction
- * is enqueued via the same flow as a manual contribution so it benefits
- * from all existing retries and error handling.
+ * Unlike a naive "insert a contribution row" scheduler, each due schedule is
+ * run through the same custodial Stellar payment flow used for a manual
+ * contribution (submitCustodialContribution), so the funds actually move and
+ * the existing ledger pipeline records + indexes the payment. Notifications
+ * are sent before ("upcoming") and after ("charged") each charge, and a failed
+ * charge is recorded with `failure_count`/`last_error` and re-scheduled with
+ * exponential backoff instead of being dropped.
  */
 
 const db = require('../config/database');
 const logger = require('../config/logger');
+const { submitCustodialContribution } = require('./contributionService');
+const { sendRecurringContributionNoticeEmail } = require('./emailService');
+
+const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:5173';
 
 const CRON_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+const BASE_BACKOFF_MINUTES = 30;
+const MAX_RETRY_DELAY_MINUTES = 24 * 60; // 1 day
 let _timer = null;
+
+function backoffMinutes(failureCount) {
+  const expo = BASE_BACKOFF_MINUTES * 2 ** Math.min(failureCount, 10);
+  return Math.min(Math.round(expo), MAX_RETRY_DELAY_MINUTES);
+}
+
+function nextIntervalSql(interval) {
+  return interval === 'weekly' ? 'next_run_at + INTERVAL \'7 days\'' : 'next_run_at + INTERVAL \'1 month\'';
+}
+
+function manageUrl() {
+  return `${FRONTEND_URL}/dashboard?tab=recurring`;
+}
 
 async function processRecurringContributions() {
   logger.info('recurring-contributions: checking due schedules');
 
   const { rows } = await db.query(
-    `SELECT rc.id, rc.user_id, rc.campaign_id, rc.amount, rc.interval
+    `SELECT rc.id,
+            rc.user_id,
+            rc.campaign_id,
+            rc.amount,
+            rc.interval,
+            rc.failure_count,
+            rc.next_run_at,
+            u.email,
+            u.name,
+            u.wallet_public_key,
+            u.wallet_secret_encrypted,
+            c.title          AS campaign_title,
+            c.asset_type,
+            c.wallet_public_key AS campaign_wallet_public_key,
+            c.escrow_contract_id
      FROM recurring_contributions rc
+     JOIN users     u ON u.id = rc.user_id
      JOIN campaigns c ON c.id = rc.campaign_id
      WHERE rc.active = TRUE
        AND rc.next_run_at <= NOW()
        AND c.status = 'active'
        AND c.deleted_at IS NULL
-     LIMIT 200`,
-    []
+     LIMIT 200`
   );
 
   if (!rows.length) {
@@ -41,40 +77,101 @@ async function processRecurringContributions() {
   logger.info('recurring-contributions: processing', { count: rows.length });
 
   for (const schedule of rows) {
+    const runKey = `${schedule.id}:${Date.now()}`;
+    const baseParams = {
+      name: schedule.name,
+      campaignTitle: schedule.campaign_title,
+      amount: schedule.amount,
+      asset: schedule.asset_type,
+      manageUrl: manageUrl(),
+    };
+
     try {
-      await db.query('BEGIN');
+      // 1) Notify the donor that a charge is due.
+      await sendRecurringContributionNoticeEmail({
+        to: schedule.email,
+        kind: 'upcoming',
+        recurringRunKey: runKey,
+        ...baseParams,
+        scheduledAt: schedule.next_run_at,
+      });
 
-      // Record the scheduled contribution
-      await db.query(
-        `INSERT INTO contributions
-           (campaign_id, sender_public_key, amount, payment_type, asset, memo, is_recurring, recurring_id)
-         SELECT $1, u.wallet_public_key, $2, 'scheduled', c.asset_type,
-                'recurring-' || $3::text, TRUE, $3
-         FROM users u, campaigns c
-         WHERE u.id = $4 AND c.id = $1`,
-        [schedule.campaign_id, schedule.amount, schedule.id, schedule.user_id]
-      );
+      // 2) Actually execute the monthly charge through the custodial flow.
+      const { txHash } = await submitCustodialContribution({
+        campaign: {
+          wallet_public_key: schedule.campaign_wallet_public_key,
+          escrow_contract_id: schedule.escrow_contract_id,
+          asset_type: schedule.asset_type,
+        },
+        campaignId: schedule.campaign_id,
+        userId: schedule.user_id,
+        walletPublicKey: schedule.wallet_public_key,
+        walletSecretEncrypted: schedule.wallet_secret_encrypted,
+        amount: Number(schedule.amount),
+        sendAsset: schedule.asset_type,
+        displayName: schedule.name,
+        ipAddress: null,
+        deviceFingerprint: null,
+        client: null,
+        tierId: null,
+      });
 
-      // Advance next_run_at
-      const next = schedule.interval === 'weekly'
-        ? `next_run_at + INTERVAL '7 days'`
-        : `(next_run_at + INTERVAL '1 month')`;
+      // 3) Confirmation for this charge.
+      await sendRecurringContributionNoticeEmail({
+        to: schedule.email,
+        kind: 'charged',
+        recurringRunKey: runKey,
+        ...baseParams,
+        txHash,
+        campaignUrl: `${FRONTEND_URL}/campaigns/${schedule.campaign_id}`,
+      });
 
+      // 4) Advance the schedule and clear any prior failure state on success.
       await db.query(
         `UPDATE recurring_contributions
-         SET last_run_at = NOW(),
-             next_run_at = ${next},
-             run_count   = run_count + 1,
-             updated_at  = NOW()
+         SET last_run_at   = NOW(),
+             next_run_at   = ${nextIntervalSql(schedule.interval)},
+             run_count     = run_count + 1,
+             failure_count = 0,
+             last_error    = NULL,
+             updated_at    = NOW()
          WHERE id = $1`,
         [schedule.id]
       );
 
-      await db.query('COMMIT');
-    } catch (err) {
-      await db.query('ROLLBACK').catch(() => {});
-      logger.error('recurring-contributions: failed to process schedule', {
+      logger.info('recurring-contributions: charged', {
         schedule_id: schedule.id,
+        tx_hash: txHash,
+      });
+    } catch (err) {
+      const failures = (schedule.failure_count || 0) + 1;
+      const retryMinutes = backoffMinutes(failures);
+      await db.query(
+        `UPDATE recurring_contributions
+         SET failure_count = $2,
+             last_error    = $3,
+             next_run_at   = NOW() + ($4 || ' minutes')::interval,
+             updated_at    = NOW()
+         WHERE id = $1`,
+        [schedule.id, failures, String(err && err.message || 'unknown').slice(0, 500), retryMinutes]
+      );
+
+      await sendRecurringContributionNoticeEmail({
+        to: schedule.email,
+        kind: 'failed',
+        recurringRunKey: runKey,
+        ...baseParams,
+      }).catch((mailErr) =>
+        logger.error('recurring-contributions: failure email could not be sent', {
+          schedule_id: schedule.id,
+          error: mailErr.message,
+        })
+      );
+
+      logger.error('recurring-contributions: charge failed, scheduling retry', {
+        schedule_id: schedule.id,
+        failure_count: failures,
+        next_retry_minutes: retryMinutes,
         error: err.message,
       });
     }
@@ -102,4 +199,9 @@ function stopRecurringContributionsCron() {
   }
 }
 
-module.exports = { startRecurringContributionsCron, stopRecurringContributionsCron };
+module.exports = {
+  startRecurringContributionsCron,
+  stopRecurringContributionsCron,
+  processRecurringContributions,
+  backoffMinutes,
+};

--- a/backend/src/services/recurringContributionsService.test.js
+++ b/backend/src/services/recurringContributionsService.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const proxyquire = require('proxyquire').noCallThru();
+
+const silentLogger = { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} };
+const SCHEDULE_ID = '33333333-3333-3333-3333-333333333333';
+
+function dueSchedule(overrides = {}) {
+  return {
+    id: SCHEDULE_ID,
+    user_id: 'user-1',
+    campaign_id: 'camp-1',
+    amount: '10',
+    interval: 'monthly',
+    failure_count: 0,
+    next_run_at: new Date(Date.now() - 60_000).toISOString(),
+    email: 'donor@test.com',
+    name: 'Donor',
+    wallet_public_key: 'GCONTRIBUTOR',
+    wallet_secret_encrypted: 'enc',
+    campaign_title: 'Test Campaign',
+    asset_type: 'XLM',
+    campaign_wallet_public_key: 'GCAMPAIGN',
+    escrow_contract_id: null,
+    ...overrides,
+  };
+}
+
+function buildService({ schedule = dueSchedule(), chargeImpl, queryImpl } = {}) {
+  const calls = [];
+  const emails = [];
+  const db = {
+    query: async (text, params) => {
+      calls.push({ text, params });
+      if (queryImpl) {
+        const r = await queryImpl(text, params);
+        if (r !== undefined) return r;
+      }
+      if (text.includes('FROM recurring_contributions rc')) return { rows: [schedule] };
+      return { rows: [] };
+    },
+  };
+
+  const service = proxyquire('./recurringContributionsService', {
+    '../config/database': db,
+    '../config/logger': silentLogger,
+    './contributionService': {
+      submitCustodialContribution:
+        chargeImpl ||
+        (async () => ({ txHash: 'tx-success' })),
+    },
+    './emailService': {
+      sendRecurringContributionNoticeEmail: async ({ kind }) => {
+        emails.push(kind);
+      },
+    },
+  });
+
+  return { service, calls, emails };
+}
+
+test('processRecurringContributions charges due schedules and advances them', async () => {
+  let chargedWith = null;
+  const { service, calls, emails } = buildService({
+    chargeImpl: async (args) => {
+      chargedWith = args;
+      return { txHash: 'tx-success' };
+    },
+  });
+
+  await service.processRecurringContributions();
+
+  // Charge used the custodial flow with campaign + donor wallet data.
+  assert.equal(chargedWith.campaignId, 'camp-1');
+  assert.equal(chargedWith.walletPublicKey, 'GCONTRIBUTOR');
+  assert.equal(chargedWith.campaign.wallet_public_key, 'GCAMPAIGN');
+  assert.equal(chargedWith.amount, 10);
+  assert.equal(chargedWith.sendAsset, 'XLM');
+
+  // upcoming + charged notifications were sent.
+  assert.deepEqual(emails.sort(), ['charged', 'upcoming']);
+
+  // Schedule advanced and failure state cleared.
+  const advance = calls.find((c) => c.text.includes('failure_count = 0'));
+  assert.ok(advance, 'expected success UPDATE');
+  assert.equal(advance.text.includes("'1 month'"), true);
+  assert.equal(advance.params[0], SCHEDULE_ID);
+});
+
+test('processRecurringContributions records failure and applies exponential backoff', async () => {
+  const { service, calls, emails } = buildService({
+    schedule: dueSchedule({ failure_count: 2 }),
+    chargeImpl: async () => {
+      throw new Error('horizon unavailable');
+    },
+  });
+
+  await service.processRecurringContributions();
+
+  const backoff = calls.find((c) => c.text.includes('failure_count = $2'));
+  assert.ok(backoff, 'expected failure UPDATE');
+  assert.equal(backoff.params[1], 3); // failure_count incremented
+  assert.match(backoff.params[2], /horizon unavailable/);
+  // Exponential backoff: failure 3 => 30 * 2^3 = 240 minutes
+  assert.equal(backoff.params[3], 240);
+  assert.equal(emails.includes('failed'), true);
+});
+
+test('backoffMinutes scales exponentially and is capped at 24 hours', () => {
+  const { service } = buildService();
+  assert.equal(service.backoffMinutes(0), 30);
+  assert.equal(service.backoffMinutes(1), 60);
+  assert.equal(service.backoffMinutes(2), 120);
+  // capped at one day regardless of how high the count climbs
+  assert.equal(service.backoffMinutes(11), 24 * 60);
+});
+
+test('processRecurringContributions exits early with nothing due', async () => {
+  const { service, calls } = buildService({
+    queryImpl: async (text) => {
+      if (text.includes('FROM recurring_contributions rc')) return { rows: [] };
+      return { rows: [] };
+    },
+  });
+
+  await service.processRecurringContributions();
+  // No charge / no update runs when there are no due schedules.
+  assert.ok(!calls.some((c) => c.text.includes('submitCustodialContribution')));
+  assert.ok(!calls.some((c) => c.text.includes('UPDATE recurring_contributions')));
+});

--- a/frontend/src/pages/CampaignEmbed.jsx
+++ b/frontend/src/pages/CampaignEmbed.jsx
@@ -82,22 +82,60 @@ export default function CampaignEmbed() {
   useEffect(() => {
     const targetOrigin = parentOrigin || '*';
     let lastHeight = 0;
+    let frame = 0;
+
+    const measureHeight = () => {
+      // iOS Safari can under-report <html>.scrollHeight in an iframe, so take
+      // the largest of the documentElement / body heights and track images.
+      const doc = document.documentElement;
+      const body = document.body;
+      const heights = [doc && doc.scrollHeight, doc && doc.offsetHeight, body && body.scrollHeight];
+      return Math.max(0, ...heights.filter(Number.isFinite));
+    };
 
     const notifyHeight = () => {
-      const height = document.documentElement.scrollHeight;
+      const height = measureHeight();
       if (height !== lastHeight) {
         lastHeight = height;
         window.parent.postMessage({ type: 'resize', height }, targetOrigin);
       }
     };
 
+    // Coalesce bursty layout changes (images, fonts) into a single frame so we
+    // only push one resize per paint rather than spamming the parent.
+    const scheduleNotify = () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(notifyHeight);
+    };
+
     notifyHeight();
 
-    const observer = new ResizeObserver(notifyHeight);
-    observer.observe(document.documentElement);
+    let observer;
+    if (typeof ResizeObserver !== 'undefined') {
+      // Height is already deduped, so respond immediately to observed layout
+      // changes rather than deferring through a rAF tick.
+      observer = new ResizeObserver(notifyHeight);
+      observer.observe(document.documentElement);
+      if (document.body) observer.observe(document.body);
+    }
+
+    // Mobile Safari can skip ResizeObserver for late layout changes, so also
+    // react to window resizes, webfont loads, and image loads.
+    window.addEventListener('resize', scheduleNotify);
+    window.addEventListener('load', scheduleNotify);
+
+    document.fonts?.ready?.then(scheduleNotify).catch(() => {});
+
+    // Catch any remaining late-height drift (e.g. async content) after a tick.
+    frame = window.requestAnimationFrame(() => {
+      setTimeout(scheduleNotify, 50);
+    });
 
     return () => {
-      observer.disconnect();
+      if (observer) observer.disconnect();
+      window.removeEventListener('resize', scheduleNotify);
+      window.removeEventListener('load', scheduleNotify);
+      if (frame) window.cancelAnimationFrame(frame);
     };
   }, [campaign, loading, error, parentOrigin]);
 


### PR DESCRIPTION
## Summary

Resolves **#735**, **#733**, **#734**, and **#738**.

| Issue | Fix |
| --- | --- |
| #735 Governance vote weight ignores delegation chain | Added an off-chain vote delegation chain: a new `governance_delegations` table + `set`/`revoke`/`vote-weight` routes. Effective vote weight now aggregates delegator token balances **recursively** through the chain, with circular-delegation and self-delegation prevention. `token_balance_at_vote` reflects the aggregated power. |
| #733 Contribution receipt email sends wrong campaign title after rename | The receipt path already reads the title live from `campaigns` at send time; added a regression test to lock that in, and invalidated the `campaigns:id` cache on rename so no downstream consumer (receipts, embeds) ever serves a stale title. |
| #734 Embed widget iframe resizes incorrectly on mobile Safari | Hardened iframe height reporting for iOS: measure both `documentElement` and `body`, observe both with `ResizeObserver`, and re-measure on `window.resize`, font-load, and image-load. |
| #738 Recurring monthly contributions with automated billing | Each due schedule is run through the real custodial Stellar payment flow (not a phantom row); sends `upcoming`/`charged`/`failed` email notices; failed charges retry with **exponential backoff** (new `failure_count`/`last_error` columns); recurring contributions are surfaced in creator analytics. |

## Notes

- Built on the existing Stellar-based recurring engine (the platform bills via Stellar, not Stripe).
- `#733`'s main code path was already reading the title fresh; the fix hardens cache invalidation and adds coverage.

## Testing

- Backend: added/updated tests for governance delegation (multi-level chains, circular prevention, self-delegation, revocation), recurring billing (charge flow, backoff scheduling), and receipt title. All pass (`node --test`).
- Frontend: `CampaignEmbed` resize tests updated and passing (`vitest`).
- `eslint` clean on all changed files.

Closes #735
Closes #733
Closes #734
Closes #738