### PR TITLE
feat(comments): add pin/unpin and rate limiting for campaign comments (#755)

### DIFF
--- a/backend/db/migrations/20260906_campaign_comment_pin.sql
+++ b/backend/db/migrations/20260906_campaign_comment_pin.sql
@@ -1,0 +1,7 @@
+-- Add pinned comment support (#755)
+ALTER TABLE campaign_comments
+  ADD COLUMN pinned BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE UNIQUE INDEX campaign_comments_campaign_pinned_idx
+  ON campaign_comments (campaign_id, pinned)
+  WHERE pinned = TRUE;

--- a/backend/src/routes/campaignComments.js
+++ b/backend/src/routes/campaignComments.js
@@ -3,6 +3,7 @@ const db = require("../config/database");
 const { requireAuth, authenticate } = require("../middleware/auth");
 const asyncHandler = require("../utils/asyncHandler");
 const logger = require("../config/logger");
+const rateLimit = require("express-rate-limit");
 const { createNotification } = require("../services/notifications");
 const { sendCampaignCommentEmail, sendCommentReplyEmail } = require("../services/emailService");
 
@@ -33,9 +34,19 @@ async function requireCampaignCreator(req, res, next) {
   req.campaign = rows[0];
   next();
 }
+const commentRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => req.user?.userId || req.ip,
+  message: { error: "Rate limit exceeded. You can post up to 5 comments per minute." },
+});
+
 
 const COMMENT_COLUMNS = `cc.id, cc.campaign_id, cc.author_id, cc.author_id AS user_id, cc.parent_id, cc.body,
        cc.hidden, cc.hidden_reason, cc.created_at, cc.updated_at,
+       cc.pinned,
        u.name AS author_name, (cc.author_id = c.creator_id) AS is_creator_reply`;
 
 // Public (optionally authenticated): list comments newest first, flat with parent_id.
@@ -80,7 +91,7 @@ router.get(
          WHERE user_id = $2
        ) u_user ON u_user.comment_id = cc.id
        WHERE cc.campaign_id = $1 ${canSeeHidden ? "" : "AND cc.hidden = FALSE"}
-       ORDER BY cc.created_at DESC`;
+       ORDER BY cc.pinned DESC, cc.created_at DESC`;
 
     const params = [req.params.id, userId];
 
@@ -99,6 +110,7 @@ router.get(
 router.post(
   "/:id/comments",
   requireAuth,
+  commentRateLimiter,
   asyncHandler(async (req, res) => {
     const body = cleanText(req.body.body);
     if (!body) return res.status(422).json({ error: "Body is required" });
@@ -396,6 +408,47 @@ router.post(
       [req.params.commentId, req.params.id],
     );
 
+    if (!rows.length) return res.status(404).json({ error: "Comment not found" });
+    res.json(rows[0]);
+  }),
+);
+
+
+// Creator/admin only: pin a comment to the top (max one per campaign)
+router.post(
+  "/:id/comments/:commentId/pin",
+  requireAuth,
+  requireCampaignCreator,
+  asyncHandler(async (req, res) => {
+    await db.query(
+      `UPDATE campaign_comments SET pinned = FALSE WHERE campaign_id = $1`,
+      [req.params.id],
+    );
+    const { rows } = await db.query(
+      `UPDATE campaign_comments
+       SET pinned = TRUE
+       WHERE id = $1 AND campaign_id = $2
+       RETURNING id, campaign_id, author_id, parent_id, body, hidden, hidden_reason, created_at, updated_at, pinned`,
+      [req.params.commentId, req.params.id],
+    );
+    if (!rows.length) return res.status(404).json({ error: "Comment not found" });
+    res.json(rows[0]);
+  }),
+);
+
+// Creator/admin only: unpin a comment
+router.post(
+  "/:id/comments/:commentId/unpin",
+  requireAuth,
+  requireCampaignCreator,
+  asyncHandler(async (req, res) => {
+    const { rows } = await db.query(
+      `UPDATE campaign_comments
+       SET pinned = FALSE
+       WHERE id = $1 AND campaign_id = $2
+       RETURNING id, campaign_id, author_id, parent_id, body, hidden, hidden_reason, created_at, updated_at, pinned`,
+      [req.params.commentId, req.params.id],
+    );
     if (!rows.length) return res.status(404).json({ error: "Comment not found" });
     res.json(rows[0]);
   }),

--- a/backend/src/routes/campaignComments.test.js
+++ b/backend/src/routes/campaignComments.test.js
@@ -210,3 +210,45 @@ test('POST /api/campaigns/:id/comments/:commentId/flag flags a comment for revie
   assert.equal(calls.length, 2);
   assert.match(calls[1].text, /INSERT INTO campaign_comment_flags/);
 });
+
+test('POST /api/campaigns/:id/comments/:commentId/pin pins a comment to the top', async () => {
+  const { app, calls } = buildApp({
+    user: { userId: CREATOR_ID, role: 'creator' },
+    queryImpl: async (text) => {
+      if (text.includes('SELECT id, creator_id FROM campaigns')) {
+        return { rows: [{ id: CAMPAIGN_ID, creator_id: CREATOR_ID }] };
+      }
+      if (text.includes('UPDATE campaign_comments SET pinned = FALSE')) {
+        return { rows: [] };
+      }
+      if (text.includes('UPDATE campaign_comments') && text.includes('pinned = TRUE')) {
+        return { rows: [{ id: COMMENT_ID, campaign_id: CAMPAIGN_ID, pinned: true }] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const res = await request(app).post(`/api/campaigns/${CAMPAIGN_ID}/comments/${COMMENT_ID}/pin`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.pinned, true);
+});
+
+test('POST /api/campaigns/:id/comments/:commentId/unpin unpins a comment', async () => {
+  const { app, calls } = buildApp({
+    user: { userId: CREATOR_ID, role: 'creator' },
+    queryImpl: async (text) => {
+      if (text.includes('SELECT id, creator_id FROM campaigns')) {
+        return { rows: [{ id: CAMPAIGN_ID, creator_id: CREATOR_ID }] };
+      }
+      if (text.includes('UPDATE campaign_comments') && text.includes('pinned = FALSE')) {
+        return { rows: [{ id: COMMENT_ID, campaign_id: CAMPAIGN_ID, pinned: false }] };
+      }
+      return { rows: [] };
+    },
+  });
+
+  const res = await request(app).post(`/api/campaigns/${CAMPAIGN_ID}/comments/${COMMENT_ID}/unpin`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.pinned, false);
+});
+


### PR DESCRIPTION
## Summary

Closes #755 (partial — pin + rate-limiting)

## Changes

- **Pin / Unpin**: Creator/admin can pin one comment to the top of a campaign. Pinning a new comment automatically unpins any previously pinned comment.
- **Rate limiting**: `POST /api/campaigns/:id/comments` is now limited to 5 comments per minute per user (keyed by `userId` or fallback IP).
- **Sort order**: `GET /api/campaigns/:id/comments` now returns pinned comments first, then newest-first.
- **Migration**: adds `pinned BOOLEAN NOT NULL DEFAULT FALSE` to `campaign_comments`.

## Acceptance criteria covered

- [x] Creator can pin one comment to the top
- [x] Comment endpoint is rate-limited (5 per minute per user)

Out of scope (already implemented in upstream): posting, replying, deleting, soft-delete, flagging, upvotes, email notifications.

## Test coverage

- Added tests for `POST .../pin` and `POST .../unpin`.