### PR TITLE
feat: campaign analytics report export to pdf

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -30,6 +30,7 @@
         "node-cron": "^3.0.3",
         "nodemailer": "^9.0.3",
         "otplib": "^13.4.1",
+        "pdfkit": "^0.15.2",
         "pg": "^8.11.5",
         "qrcode": "^1.5.4",
         "sanitize-html": "^2.17.5",
@@ -2996,6 +2997,15 @@
         "urijs": "^1.19.1"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
+      "integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -3288,6 +3298,22 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -3534,6 +3560,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -3742,6 +3786,15 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color": {
@@ -3968,6 +4021,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "deprecated": "Active development of CryptoJS has been discontinued. This library is no longer maintained.",
+      "license": "MIT"
+    },
     "node_modules/dayjs": {
       "version": "1.11.21",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
@@ -3990,6 +4050,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/deep-is": {
@@ -4017,6 +4109,23 @@
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
         "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4063,6 +4172,12 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
@@ -4262,6 +4377,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-module-lexer": {
@@ -5004,6 +5139,23 @@
         }
       }
     },
+    "node_modules/fontkit": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
+      "integrity": "sha512-HkW/8Lrk8jl18kzQHvAw9aTHe1cqsyx5sDnxncx652+CIfhawokEPkeM3BoIC+z/Xv7a0yMr0f3pRRwhGH455g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.3.13",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "deep-equal": "^2.0.5",
+        "dfa": "^1.2.0",
+        "restructure": "^2.0.1",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.3.1",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -5117,6 +5269,15 @@
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/gaxios": {
       "version": "6.7.1",
@@ -5391,6 +5552,18 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-flag": {
@@ -5712,6 +5885,20 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
@@ -5730,6 +5917,54 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -5741,6 +5976,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-callable": {
@@ -5763,6 +6014,22 @@
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5803,6 +6070,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5811,6 +6090,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-object": {
@@ -5832,6 +6127,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -5844,6 +6184,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
@@ -5851,6 +6224,34 @@
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5894,6 +6295,13 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.3.1",
@@ -6077,6 +6485,25 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
       "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -6557,6 +6984,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -6683,6 +7155,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6772,6 +7250,19 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
+    },
+    "node_modules/pdfkit": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.15.2.tgz",
+      "integrity": "sha512-s3GjpdBFSCaeDSX/v73MI5UsPqH1kjKut2AXCgxQ5OH10lPVOu5q5vLAG0OCpz/EYqKsTSw1WHpENqMvp43RKg==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^1.8.1",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.0.2",
+        "png-js": "^1.0.0"
+      }
     },
     "node_modules/peek-readable": {
       "version": "4.1.0",
@@ -6892,6 +7383,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
       }
     },
     "node_modules/pngjs": {
@@ -7211,6 +7710,26 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/require-addon": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
@@ -7316,6 +7835,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/restructure": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-2.0.1.tgz",
+      "integrity": "sha512-e0dOpjm5DseomnXx2M5lpdZ5zoHqF1+bqdMJUohoYVVQa7cBdnk7fdmeI6byNWP/kiME72EeTiSypTCVnpLiDg==",
+      "license": "MIT"
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -7360,6 +7885,23 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
@@ -7471,6 +8013,21 @@
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
         "has-property-descriptors": "^1.0.2"
       },
       "engines": {
@@ -7674,6 +8231,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/stream-events": {
@@ -7977,6 +8547,12 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/to-buffer": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
@@ -8132,6 +8708,32 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -8252,6 +8854,43 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-module": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,6 +39,7 @@
     "node-cron": "^3.0.3",
     "nodemailer": "^9.0.3",
     "otplib": "^13.4.1",
+    "pdfkit": "^0.15.2",
     "pg": "^8.11.5",
     "qrcode": "^1.5.4",
     "sanitize-html": "^2.17.5",

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -79,6 +79,8 @@ const {
 const { stripHtml } = require('../lib/sanitize');
 const { getSimhash, simhashSimilarity } = require('../utils/simhash');
 const { parsePagination } = require('../utils/pagination');
+const { assembleReport, generateSignedUrl, verifySignedToken } = require('../services/campaignReportService');
+const { streamCampaignReportPdf, reportFilename } = require('../services/campaignReportPdf');
 
 const crypto = require('crypto');
 
@@ -2602,6 +2604,55 @@ router.delete('/:id/stretch-goals/:goalId', requireAuth, requireCampaignMember('
   );
   if (!rows.length) return res.status(404).json({ error: 'Stretch goal not found' });
   res.status(204).end();
+}));
+
+// ── Campaign Report Export (PDF) ──────────────────────────────────────────────
+
+// Download a PDF report for the campaign (owner or admin only)
+router.get('/:id/report/export', requireAuth, requireCampaignMember('owner'), asyncHandler(async (req, res) => {
+  const report = await assembleReport(req.params.id);
+  if (!report) {
+    return res.status(404).json({ error: 'Campaign not found' });
+  }
+
+  const filename = reportFilename(report.campaign.id, report.campaign.title);
+  res.setHeader('Content-Type', 'application/pdf');
+  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+  res.setHeader('Cache-Control', 'no-store');
+
+  streamCampaignReportPdf(report, res);
+}));
+
+// Generate a shareable signed URL for the report (owner or admin only)
+router.get('/:id/report/share', requireAuth, requireCampaignMember('owner'), asyncHandler(async (req, res) => {
+  const report = await assembleReport(req.params.id);
+  if (!report) {
+    return res.status(404).json({ error: 'Campaign not found' });
+  }
+
+  const baseUrl = process.env.BASE_URL || `${req.protocol}://${req.get('host')}`;
+  const shareableUrl = generateSignedUrl(req.params.id, baseUrl);
+
+  res.json({ url: shareableUrl, expires_in_seconds: 24 * 60 * 60 });
+}));
+
+// Serve a PDF report via signed URL (no auth required — token-verified)
+router.get('/:id/report/share/:token', asyncHandler(async (req, res) => {
+  if (!verifySignedToken(req.params.token, req.params.id)) {
+    return res.status(403).json({ error: 'Invalid or expired share link' });
+  }
+
+  const report = await assembleReport(req.params.id);
+  if (!report) {
+    return res.status(404).json({ error: 'Campaign not found' });
+  }
+
+  const filename = reportFilename(report.campaign.id, report.campaign.title);
+  res.setHeader('Content-Type', 'application/pdf');
+  res.setHeader('Content-Disposition', `inline; filename="${filename}"`);
+  res.setHeader('Cache-Control', 'no-store');
+
+  streamCampaignReportPdf(report, res);
 }));
 
 // Soroban treasury endpoints (#687) live in their own router to keep this file

