### PR TITLE
fix(frontend): resolve api.getFeaturedCampaigns crash and baseURL mismatch

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,7 +1,17 @@
 import axios from 'axios';
 
+function resolveApiBaseUrl() {
+  if (import.meta.env.VITE_API_URL) {
+    return import.meta.env.VITE_API_URL;
+  }
+  if (import.meta.env.VITE_API_BASE_URL) {
+    return `${import.meta.env.VITE_API_BASE_URL.replace(/\/+$/, '')}/api`;
+  }
+  return '/api';
+}
+
 export const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || '/api',
+  baseURL: resolveApiBaseUrl(),
   withCredentials: true,
 });
 
@@ -32,6 +42,26 @@ export function retryQueuedRequests() {
 }
 
 export const api = {
+  async getFeaturedCampaigns() {
+    const res = await apiClient.get('/campaigns/featured');
+    return res.data;
+  },
+  async getCampaigns(params) {
+    const res = await apiClient.get('/campaigns', { params });
+    return res.data;
+  },
+  async getCampaignCategories() {
+    const res = await apiClient.get('/campaigns/categories');
+    return res.data;
+  },
+  async getCampaignFacets() {
+    const res = await apiClient.get('/campaigns/facets');
+    return res.data;
+  },
+  async getRecommendedCampaigns(params) {
+    const res = await apiClient.get('/campaigns/recommended', { params });
+    return res.data;
+  },
   async getCampaign(id) {
     const res = await apiClient.get(`/campaigns/${id}`);
     return res.data;

--- a/frontend/src/test/pages/Home.test.jsx
+++ b/frontend/src/test/pages/Home.test.jsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import Home from '../../pages/Home';
 import { renderWithProviders } from '../renderWithProviders';
+import { api } from '../../services/api';
 
 const apiMocks = vi.hoisted(() => ({
   getCampaignCategories: vi.fn().mockResolvedValue([]),
@@ -9,6 +10,7 @@ const apiMocks = vi.hoisted(() => ({
   getCampaignFacets: vi.fn().mockResolvedValue({ categories: [], assets: [], countries: [], funding: { min: 0, max: 0 }, verified_creators: 0 }),
   getCampaigns: vi.fn().mockResolvedValue({ campaigns: [{ id: '1', title: 'Test campaign', status: 'active', target_amount: '100', asset_type: 'USDC' }], total: 1 }),
   getCampaign: vi.fn().mockResolvedValue({}),
+  getRecommendedCampaigns: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('../../context/AuthContext', () => ({
@@ -45,5 +47,15 @@ describe('Home page', () => {
     renderWithProviders(<Home />);
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load campaigns');
+  });
+});
+
+describe('api exports for Home page', () => {
+  it('exports all required campaign methods', () => {
+    expect(typeof api.getFeaturedCampaigns).toBe('function');
+    expect(typeof api.getCampaigns).toBe('function');
+    expect(typeof api.getCampaignCategories).toBe('function');
+    expect(typeof api.getCampaignFacets).toBe('function');
+    expect(typeof api.getRecommendedCampaigns).toBe('function');
   });
 });

--- a/frontend/src/test/pages/Landing.test.jsx
+++ b/frontend/src/test/pages/Landing.test.jsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import Landing from '../../pages/Landing';
 import { renderWithProviders } from '../renderWithProviders';
+import { api } from '../../services/api';
 
 const apiMocks = vi.hoisted(() => ({
   getFeaturedCampaigns: vi.fn().mockResolvedValue([]),
@@ -24,5 +25,19 @@ describe('Landing page', () => {
 
     expect(await screen.findByRole('heading', { name: /Support with Confidence/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Explore Support Spaces/i })).toBeInTheDocument();
+  });
+
+  it('calls getFeaturedCampaigns on mount', async () => {
+    renderWithProviders(<Landing />);
+
+    await screen.findByRole('heading', { name: /Support with Confidence/i });
+    expect(apiMocks.getFeaturedCampaigns).toHaveBeenCalled();
+  });
+});
+
+describe('api exports', () => {
+  it('exports getFeaturedCampaigns and getCampaigns methods', () => {
+    expect(typeof api.getFeaturedCampaigns).toBe('function');
+    expect(typeof api.getCampaigns).toBe('function');
   });
 });


### PR DESCRIPTION
## Summary

Fixes live Landing crash on https://crowdpay-eta.vercel.app:

1. **`api.getFeaturedCampaigns is not a function`** — add missing `getFeaturedCampaigns` / `getCampaigns` (and related) on `frontend/src/services/api.js`
2. **`/api/feature-flags` 404 on Vercel** — `apiClient` ignored `VITE_API_BASE_URL` and fell back to relative `/api`. Prefer `VITE_API_URL`, else `${VITE_API_BASE_URL}/api`, else `/api` for local Vite proxy.

## Deploy

Vercel already has `VITE_API_BASE_URL=https://crowdpay.up.railway.app` and `VITE_STELLAR_NETWORK=testnet`. After merge, **redeploy production** from main (Vite bakes env at build).