### PR TITLE
fix(backend): Railway boot — rate-limit IPv6 + require arbitrator secret

### DIFF
--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -7,6 +7,7 @@ const REQUIRED = [
   'JWT_SECRET',
   'API_KEY_PEPPER',
   'PLATFORM_SECRET_KEY',
+  'ARBITRATOR_SECRET_KEY',
   'STELLAR_NETWORK',
   'STELLAR_HORIZON_URL',
   'WALLET_ENCRYPTION_KEY',
@@ -48,6 +49,13 @@ function validateEnv() {
   if (!/^S[A-Z2-7]{55}$/.test(platformKey)) {
     errors.push(
       'PLATFORM_SECRET_KEY must be a valid Stellar secret seed (56 characters, starting with S)'
+    );
+  }
+
+  const arbitratorKey = process.env.ARBITRATOR_SECRET_KEY;
+  if (!/^S[A-Z2-7]{55}$/.test(arbitratorKey)) {
+    errors.push(
+      'ARBITRATOR_SECRET_KEY must be a valid Stellar secret seed (56 characters, starting with S)'
     );
   }
 

--- a/backend/src/routes/campaignComments.js
+++ b/backend/src/routes/campaignComments.js
@@ -4,6 +4,7 @@ const { requireAuth, authenticate } = require("../middleware/auth");
 const asyncHandler = require("../utils/asyncHandler");
 const logger = require("../config/logger");
 const rateLimit = require("express-rate-limit");
+const { ipKeyGenerator } = rateLimit;
 const { createNotification } = require("../services/notifications");
 const { sendCampaignCommentEmail, sendCommentReplyEmail } = require("../services/emailService");
 
@@ -39,7 +40,7 @@ const commentRateLimiter = rateLimit({
   max: 5,
   standardHeaders: true,
   legacyHeaders: false,
-  keyGenerator: (req) => req.user?.userId || req.ip,
+  keyGenerator: (req) => req.user?.userId || ipKeyGenerator(req.ip),
   message: { error: "Rate limit exceeded. You can post up to 5 comments per minute." },
 });
 


### PR DESCRIPTION
## Summary
- Fix `ERR_ERL_KEY_GEN_IPV6` crash on Railway boot from `campaignComments.js` custom rate limiter (`req.ip` without `ipKeyGenerator`).
- Require and format-check `ARBITRATOR_SECRET_KEY` in startup env validation so missing Stellar secrets fail with a clear message before `Keypair.fromSecret` throws.

## Test plan
- [ ] Railway redeploy with root `backend/` after merge
- [ ] Confirm server stays up (no ValidationError from express-rate-limit)
- [ ] Confirm missing `ARBITRATOR_SECRET_KEY` prints clear missing-env error