--- a/backend/src/routes/campaigns.test.js
+++ b/backend/src/routes/campaigns.test.js
@@ -26,6 +26,8 @@ function buildApp({
   sorobanInvokeImpl,
   listCreatorCampaignsImpl,
   getRecommendedCampaignsImpl,
+  reportImpl,
+  signedTokenValid,
 }) {
   const router = proxyquire('./campaigns', {
     '../services/campaignStatusService': campaignStatusImpl || {
@@ -122,6 +124,28 @@ function buildApp({
       getCampaignBackers: async () => ([]),
     },
     '../utils/asyncHandler': (fn) => (req, res, next) => fn(req, res, next).catch(next),
+    '../services/campaignReportService': {
+      assembleReport: async () => reportImpl || {
+        campaign: { id: 'campaign-1', title: 'Test', asset_type: 'USDC', status: 'active', created_at: new Date(), deadline: null, category: 'technology', description: null, target_amount: 100, raised_amount: 0, share_count: 0 },
+        financials: { goal_pct: 0, total_received: 0, target_amount: 100, total_platform_fees: 0, net_received: 0, average_contribution: 0, largest_contribution: 0 },
+        engagement: { total_contributions: 0, unique_contributors: 0, asset_breakdown: [] },
+        top_contributors: [],
+        milestones: [],
+        daily_series: [],
+        timeline: [],
+        generated_at: new Date().toISOString(),
+      },
+      generateSignedUrl: () => 'https://crowdpay.io/api/campaigns/campaign-1/report/share/tok',
+      verifySignedToken: (token) => signedTokenValid !== false,
+    },
+    '../services/campaignReportPdf': {
+      streamCampaignReportPdf: (report, res) => {
+        res.setHeader('Content-Type', 'application/pdf');
+        res.write('%PDF-1.4 test pdf');
+        res.end();
+      },
+      reportFilename: () => 'campaign-1-report.pdf',
+    },
     '../middleware/auth': {
       requireAuth: (req, res, next) => {
         if (authUser === null) {
@@ -905,4 +929,141 @@ test('GET /api/campaigns/:id denies hidden campaign to demoted admin with stale 
     .set('Authorization', `Bearer ${token}`);
 
   assert.equal(res.status, 404);
+});
+
+test('GET /api/campaigns/:id/report/export streams a PDF for the owner', async () => {
+  const queries = [];
+  const app = buildApp({
+    authUser: { userId: 'creator-1', role: 'creator' },
+    queryImpl: async (text, params) => {
+      queries.push({ text, params });
+      if (text.includes('SELECT creator_id FROM campaigns WHERE id = $1')) {
+        return { rows: [{ creator_id: 'creator-1' }] };
+      }
+      if (text.includes('SELECT role, accepted_at FROM campaign_members')) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    },
+    buildWithdrawalTransactionImpl: async () => '',
+    insertWithdrawalPendingSignaturesImpl: async () => 'tx-row',
+  });
+
+  const response = await request(app)
+    .get('/api/campaigns/campaign-1/report/export')
+    .set('Authorization', 'Bearer token');
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers['content-type'], /application\/pdf/);
+  assert.match(response.headers['content-disposition'], /campaign-1-report\.pdf/);
+  const bodyText = Buffer.isBuffer(response.body) ? response.body.toString('utf8') : response.text;
+  assert.ok(bodyText.includes('%PDF'));
+});
+
+test('GET /api/campaigns/:id/report/export rejects non-owners', async () => {
+  const app = buildApp({
+    authUser: { userId: 'user-2', role: 'creator' },
+    queryImpl: async (text) => {
+      if (text.includes('SELECT creator_id FROM campaigns WHERE id = $1')) {
+        return { rows: [{ creator_id: 'creator-1' }] };
+      }
+      if (text.includes('SELECT role, accepted_at FROM campaign_members')) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    },
+    buildWithdrawalTransactionImpl: async () => '',
+    insertWithdrawalPendingSignaturesImpl: async () => 'tx-row',
+  });
+
+  const response = await request(app)
+    .get('/api/campaigns/campaign-1/report/export')
+    .set('Authorization', 'Bearer token');
+
+  assert.equal(response.status, 403);
+});
+
+test('GET /api/campaigns/:id/report/export requires authentication', async () => {
+  const app = buildApp({
+    authUser: null,
+    queryImpl: async () => ({ rows: [] }),
+    buildWithdrawalTransactionImpl: async () => '',
+    insertWithdrawalPendingSignaturesImpl: async () => 'tx-row',
+  });
+
+  const response = await request(app)
+    .get('/api/campaigns/campaign-1/report/export');
+
+  assert.equal(response.status, 401);
+});
+
+test('GET /api/campaigns/:id/report/share returns a signed URL for the owner', async () => {
+  const app = buildApp({
+    authUser: { userId: 'creator-1', role: 'creator' },
+    queryImpl: async (text) => {
+      if (text.includes('SELECT creator_id FROM campaigns WHERE id = $1')) {
+        return { rows: [{ creator_id: 'creator-1' }] };
+      }
+      if (text.includes('SELECT role, accepted_at FROM campaign_members')) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    },
+    buildWithdrawalTransactionImpl: async () => '',
+    insertWithdrawalPendingSignaturesImpl: async () => 'tx-row',
+  });
+
+  const response = await request(app)
+    .get('/api/campaigns/campaign-1/report/share')
+    .set('Authorization', 'Bearer token');
+
+  assert.equal(response.status, 200);
+  assert.match(response.body.url, /\/api\/campaigns\/campaign-1\/report\/share\//);
+  assert.equal(response.body.expires_in_seconds, 24 * 60 * 60);
+});
+
+test('GET /api/campaigns/:id/report/share/TOKEN serves the PDF for a valid signed token', async () => {
+  const app = buildApp({
+    authUser: null,
+    signedTokenValid: true,
+    queryImpl: async (text) => {
+      if (text.includes('SELECT creator_id FROM campaigns WHERE id = $1')) {
+        return { rows: [{ creator_id: 'creator-1' }] };
+      }
+      if (text.includes('SELECT role, accepted_at FROM campaign_members')) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    },
+    buildWithdrawalTransactionImpl: async () => '',
+    insertWithdrawalPendingSignaturesImpl: async () => 'tx-row',
+  });
+
+  const response = await request(app).get('/api/campaigns/campaign-1/report/share/sometoken');
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers['content-type'], /application\/pdf/);
+});
+
+test('GET /api/campaigns/:id/report/share/TOKEN rejects an invalid/expired signed token', async () => {
+  const app = buildApp({
+    authUser: null,
+    signedTokenValid: false,
+    queryImpl: async (text) => {
+      if (text.includes('SELECT creator_id FROM campaigns WHERE id = $1')) {
+        return { rows: [{ creator_id: 'creator-1' }] };
+      }
+      if (text.includes('SELECT role, accepted_at FROM campaign_members')) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    },
+    buildWithdrawalTransactionImpl: async () => '',
+    insertWithdrawalPendingSignaturesImpl: async () => 'tx-row',
+  });
+
+  const response = await request(app).get('/api/campaigns/campaign-1/report/share/invalidtoken');
+
+  assert.equal(response.status, 403);
+  assert.match(response.body.error, /Invalid or expired share link/);
 });

--- a/backend/src/services/campaignReportPdf.js
+++ b/backend/src/services/campaignReportPdf.js
@@ -1,0 +1,219 @@
+'use strict';
+
+const PDFDocument = require('pdfkit');
+
+const BRAND_COLOR = '#0f1f3d';
+const ACCENT_COLOR = '#7c3aed';
+const MUTED_COLOR = '#666666';
+const TEXT_COLOR = '#1a1a1a';
+const LABEL_COLOR = '#555555';
+const PAGE_MARGIN = 50;
+
+const STATUS_LABELS = {
+  pending: 'Pending',
+  pending_review: 'Pending Review',
+  approved: 'Approved',
+  rejected: 'Rejected',
+  released: 'Released',
+};
+
+function formatValue(value) {
+  if (!value) return 'N/A';
+  const date = new Date(value);
+  if (!Number.isNaN(date.getTime())) {
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  }
+  return String(value);
+}
+
+function formatCurrency(amount, asset) {
+  return `${Number(amount).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 7 })} ${asset || ''}`;
+}
+
+function drawSectionHeader(doc, title) {
+  doc.moveDown(1);
+  doc.fontSize(14).fillColor(BRAND_COLOR).text(title, { underline: true });
+  doc.moveDown(0.5);
+}
+
+function drawLabelValue(doc, label, value) {
+  doc.fontSize(10).fillColor(LABEL_COLOR).text(`${label}: `, { continued: true, bold: true });
+  doc.fillColor(TEXT_COLOR).text(String(value));
+  doc.moveDown(0.2);
+}
+
+function drawProgressBar(doc, pct, width) {
+  const barY = doc.y;
+  const barHeight = 12;
+  const filled = Math.min(100, Math.max(0, pct));
+
+  doc.rect(doc.x, barY, width, barHeight).fill('#e5e7eb');
+  if (filled > 0) {
+    doc.rect(doc.x, barY, (width * filled) / 100, barHeight).fill(ACCENT_COLOR);
+  }
+  doc.fillColor(TEXT_COLOR);
+  doc.fontSize(9).text(`${pct.toFixed(1)}%`, doc.x + width + 6, barY + 1);
+  doc.y = barY + barHeight + 4;
+}
+
+function renderReportContent(doc, report) {
+  const c = report.campaign;
+  const asset = c.asset_type;
+  const f = report.financials;
+  const e = report.engagement;
+
+  // ── Header ──
+  doc.fontSize(22).fillColor(BRAND_COLOR).text('Campaign Analytics Report', { align: 'left' });
+  doc.fontSize(10).fillColor(MUTED_COLOR).text(`Generated ${report.generated_at}`);
+  doc.moveDown(1.5);
+
+  // ── Campaign Summary ──
+  doc.fontSize(14).fillColor(BRAND_COLOR).text('Campaign Summary', { underline: true });
+  doc.moveDown(0.5);
+  drawLabelValue(doc, 'Title', c.title);
+  drawLabelValue(doc, 'Status', c.status);
+  drawLabelValue(doc, 'Category', c.category || 'Uncategorized');
+  drawLabelValue(doc, 'Created', formatValue(c.created_at));
+  drawLabelValue(doc, 'Deadline', formatValue(c.deadline));
+  drawLabelValue(doc, 'Description', c.description || 'No description provided');
+  doc.moveDown(0.5);
+
+  // ── Financial Overview ──
+  drawSectionHeader(doc, 'Financial Overview');
+  drawLabelValue(doc, 'Funds Raised', formatCurrency(f.raised_amount, asset));
+  drawLabelValue(doc, 'Goal', formatCurrency(f.target_amount, asset));
+  drawLabelValue(doc, 'Goal Progress', `${f.goal_pct}%`);
+  drawProgressBar(doc, f.goal_pct, 250);
+  drawLabelValue(doc, 'Net Received (after fees)', formatCurrency(f.net_received, asset));
+  drawLabelValue(doc, 'Platform Fees', formatCurrency(f.total_platform_fees, asset));
+  drawLabelValue(doc, 'Average Contribution', formatCurrency(f.average_contribution, asset));
+  drawLabelValue(doc, 'Largest Contribution', formatCurrency(f.largest_contribution, asset));
+
+  // ── Contributor Breakdown ──
+  drawSectionHeader(doc, 'Contributor Breakdown');
+  drawLabelValue(doc, 'Total Contributions', e.total_contributions);
+  drawLabelValue(doc, 'Unique Contributors', e.unique_contributors);
+  if (e.asset_breakdown && e.asset_breakdown.length) {
+    doc.moveDown(0.3);
+    doc.fontSize(10).fillColor(LABEL_COLOR).text('Asset Breakdown:');
+    doc.moveDown(0.2);
+    for (const a of e.asset_breakdown) {
+      doc.fontSize(9).fillColor(TEXT_COLOR).text(`  ${a.asset}: ${a.count} contributions — ${formatCurrency(a.total, a.asset)}`);
+    }
+  }
+
+  // ── Top Contributors ──
+  drawSectionHeader(doc, 'Top Contributors');
+  if (!report.top_contributors || report.top_contributors.length === 0) {
+    doc.fontSize(10).fillColor(MUTED_COLOR).text('No contributors yet.');
+  } else {
+    doc.fontSize(9).fillColor(BRAND_COLOR).text('Rank  Contributor                  Wallet               Count   Total');
+    doc.moveDown(0.2);
+    for (let idx = 0; idx < report.top_contributors.length; idx++) {
+      const tc = report.top_contributors[idx];
+      doc.fontSize(9).fillColor(TEXT_COLOR).text(
+        `${String(idx + 1).padEnd(5)} ${(tc.display_name || '').padEnd(28)} ${(tc.truncated_key || '').padEnd(20)} ${String(tc.contribution_count).padEnd(7)} ${formatCurrency(tc.total_amount, asset)}`
+      );
+      doc.moveDown(0.3);
+    }
+  }
+
+  // ── Milestone Status ──
+  drawSectionHeader(doc, 'Milestone Status');
+  if (!report.milestones || report.milestones.length === 0) {
+    doc.fontSize(10).fillColor(MUTED_COLOR).text('No milestones defined.');
+  } else {
+    for (const m of report.milestones) {
+      doc.fontSize(10).fillColor(BRAND_COLOR).text(m.title, { bold: true });
+      doc.fontSize(9).fillColor(LABEL_COLOR).text(
+        `Release: ${m.release_percentage}%  |  Status: ${STATUS_LABELS[m.status] || m.status}  |  Progress: ${m.progress_pct}%`
+      );
+      if (m.description) {
+        doc.fontSize(9).fillColor(MUTED_COLOR).text(m.description, { indent: 10 });
+      }
+      drawProgressBar(doc, m.progress_pct, 200);
+      doc.moveDown(0.3);
+    }
+  }
+
+  // ── Funding Timeline ──
+  drawSectionHeader(doc, 'Funding Timeline');
+  if (!report.daily_series || report.daily_series.length === 0) {
+    doc.fontSize(10).fillColor(MUTED_COLOR).text('No contribution activity recorded.');
+  } else {
+    doc.fontSize(9).fillColor(LABEL_COLOR).text('Daily contribution summary:');
+    doc.moveDown(0.3);
+    for (const d of report.daily_series) {
+      doc.fontSize(9).fillColor(TEXT_COLOR).text(
+        `  ${d.day}: ${d.count} contribution${d.count === 1 ? '' : 's'} — ${formatCurrency(d.amount, asset)}`
+      );
+    }
+  }
+
+  // ── Status Change Timeline ──
+  if (report.timeline && report.timeline.length > 0) {
+    drawSectionHeader(doc, 'Status Change Timeline');
+    for (const t of report.timeline) {
+      doc.fontSize(9).fillColor(TEXT_COLOR).text(
+        `  ${formatValue(t.at)}: ${t.from || '(none)'} → ${t.to}`
+      );
+    }
+  }
+
+  // ── Footer ──
+  doc.moveDown(3);
+  doc.fontSize(8).fillColor(MUTED_COLOR).text(
+    'CrowdPay — Blockchain-powered crowdfunding. All contribution data is recorded on the Stellar network.',
+    { align: 'center' }
+  );
+}
+
+/**
+ * Stream the rendered report directly to an HTTP response. The PDF bytes are
+ * piped chunk-by-chunk as they are produced, so the whole document is never
+ * buffered in memory.
+ */
+function streamCampaignReportPdf(report, res) {
+  const doc = new PDFDocument({ margin: PAGE_MARGIN });
+  doc.pipe(res);
+  renderReportContent(doc, report);
+  doc.end();
+}
+
+/**
+ * Render the report to an in-memory Buffer. Used by tests and any flows that
+ * require a fully materialised document (e.g. caching to object storage).
+ */
+function generateCampaignReportPdfBuffer(report) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    const doc = new PDFDocument({ margin: PAGE_MARGIN });
+
+    doc.on('data', (chunk) => chunks.push(chunk));
+    doc.on('end', () => resolve(Buffer.concat(chunks)));
+    doc.on('error', reject);
+
+    renderReportContent(doc, report);
+    doc.end();
+  });
+}
+
+function reportFilename(campaignId, campaignTitle) {
+  const safeTitle = (campaignTitle || campaignId)
+    .replace(/[^a-zA-Z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .toLowerCase()
+    .slice(0, 60);
+  const safeId = String(campaignId).replace(/[^a-zA-Z0-9_-]/g, '_');
+  return `${safeTitle}-${safeId}-report.pdf`;
+}
+
+module.exports = {
+  streamCampaignReportPdf,
+  generateCampaignReportPdfBuffer,
+  reportFilename,
+};

--- a/backend/src/services/campaignReportService.js
+++ b/backend/src/services/campaignReportService.js
@@ -1,0 +1,228 @@
+'use strict';
+
+const db = require('../config/database');
+const crypto = require('crypto');
+
+const SIGNING_ALGO = 'sha256';
+const SIGNED_URL_TTL_SECONDS = 24 * 60 * 60;
+
+function signingSecret() {
+  return process.env.JWT_SECRET || 'campaign-report-signing-secret';
+}
+
+function verifySignedToken(token, campaignId) {
+  const sep = token.lastIndexOf('.');
+  if (sep < 0) return false;
+  const payload = token.slice(0, sep);
+  const sig = token.slice(sep + 1);
+
+  const expected = crypto
+    .createHmac(SIGNING_ALGO, signingSecret())
+    .update(payload)
+    .digest('hex');
+
+  const supplied = Buffer.from(sig, 'hex');
+  const expectedBuf = Buffer.from(expected, 'hex');
+  if (supplied.length !== expectedBuf.length) return false;
+  if (!crypto.timingSafeEqual(supplied, expectedBuf)) return false;
+
+  const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+  if (decoded.cid !== campaignId) return false;
+  if (typeof decoded.exp !== 'number' || Date.now() > decoded.exp) return false;
+
+  return true;
+}
+
+function generateSignedUrl(campaignId, baseUrl) {
+  const payload = JSON.stringify({
+    cid: campaignId,
+    exp: Date.now() + SIGNED_URL_TTL_SECONDS * 1000,
+  });
+  const encoded = Buffer.from(payload).toString('base64url');
+  const sig = crypto
+    .createHmac(SIGNING_ALGO, signingSecret())
+    .update(encoded)
+    .digest('hex');
+  return `${baseUrl}/api/campaigns/${campaignId}/report/share/${encoded}.${sig}`;
+}
+
+function truncPubKey(key) {
+  if (!key || key.length <= 16) return key || 'N/A';
+  return `${key.slice(0, 6)}...${key.slice(-4)}`;
+}
+
+async function assembleReport(campaignId) {
+  const [
+    campaignResult,
+    totalsResult,
+    assetBreakdownResult,
+    milestonesResult,
+    topContributorsResult,
+    dailySeriesResult,
+    statusEventsResult,
+  ] = await Promise.all([
+    db.query(
+      `SELECT id, title, description, target_amount, raised_amount, asset_type,
+              status, deadline, category, created_at, share_count
+       FROM campaigns WHERE id = $1`,
+      [campaignId]
+    ),
+    db.query(
+      `SELECT
+         COUNT(*)::int AS total_contributions,
+         COUNT(DISTINCT sender_public_key)::int AS unique_contributors,
+         COALESCE(SUM(amount), 0) AS total_received,
+         COALESCE(AVG(amount), 0) AS average_contribution,
+         COALESCE(MAX(amount), 0) AS largest_contribution,
+         COALESCE(SUM(platform_fee_amount), 0) AS total_platform_fees
+       FROM contributions
+       WHERE campaign_id = $1`,
+      [campaignId]
+    ),
+    db.query(
+      `SELECT COALESCE(source_asset, asset) AS asset,
+              COUNT(*)::int AS count,
+              COALESCE(SUM(amount), 0) AS total
+       FROM contributions
+       WHERE campaign_id = $1
+       GROUP BY asset
+       ORDER BY total DESC`,
+      [campaignId]
+    ),
+    db.query(
+      `SELECT title, description, release_percentage, sort_order, status,
+              completed_at, approved_at, released_at
+       FROM milestones
+       WHERE campaign_id = $1
+       ORDER BY sort_order ASC`,
+      [campaignId]
+    ),
+    db.query(
+      `SELECT ctr.sender_public_key,
+              ctr.display_name,
+              u.name AS contributor_name,
+              COUNT(*)::int AS contribution_count,
+              COALESCE(SUM(ctr.amount), 0) AS total_amount,
+              MIN(ctr.created_at) AS first_contribution_at
+       FROM contributions ctr
+       LEFT JOIN users u ON u.wallet_public_key = ctr.sender_public_key
+       WHERE ctr.campaign_id = $1
+       GROUP BY ctr.sender_public_key, ctr.display_name, u.name
+       ORDER BY total_amount DESC
+       LIMIT 10`,
+      [campaignId]
+    ),
+    db.query(
+      `SELECT
+         DATE(created_at)::text AS day,
+         COUNT(*)::int AS count,
+         COALESCE(SUM(amount), 0) AS amount
+       FROM contributions
+       WHERE campaign_id = $1
+       GROUP BY DATE(created_at)
+       ORDER BY day ASC`,
+      [campaignId]
+    ),
+    db.query(
+      `SELECT old_status, new_status, created_at
+       FROM campaign_status_events
+       WHERE campaign_id = $1
+       ORDER BY created_at ASC`,
+      [campaignId]
+    ),
+  ]);
+
+  if (!campaignResult.rows.length) {
+    return null;
+  }
+
+  const c = campaignResult.rows[0];
+  const t = totalsResult.rows[0];
+  const target = Number(c.target_amount) || 0;
+  const raised = Number(t.total_received) || 0;
+  const goalPct = target > 0 ? Math.min(100, (raised / target) * 100) : 0;
+
+  const milestones = milestonesResult.rows.map((m) => {
+    const threshold = (Number(m.release_percentage) / 100) * target;
+    const progressPct = target > 0 ? Math.min(100, (raised / threshold) * 100) : 0;
+    return {
+      title: m.title,
+      description: m.description,
+      release_percentage: Number(m.release_percentage),
+      status: m.status,
+      progress_pct: Math.round(progressPct * 10) / 10,
+      completed_at: m.completed_at,
+      approved_at: m.approved_at,
+      released_at: m.released_at,
+    };
+  });
+
+  const topContributors = topContributorsResult.rows.map((r) => ({
+    display_name: r.display_name || r.contributor_name || 'Anonymous',
+    truncated_key: truncPubKey(r.sender_public_key),
+    contribution_count: r.contribution_count,
+    total_amount: Number(r.total_amount),
+    first_contribution_at: r.first_contribution_at,
+  }));
+
+  const dailySeries = dailySeriesResult.rows.map((r) => ({
+    day: r.day,
+    count: r.count,
+    amount: Number(r.amount),
+  }));
+
+  const timeline = statusEventsResult.rows.map((e) => ({
+    from: e.old_status,
+    to: e.new_status,
+    at: e.created_at,
+  }));
+
+  const platformFees = Number(t.total_platform_fees) || 0;
+  const netReceived = raised - platformFees;
+
+  return {
+    campaign: {
+      id: c.id,
+      title: c.title,
+      description: c.description,
+      target_amount: target,
+      raised_amount: raised,
+      asset_type: c.asset_type,
+      status: c.status,
+      deadline: c.deadline,
+      category: c.category,
+      created_at: c.created_at,
+      share_count: c.share_count,
+    },
+    financials: {
+      goal_pct: Math.round(goalPct * 10) / 10,
+      total_received: raised,
+      target_amount: target,
+      total_platform_fees: platformFees,
+      net_received: netReceived,
+      average_contribution: Number(t.average_contribution) || 0,
+      largest_contribution: Number(t.largest_contribution) || 0,
+    },
+    engagement: {
+      total_contributions: t.total_contributions,
+      unique_contributors: t.unique_contributors,
+      asset_breakdown: assetBreakdownResult.rows.map((a) => ({
+        asset: a.asset,
+        count: a.count,
+        total: Number(a.total),
+      })),
+    },
+    top_contributors: topContributors,
+    milestones,
+    daily_series: dailySeries,
+    timeline,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+module.exports = {
+  assembleReport,
+  generateSignedUrl,
+  verifySignedToken,
+  SIGNED_URL_TTL_SECONDS,
+};

--- a/backend/src/services/campaignReportService.test.js
+++ b/backend/src/services/campaignReportService.test.js
@@ -1,0 +1,194 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const proxyquire = require('proxyquire').noCallThru();
+
+function buildService({ queryImpl }) {
+  return proxyquire('./campaignReportService', {
+    '../config/database': { query: queryImpl },
+  });
+}
+
+const baseRows = {
+  campaign: {
+    id: 'campaign-1',
+    title: 'Test Campaign',
+    description: 'A test campaign',
+    target_amount: '1000.0000000',
+    raised_amount: '0.0000000',
+    asset_type: 'USDC',
+    status: 'active',
+    deadline: '2026-12-31',
+    category: 'technology',
+    created_at: new Date('2026-01-01T00:00:00Z'),
+    share_count: 0,
+  },
+  totals: {
+    total_contributions: 0,
+    unique_contributors: 0,
+    total_received: '0.0000000',
+    average_contribution: '0.0000000',
+    largest_contribution: '0.0000000',
+    total_platform_fees: '0.0000000',
+  },
+  asset: [],
+  milestones: [],
+  topContributors: [],
+  daily: [],
+  statusEvents: [],
+};
+
+function buildQueryImpl({ campaign, totals, asset, milestones, topContributors, daily, statusEvents }) {
+  const c = campaign === undefined ? baseRows.campaign : campaign;
+  const t = totals === undefined ? baseRows.totals : totals;
+  return async (text) => {
+    if (text.includes('FROM campaigns WHERE id = $1')) return { rows: c ? [c] : [] };
+    if (text.includes('FROM contributions\n       WHERE campaign_id = $1') && !text.includes('GROUP BY')) {
+      if (text.includes('platform_fee_amount')) return { rows: [t] };
+    }
+    if (text.includes('GROUP BY asset')) return { rows: asset || [] };
+    if (text.includes('FROM milestones')) return { rows: milestones || [] };
+    if (text.includes('GROUP BY ctr.sender_public_key')) return { rows: topContributors || [] };
+    if (text.includes('GROUP BY DATE(created_at)')) return { rows: daily || [] };
+    if (text.includes('FROM campaign_status_events')) return { rows: statusEvents || [] };
+    if (text.includes('FROM contributions')) return { rows: [t] };
+    return { rows: [] };
+  };
+}
+
+test('assembleReport returns null for nonexistent campaign', async () => {
+  const service = buildService({ queryImpl: buildQueryImpl({ campaign: null }) });
+  const report = await service.assembleReport('missing');
+  assert.equal(report, null);
+});
+
+test('assembleReport handles an empty campaign gracefully', async () => {
+  const service = buildService({ queryImpl: buildQueryImpl({}) });
+  const report = await service.assembleReport('campaign-1');
+
+  assert.ok(report);
+  assert.equal(report.campaign.id, 'campaign-1');
+  assert.equal(report.campaign.title, 'Test Campaign');
+  assert.equal(report.engagement.total_contributions, 0);
+  assert.equal(report.engagement.unique_contributors, 0);
+  assert.equal(report.top_contributors.length, 0);
+  assert.equal(report.milestones.length, 0);
+  assert.equal(report.daily_series.length, 0);
+  assert.equal(report.financials.goal_pct, 0);
+  assert.equal(report.financials.total_received, 0);
+});
+
+test('assembleReport computes financials, milestones, and top contributors', async () => {
+  const service = buildService({
+    queryImpl: buildQueryImpl({
+      campaign: { ...baseRows.campaign, target_amount: '1000.0000000' },
+      totals: {
+        total_contributions: 5,
+        unique_contributors: 3,
+        total_received: '750.0000000',
+        average_contribution: '150.0000000',
+        largest_contribution: '300.0000000',
+        total_platform_fees: '50.0000000',
+      },
+      asset: [
+        { asset: 'USDC', count: 4, total: '700.0000000' },
+        { asset: 'XLM', count: 1, total: '50.0000000' },
+      ],
+      milestones: [
+        {
+          title: 'Milestone 1',
+          description: 'First milestone',
+          release_percentage: '50.0000',
+          status: 'approved',
+          completed_at: null,
+          approved_at: new Date('2026-03-01T00:00:00Z'),
+          released_at: null,
+        },
+      ],
+      topContributors: [
+        {
+          sender_public_key: 'GABCDEFGHIJKLMNOPQRSTUV123456',
+          display_name: 'Alice',
+          contributor_name: 'Alice User',
+          contribution_count: 3,
+          total_amount: '500.0000000',
+          first_contribution_at: new Date('2026-01-05T00:00:00Z'),
+        },
+      ],
+      daily: [
+        { day: '2026-01-01', count: 2, amount: '300.0000000' },
+        { day: '2026-01-02', count: 3, amount: '450.0000000' },
+      ],
+      statusEvents: [
+        { old_status: null, new_status: 'active', created_at: new Date('2026-01-01T00:00:00Z') },
+      ],
+    }),
+  });
+
+  const report = await service.assembleReport('campaign-1');
+
+  assert.equal(report.financials.total_received, 750);
+  assert.equal(report.financials.goal_pct, 75);
+  assert.equal(report.financials.net_received, 700);
+  assert.equal(report.financials.total_platform_fees, 50);
+  assert.equal(report.engagement.total_contributions, 5);
+  assert.equal(report.engagement.unique_contributors, 3);
+  assert.equal(report.engagement.asset_breakdown.length, 2);
+  assert.equal(report.top_contributors.length, 1);
+  assert.equal(report.top_contributors[0].display_name, 'Alice');
+  assert.equal(report.milestones[0].status, 'approved');
+  assert.equal(report.milestones[0].progress_pct, 100);
+  assert.equal(report.daily_series.length, 2);
+  assert.equal(report.timeline.length, 1);
+});
+
+test('generateSignedUrl produces a token that verifySignedToken accepts', () => {
+  process.env.JWT_SECRET = 'test-secret';
+  const service = buildService({ queryImpl: buildQueryImpl({}) });
+  const url = service.generateSignedUrl('campaign-1', 'https://crowdpay.io');
+  const token = url.split('/report/share/')[1];
+  assert.ok(token);
+  assert.equal(url.startsWith('https://crowdpay.io/api/campaigns/campaign-1/report/share/'), true);
+});
+
+test('verifySignedToken rejects an expired token', () => {
+  process.env.JWT_SECRET = 'test-secret';
+  const service = buildService({ queryImpl: buildQueryImpl({}) });
+
+  const payload = Buffer.from(
+    JSON.stringify({ cid: 'campaign-1', exp: Date.now() - 1000 })
+  ).toString('base64url');
+  const crypto = require('crypto');
+  const sig = crypto
+    .createHmac('sha256', process.env.JWT_SECRET)
+    .update(payload)
+    .digest('hex');
+
+  assert.equal(service.verifySignedToken(`${payload}.${sig}`, 'campaign-1'), false);
+});
+
+test('verifySignedToken rejects a tampered signature', () => {
+  process.env.JWT_SECRET = 'test-secret';
+  const service = buildService({ queryImpl: buildQueryImpl({}) });
+
+  const payload = Buffer.from(
+    JSON.stringify({ cid: 'campaign-1', exp: Date.now() + 100000 })
+  ).toString('base64url');
+
+  assert.equal(service.verifySignedToken(`${payload}.deadbeef`, 'campaign-1'), false);
+});
+
+test('verifySignedToken rejects a token for a different campaign', () => {
+  process.env.JWT_SECRET = 'test-secret';
+  const service = buildService({ queryImpl: buildQueryImpl({}) });
+
+  const payload = Buffer.from(
+    JSON.stringify({ cid: 'campaign-other', exp: Date.now() + 100000 })
+  ).toString('base64url');
+  const crypto = require('crypto');
+  const sig = crypto
+    .createHmac('sha256', process.env.JWT_SECRET)
+    .update(payload)
+    .digest('hex');
+
+  assert.equal(service.verifySignedToken(`${payload}.${sig}`, 'campaign-1'), false);
+});

--- a/frontend/src/pages/CreatorCampaignAnalytics.jsx
+++ b/frontend/src/pages/CreatorCampaignAnalytics.jsx
@@ -29,6 +29,7 @@ export default function CreatorCampaignAnalytics() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [exporting, setExporting] = useState(false);
+  const [downloadingPdf, setDownloadingPdf] = useState(false);
 
   const isCreator = user?.role === 'creator' || user?.role === 'admin';
 
@@ -67,6 +68,27 @@ export default function CreatorCampaignAnalytics() {
     }
   }, [campaignId]);
 
+  const handleDownloadReport = useCallback(async () => {
+    if (!campaignId) return;
+    setDownloadingPdf(true);
+    setError('');
+    try {
+      const { blob, filename } = await api.exportCampaignReport(campaignId);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setError(err.message || 'Report download failed');
+    } finally {
+      setDownloadingPdf(false);
+    }
+  }, [campaignId]);
+
   if (!ready) return null;
   if (!user) return <Navigate to="/login" replace />;
   if (!isCreator) return <Navigate to="/dashboard" replace />;
@@ -101,6 +123,9 @@ export default function CreatorCampaignAnalytics() {
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
           <button type="button" className="btn-secondary" onClick={handleExport} disabled={exporting}>
             {exporting ? 'Exporting…' : 'Export CSV'}
+          </button>
+          <button type="button" className="btn-secondary" onClick={handleDownloadReport} disabled={downloadingPdf}>
+            {downloadingPdf ? 'Generating…' : 'Download Report'}
           </button>
           <Link to="/dashboard/analytics" style={{ color: 'var(--color-accent)', fontWeight: 600, fontSize: '0.9rem' }}>
             ← Back to Analytics

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -30,6 +30,14 @@ export const api = {
     if (match && match[1]) filename = match[1];
     return { blob: res.data, filename };
   },
+  async exportCampaignReport(campaignId) {
+    const res = await apiClient.get(`/campaigns/${campaignId}/report/export`, { responseType: 'blob' });
+    const disposition = res.headers['content-disposition'] || '';
+    let filename = 'campaign-report.pdf';
+    const match = disposition.match(/filename="?([^"]+)"?/);
+    if (match && match[1]) filename = match[1];
+    return { blob: res.data, filename };
+  },
   async getCampaignVelocity(campaignId) {
     const res = await apiClient.get(`/creator/campaigns/${campaignId}/velocity`);
     return res.data;


### PR DESCRIPTION
# feat: Campaign analytics report export to PDF

## Overview

Adds campaign creator analytics export to PDF, complementing the existing CSV export (#408). Creators can now generate a polished, printable financial and engagement report for their campaign, and share it via an expiring signed URL.

## Changes

### Backend

**New: `backend/src/services/campaignReportService.js`**
- Assembles all report data in a single payload via parallel DB queries: campaign summary, financials (raised vs goal, platform fees, net received, average/largest contribution), engagement (total contributions, unique contributors, asset breakdown), top contributors (wallet keys truncated for privacy), milestone status, and status-change timeline.
- Signed URL generation/verification: HMAC-signed, expiring (24h), and bound to the campaign id. Verification uses constant-time comparison with explicit length checks.

**New: `backend/src/services/campaignReportPdf.js`**
- Renders the report to PDF with `pdfkit`, including: campaign summary, raised vs goal (with progress bar), fee breakdown, contributor count, top contributors, milestone status, and funding/status timeline.
- `streamCampaignReportPdf` pipes PDF bytes directly to the HTTP response (no large in-memory buffer) as required by the issue.
- Handles an empty campaign gracefully (no contributors / no milestones → placeholder text).
- `generateCampaignReportPdfBuffer` provided for tests / object-storage flows.

**`backend/src/routes/campaigns.js`** — new routes:
- `GET /api/campaigns/:id/report/export` — streams a PDF attachment; requires authentication and owner (or admin) membership.
- `GET /api/campaigns/:id/report/share` — returns an expiring signed share URL; requires authentication and owner (or admin) membership.
- `GET /api/campaigns/:id/report/share/:token` — serves the PDF via a validated signed token (shareable link, no auth required, token-expiry enforced).

**`backend/package.json`** — added `pdfkit` dependency.

### Frontend

- `frontend/src/pages/CreatorCampaignAnalytics.jsx` — added a "Download Report" button beside the existing CSV export, with loading state.
- `frontend/src/services/api.js` — added `exportCampaignReport()` blob download helper.

## Tests

**New: `backend/src/services/campaignReportService.test.js`**
- Report assembly (financials, milestones, top contributors)
- Empty campaign handled gracefully
- Signed URL generation and validation
- Expired token rejection
- Tampered signature rejection
- Wrong-campaign token rejection

**`backend/src/routes/campaigns.test.js`** — added route coverage:
- Owner streams PDF (200, correct headers/body)
- Non-owner rejected (403)
- Auth required (401)
- Signed URL generation endpoint
- Valid signed token serves PDF
- Invalid/expired token rejected (403)

All backend tests pass (39 tests).


Closes #765 